### PR TITLE
  Set up CI pipeline on PR and merge to master across Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  computer-use:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xdotool gnome-screenshot wl-clipboard
+
+      - name: Install Python dependencies
+        run: pip install -r computer_use/requirements.txt pytest-cov evdev
+
+      - name: Run tests with coverage
+        run: python -m pytest computer_use/tests/ -v --cov --cov-config=computer_use/.coveragerc --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .venv/
 .mcp.json
 .debug/
+.coverage
 
 # Binaries and shared objects
 *.so

--- a/computer_use/.coveragerc
+++ b/computer_use/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+source = computer_use
+omit =
+    computer_use/bridge/daemon.py
+    computer_use/platform/macos.py
+    computer_use/platform/windows.py
+    computer_use/tests/*
+
+[report]
+show_missing = true

--- a/computer_use/tests/test_accessibility.py
+++ b/computer_use/tests/test_accessibility.py
@@ -1,0 +1,245 @@
+"""Unit tests for computer_use.grounding.accessibility."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from computer_use.core.types import Element, Platform, Region
+from computer_use.grounding.accessibility import (
+    AccessibilityLocator,
+    _LinuxA11y,
+    _MacOSA11y,
+    _WindowsA11y,
+)
+
+
+class TestAccessibilityLocatorInit(unittest.TestCase):
+    """Test that _load_impl picks the correct backend for each Platform."""
+
+    @patch("computer_use.grounding.accessibility.shutil")
+    def test_load_impl_wsl2(self, _mock_shutil):
+        loc = AccessibilityLocator(Platform.WSL2)
+        self.assertIsInstance(loc._impl, _WindowsA11y)
+
+    @patch("computer_use.grounding.accessibility.shutil")
+    def test_load_impl_windows(self, _mock_shutil):
+        loc = AccessibilityLocator(Platform.WINDOWS)
+        self.assertIsInstance(loc._impl, _WindowsA11y)
+
+    @patch("computer_use.grounding.accessibility.shutil")
+    def test_load_impl_macos(self, _mock_shutil):
+        loc = AccessibilityLocator(Platform.MACOS)
+        self.assertIsInstance(loc._impl, _MacOSA11y)
+
+    @patch("computer_use.grounding.accessibility.shutil")
+    def test_load_impl_linux(self, _mock_shutil):
+        loc = AccessibilityLocator(Platform.LINUX)
+        self.assertIsInstance(loc._impl, _LinuxA11y)
+
+
+class TestWindowsA11yIsAvailable(unittest.TestCase):
+    """Test _WindowsA11y.is_available checks for powershell.exe."""
+
+    def setUp(self):
+        self.a11y = _WindowsA11y()
+
+    @patch("computer_use.grounding.accessibility.shutil.which", return_value="/usr/bin/powershell.exe")
+    def test_available_when_powershell_found(self, _mock_which):
+        self.assertTrue(self.a11y.is_available())
+
+    @patch("computer_use.grounding.accessibility.shutil.which", return_value=None)
+    def test_unavailable_when_powershell_missing(self, _mock_which):
+        self.assertFalse(self.a11y.is_available())
+
+
+class TestWindowsA11yFindElement(unittest.TestCase):
+    """Test _WindowsA11y.find_element with mocked _run_ps."""
+
+    def setUp(self):
+        self.a11y = _WindowsA11y()
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_find_element_success(self, mock_run_ps):
+        mock_run_ps.return_value = "Save|ControlType.Button|100|200|80|30"
+        result = self.a11y.find_element("Save")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "Save")
+        self.assertEqual(result.role, "Button")
+        self.assertEqual(result.region, Region(x=100, y=200, width=80, height=30))
+        self.assertEqual(result.confidence, 1.0)
+        self.assertEqual(result.source, "accessibility")
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_find_element_not_found(self, mock_run_ps):
+        mock_run_ps.return_value = "NOT_FOUND"
+        result = self.a11y.find_element("NonExistent")
+        self.assertIsNone(result)
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_find_element_empty_result(self, mock_run_ps):
+        mock_run_ps.return_value = ""
+        result = self.a11y.find_element("Empty")
+        self.assertIsNone(result)
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("ps failed"))
+    def test_find_element_exception(self, _mock_run_ps):
+        result = self.a11y.find_element("Broken")
+        self.assertIsNone(result)
+
+
+class TestWindowsA11yFindAllElements(unittest.TestCase):
+    """Test _WindowsA11y.find_all_elements."""
+
+    def setUp(self):
+        self.a11y = _WindowsA11y()
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_multiple_elements(self, mock_run_ps):
+        mock_run_ps.return_value = (
+            "File|ControlType.MenuItem|0|0|60|25\n"
+            "Edit|ControlType.MenuItem|60|0|60|25\n"
+            "Help|ControlType.MenuItem|120|0|60|25"
+        )
+        result = self.a11y.find_all_elements()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0].name, "File")
+        self.assertEqual(result[1].name, "Edit")
+        self.assertEqual(result[2].name, "Help")
+        for el in result:
+            self.assertEqual(el.role, "MenuItem")
+            self.assertEqual(el.source, "accessibility")
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_empty_result(self, mock_run_ps):
+        mock_run_ps.return_value = ""
+        result = self.a11y.find_all_elements()
+        self.assertEqual(result, [])
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=OSError("timeout"))
+    def test_exception_returns_empty(self, _mock_run_ps):
+        result = self.a11y.find_all_elements()
+        self.assertEqual(result, [])
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_skips_malformed_lines(self, mock_run_ps):
+        mock_run_ps.return_value = (
+            "Good|ControlType.Button|10|20|30|40\n"
+            "bad|line\n"
+            "Also Good|ControlType.Text|50|60|70|80"
+        )
+        result = self.a11y.find_all_elements()
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "Good")
+        self.assertEqual(result[1].name, "Also Good")
+
+
+class TestWindowsA11yFindElementAt(unittest.TestCase):
+    """Test _WindowsA11y.find_element_at."""
+
+    def setUp(self):
+        self.a11y = _WindowsA11y()
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_found(self, mock_run_ps):
+        mock_run_ps.return_value = "Submit|ControlType.Button|200|300|100|40"
+        result = self.a11y.find_element_at(250, 320)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "Submit")
+        self.assertEqual(result.role, "Button")
+        self.assertEqual(result.region, Region(x=200, y=300, width=100, height=40))
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_not_found(self, mock_run_ps):
+        mock_run_ps.return_value = "NOT_FOUND"
+        result = self.a11y.find_element_at(0, 0)
+        self.assertIsNone(result)
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_empty_result(self, mock_run_ps):
+        mock_run_ps.return_value = ""
+        result = self.a11y.find_element_at(10, 10)
+        self.assertIsNone(result)
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=Exception("boom"))
+    def test_exception(self, _mock_run_ps):
+        result = self.a11y.find_element_at(10, 10)
+        self.assertIsNone(result)
+
+
+class TestWindowsA11yParseElement(unittest.TestCase):
+    """Test _WindowsA11y._parse_element directly."""
+
+    def setUp(self):
+        self.a11y = _WindowsA11y()
+
+    def test_valid_line(self):
+        el = self.a11y._parse_element("OK|ControlType.Button|10|20|100|50")
+        self.assertIsNotNone(el)
+        self.assertEqual(el.name, "OK")
+        self.assertEqual(el.role, "Button")
+        self.assertEqual(el.region, Region(x=10, y=20, width=100, height=50))
+        self.assertEqual(el.confidence, 1.0)
+        self.assertEqual(el.source, "accessibility")
+
+    def test_float_coordinates(self):
+        el = self.a11y._parse_element("Btn|ControlType.Button|10.5|20.7|100.9|50.1")
+        self.assertIsNotNone(el)
+        self.assertEqual(el.region, Region(x=10, y=20, width=100, height=50))
+
+    def test_too_few_parts(self):
+        el = self.a11y._parse_element("Name|Role|10")
+        self.assertIsNone(el)
+
+    def test_empty_string(self):
+        el = self.a11y._parse_element("")
+        self.assertIsNone(el)
+
+    def test_bad_numbers(self):
+        el = self.a11y._parse_element("Name|Role|abc|def|ghi|jkl")
+        self.assertIsNone(el)
+
+    def test_strips_controltype_prefix(self):
+        el = self.a11y._parse_element("X|ControlType.TextBox|0|0|10|10")
+        self.assertEqual(el.role, "TextBox")
+
+    def test_no_controltype_prefix(self):
+        el = self.a11y._parse_element("X|Button|0|0|10|10")
+        self.assertEqual(el.role, "Button")
+
+    def test_extra_parts_ignored(self):
+        el = self.a11y._parse_element("X|ControlType.Button|0|0|10|10|extra|stuff")
+        self.assertIsNotNone(el)
+        self.assertEqual(el.name, "X")
+
+
+class TestMacOSA11y(unittest.TestCase):
+    """Test _MacOSA11y stub behavior (AppKit not available in test env)."""
+
+    def setUp(self):
+        self.a11y = _MacOSA11y()
+
+    @patch.dict("sys.modules", {"AppKit": None})
+    def test_is_available_false_when_no_appkit(self):
+        self.assertFalse(self.a11y.is_available())
+
+    @patch.dict("sys.modules", {"AppKit": MagicMock()})
+    def test_is_available_true_when_appkit_present(self):
+        self.assertTrue(self.a11y.is_available())
+
+
+class TestLinuxA11y(unittest.TestCase):
+    """Test _LinuxA11y stub behavior (pyatspi not available in test env)."""
+
+    def setUp(self):
+        self.a11y = _LinuxA11y()
+
+    @patch.dict("sys.modules", {"pyatspi": None})
+    def test_is_available_false_when_no_pyatspi(self):
+        self.assertFalse(self.a11y.is_available())
+
+    @patch.dict("sys.modules", {"pyatspi": MagicMock()})
+    def test_is_available_true_when_pyatspi_present(self):
+        self.assertTrue(self.a11y.is_available())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/computer_use/tests/test_anthropic_provider.py
+++ b/computer_use/tests/test_anthropic_provider.py
@@ -1,0 +1,577 @@
+"""Tests for the Anthropic vision provider."""
+
+import json
+import urllib.error
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from computer_use.core.errors import ProviderError
+from computer_use.core.types import (
+    Action,
+    ActionType,
+    Element,
+    Region,
+    ScreenState,
+)
+from computer_use.providers.anthropic import AnthropicProvider
+from computer_use.providers.base import AgentDecision
+
+
+def make_screen(width=1920, height=1080, image_bytes=b"\x89PNG_fake"):
+    return ScreenState(image_bytes=image_bytes, width=width, height=height)
+
+
+def make_api_response(text):
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def make_urlopen_mock(response_dict):
+    body = json.dumps(response_dict).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestCallApi:
+    def test_successful_request(self):
+        provider = AnthropicProvider(api_key="sk-test-key", model="claude-test")
+        expected_response = {"content": [{"type": "text", "text": "hello"}]}
+        mock_resp = make_urlopen_mock(expected_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            result = provider._call_api({"model": "claude-test", "messages": []})
+
+        assert result == expected_response
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert req.get_header("X-api-key") == "sk-test-key"
+        assert req.get_header("Content-type") == "application/json"
+        assert req.get_header("Anthropic-version") == "2023-06-01"
+        assert call_args[1]["timeout"] == 60
+
+    def test_http_error_raises_provider_error(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        fp = BytesIO(b'{"error": "rate_limited"}')
+        http_err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=429,
+            msg="Too Many Requests",
+            hdrs={},
+            fp=fp,
+        )
+
+        with patch("urllib.request.urlopen", side_effect=http_err):
+            with pytest.raises(ProviderError, match="429"):
+                provider._call_api({"model": "x", "messages": []})
+
+    def test_url_error_raises_provider_error(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        url_err = urllib.error.URLError("Connection refused")
+
+        with patch("urllib.request.urlopen", side_effect=url_err):
+            with pytest.raises(ProviderError, match="connection error"):
+                provider._call_api({"model": "x", "messages": []})
+
+    def test_payload_sent_as_json(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        payload = {"model": "claude-test", "messages": [{"role": "user", "content": "hi"}]}
+        mock_resp = make_urlopen_mock({"content": []})
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            provider._call_api(payload)
+
+        req = mock_urlopen.call_args[0][0]
+        sent_data = json.loads(req.data.decode("utf-8"))
+        assert sent_data == payload
+
+
+class TestExtractText:
+    def test_plain_text(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response('{"action": "click"}')
+        assert provider._extract_text(response) == '{"action": "click"}'
+
+    def test_strips_code_fences(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response('```json\n{"action": "click"}\n```')
+        assert provider._extract_text(response) == '{"action": "click"}'
+
+    def test_strips_code_fences_no_language(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response('```\n{"x": 1}\n```')
+        assert provider._extract_text(response) == '{"x": 1}'
+
+    def test_empty_content(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        assert provider._extract_text({"content": []}) == ""
+        assert provider._extract_text({}) == ""
+
+    def test_skips_non_text_blocks(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = {
+            "content": [
+                {"type": "image", "data": "..."},
+                {"type": "text", "text": "found it"},
+            ]
+        }
+        assert provider._extract_text(response) == "found it"
+
+    def test_strips_whitespace(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response("  hello world  \n")
+        assert provider._extract_text(response) == "hello world"
+
+
+class TestParseAction:
+    def test_click(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({"action": "click", "x": 100, "y": 200})
+        assert action.action_type == ActionType.CLICK
+        assert action.x == 100
+        assert action.y == 200
+
+    def test_all_action_types(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        expected = {
+            "click": ActionType.CLICK,
+            "double_click": ActionType.DOUBLE_CLICK,
+            "right_click": ActionType.RIGHT_CLICK,
+            "type_text": ActionType.TYPE_TEXT,
+            "key_press": ActionType.KEY_PRESS,
+            "scroll": ActionType.SCROLL,
+            "move": ActionType.MOVE,
+            "drag": ActionType.DRAG,
+            "wait": ActionType.WAIT,
+        }
+        for name, action_type in expected.items():
+            action = provider._parse_action({"action": name})
+            assert action.action_type == action_type
+
+    def test_type_text_carries_text(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({"action": "type_text", "text": "hello world"})
+        assert action.text == "hello world"
+        assert action.action_type == ActionType.TYPE_TEXT
+
+    def test_key_press_carries_keys(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({"action": "key_press", "keys": ["ctrl", "s"]})
+        assert action.keys == ["ctrl", "s"]
+
+    def test_scroll_carries_amount(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({"action": "scroll", "x": 50, "y": 50, "amount": -3})
+        assert action.scroll_amount == -3
+        assert action.x == 50
+
+    def test_drag_carries_target(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({
+            "action": "drag", "x": 10, "y": 20, "target_x": 100, "target_y": 200,
+        })
+        assert action.target_x == 100
+        assert action.target_y == 200
+
+    def test_wait_carries_duration(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({"action": "wait", "duration": 2.5})
+        assert action.duration == 2.5
+
+    def test_unknown_action_raises(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        with pytest.raises(ProviderError, match="Unknown action type"):
+            provider._parse_action({"action": "teleport"})
+
+    def test_empty_action_raises(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        with pytest.raises(ProviderError, match="Unknown action type"):
+            provider._parse_action({})
+
+    def test_defaults_for_optional_fields(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        action = provider._parse_action({"action": "click"})
+        assert action.x is None
+        assert action.y is None
+        assert action.text is None
+        assert action.keys is None
+        assert action.scroll_amount == 0
+        assert action.duration == 0.0
+        assert action.target_x is None
+        assert action.target_y is None
+
+
+class TestParseDecision:
+    def test_click_decision(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "reasoning": "I see the button",
+            "action": {"action": "click", "x": 500, "y": 300},
+            "confidence": 0.9,
+            "error": None,
+        }))
+        decision = provider._parse_decision(response)
+        assert isinstance(decision, AgentDecision)
+        assert decision.action.action_type == ActionType.CLICK
+        assert decision.action.x == 500
+        assert decision.reasoning == "I see the button"
+        assert decision.confidence == 0.9
+        assert decision.is_task_complete is False
+        assert decision.error_detected is None
+
+    def test_done_action_marks_complete(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "reasoning": "All steps finished",
+            "action": {"action": "done"},
+            "confidence": 0.95,
+        }))
+        decision = provider._parse_decision(response)
+        assert decision.is_task_complete is True
+        assert decision.action.action_type == ActionType.WAIT
+        assert decision.action.duration == 0
+        assert decision.reasoning == "All steps finished"
+
+    def test_done_without_reasoning_defaults(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "action": {"action": "done"},
+        }))
+        decision = provider._parse_decision(response)
+        assert decision.reasoning == "Task complete"
+        assert decision.confidence == 1.0
+
+    def test_non_done_without_confidence_defaults(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "action": {"action": "click", "x": 1, "y": 1},
+        }))
+        decision = provider._parse_decision(response)
+        assert decision.confidence == 0.5
+        assert decision.reasoning == ""
+
+    def test_error_field_forwarded(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "reasoning": "something is off",
+            "action": {"action": "click", "x": 1, "y": 1},
+            "confidence": 0.3,
+            "error": "dialog box appeared unexpectedly",
+        }))
+        decision = provider._parse_decision(response)
+        assert decision.error_detected == "dialog box appeared unexpectedly"
+
+    def test_invalid_json_raises(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response("this is not json at all")
+        with pytest.raises(ProviderError, match="Cannot parse LLM response"):
+            provider._parse_decision(response)
+
+    def test_unknown_action_in_decision_raises(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "reasoning": "x",
+            "action": {"action": "fly_away"},
+            "confidence": 0.5,
+        }))
+        with pytest.raises(ProviderError, match="Unknown action type"):
+            provider._parse_decision(response)
+
+
+class TestParseElement:
+    def test_found_element(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "x": 100, "y": 200, "width": 80, "height": 30,
+            "name": "Submit", "role": "button", "confidence": 0.95,
+        }))
+        elem = provider._parse_element(response)
+        assert elem is not None
+        assert elem.name == "Submit"
+        assert elem.role == "button"
+        assert elem.region == Region(x=100, y=200, width=80, height=30)
+        assert elem.confidence == 0.95
+        assert elem.source == "vision"
+
+    def test_not_found_returns_none(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({"not_found": True}))
+        assert provider._parse_element(response) is None
+
+    def test_invalid_json_returns_none(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response("no json here, sorry")
+        assert provider._parse_element(response) is None
+
+    def test_missing_x_returns_none(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "y": 200, "name": "Submit", "role": "button",
+        }))
+        assert provider._parse_element(response) is None
+
+    def test_missing_y_returns_none(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "x": 100, "name": "Submit", "role": "button",
+        }))
+        assert provider._parse_element(response) is None
+
+    def test_defaults_for_optional_fields(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({"x": 50, "y": 60}))
+        elem = provider._parse_element(response)
+        assert elem is not None
+        assert elem.name == "unknown"
+        assert elem.role == "unknown"
+        assert elem.region.width == 50
+        assert elem.region.height == 30
+        assert elem.confidence == 0.5
+
+    def test_non_numeric_x_returns_none(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        response = make_api_response(json.dumps({
+            "x": "abc", "y": 100, "name": "X", "role": "button",
+        }))
+        assert provider._parse_element(response) is None
+
+
+class TestDecideAction:
+    def test_builds_payload_and_parses(self):
+        provider = AnthropicProvider(api_key="sk-test", model="claude-test")
+        screen = make_screen()
+        api_response = make_api_response(json.dumps({
+            "reasoning": "Clicking the save button",
+            "action": {"action": "click", "x": 400, "y": 300},
+            "confidence": 0.85,
+            "error": None,
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            decision = provider.decide_action(screen, "Save the file", [])
+
+        assert decision.action.action_type == ActionType.CLICK
+        assert decision.action.x == 400
+        assert decision.reasoning == "Clicking the save button"
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        assert sent["model"] == "claude-test"
+        assert sent["max_tokens"] == 1024
+
+        user_content = sent["messages"][0]["content"]
+        assert user_content[0]["type"] == "image"
+        assert user_content[0]["source"]["media_type"] == "image/png"
+        assert "Save the file" in user_content[1]["text"]
+        assert "1920x1080" in user_content[1]["text"]
+
+    def test_includes_elements_when_provided(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        screen = make_screen()
+        elements = [
+            Element(name="OK", role="button", region=Region(10, 20, 60, 30), confidence=0.9, source="a11y"),
+            Element(name="Cancel", role="button", region=Region(80, 20, 60, 30), confidence=0.8, source="a11y"),
+        ]
+        api_response = make_api_response(json.dumps({
+            "reasoning": "r", "action": {"action": "click", "x": 1, "y": 1}, "confidence": 0.5,
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            provider.decide_action(screen, "Click OK", [], elements=elements)
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        content_texts = [c["text"] for c in sent["messages"][0]["content"] if c["type"] == "text"]
+        element_block = [t for t in content_texts if "UI elements" in t]
+        assert len(element_block) == 1
+        assert "OK (button)" in element_block[0]
+        assert "Cancel (button)" in element_block[0]
+
+    def test_includes_history_when_provided(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        screen = make_screen()
+        history = [
+            {"step": 1, "action": "click at (100,200)", "success": True},
+            {"step": 2, "action": "type hello", "success": False},
+        ]
+        api_response = make_api_response(json.dumps({
+            "reasoning": "r", "action": {"action": "wait", "duration": 1}, "confidence": 0.5,
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            provider.decide_action(screen, "Do stuff", history)
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        content_texts = [c["text"] for c in sent["messages"][0]["content"] if c["type"] == "text"]
+        history_block = [t for t in content_texts if "Recent actions" in t]
+        assert len(history_block) == 1
+        assert "Step 1" in history_block[0]
+        assert "OK" in history_block[0]
+        assert "FAILED" in history_block[0]
+
+    def test_no_elements_no_history_sends_only_image_and_task(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        screen = make_screen()
+        api_response = make_api_response(json.dumps({
+            "reasoning": "r", "action": {"action": "done"}, "confidence": 1.0,
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            provider.decide_action(screen, "Do it", [])
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        content = sent["messages"][0]["content"]
+        assert len(content) == 2
+        assert content[0]["type"] == "image"
+        assert content[1]["type"] == "text"
+
+    def test_history_limited_to_last_five(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        screen = make_screen()
+        history = [{"step": i, "action": f"action_{i}", "success": True} for i in range(10)]
+        api_response = make_api_response(json.dumps({
+            "reasoning": "r", "action": {"action": "done"}, "confidence": 1.0,
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            provider.decide_action(screen, "task", history)
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        content_texts = [c["text"] for c in sent["messages"][0]["content"] if c["type"] == "text"]
+        history_block = [t for t in content_texts if "Recent actions" in t][0]
+        assert "action_0" not in history_block
+        assert "action_4" not in history_block
+        assert "action_5" in history_block
+        assert "action_9" in history_block
+
+
+class TestLocateElement:
+    def test_found(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        screen = make_screen(width=800, height=600)
+        api_response = make_api_response(json.dumps({
+            "x": 150, "y": 250, "width": 100, "height": 40,
+            "name": "Login", "role": "button", "confidence": 0.88,
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            elem = provider.locate_element(screen, "the Login button")
+
+        assert elem is not None
+        assert elem.name == "Login"
+        assert elem.region.x == 150
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        assert sent["max_tokens"] == 512
+        text_parts = [c["text"] for c in sent["messages"][0]["content"] if c["type"] == "text"]
+        assert any("800x600" in t for t in text_parts)
+        assert any("the Login button" in t for t in text_parts)
+
+    def test_not_found(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        screen = make_screen()
+        api_response = make_api_response(json.dumps({"not_found": True}))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            assert provider.locate_element(screen, "invisible thing") is None
+
+
+class TestVerifyAction:
+    def test_success(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        before = make_screen(image_bytes=b"before_img")
+        after = make_screen(image_bytes=b"after_img")
+        api_response = make_api_response(json.dumps({
+            "success": True, "explanation": "The file was saved",
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            success, explanation = provider.verify_action(before, after, "File should be saved")
+
+        assert success is True
+        assert explanation == "The file was saved"
+
+        req = mock_urlopen.call_args[0][0]
+        sent = json.loads(req.data.decode("utf-8"))
+        assert sent["max_tokens"] == 256
+        content = sent["messages"][0]["content"]
+        image_blocks = [c for c in content if c["type"] == "image"]
+        assert len(image_blocks) == 2
+
+    def test_failure(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        before = make_screen()
+        after = make_screen()
+        api_response = make_api_response(json.dumps({
+            "success": False, "explanation": "Nothing changed",
+        }))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            success, explanation = provider.verify_action(before, after, "Something should change")
+
+        assert success is False
+        assert explanation == "Nothing changed"
+
+    def test_api_error_returns_inconclusive(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        before = make_screen()
+        after = make_screen()
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("timeout")):
+            success, explanation = provider.verify_action(before, after, "expected change")
+
+        assert success is True
+        assert "inconclusive" in explanation.lower()
+
+    def test_bad_json_returns_inconclusive(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        before = make_screen()
+        after = make_screen()
+        api_response = make_api_response("not valid json")
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            success, explanation = provider.verify_action(before, after, "expected")
+
+        assert success is True
+        assert "inconclusive" in explanation.lower()
+
+    def test_missing_success_defaults_false(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        before = make_screen()
+        after = make_screen()
+        api_response = make_api_response(json.dumps({"explanation": "unclear"}))
+        mock_resp = make_urlopen_mock(api_response)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            success, explanation = provider.verify_action(before, after, "expected")
+
+        assert success is False
+        assert explanation == "unclear"
+
+
+class TestInit:
+    def test_default_model(self):
+        provider = AnthropicProvider(api_key="my-key")
+        assert provider._api_key == "my-key"
+        assert provider._model == "claude-sonnet-4-20250514"
+
+    def test_custom_model(self):
+        provider = AnthropicProvider(api_key="key2", model="claude-opus-4-20250514")
+        assert provider._model == "claude-opus-4-20250514"

--- a/computer_use/tests/test_cli.py
+++ b/computer_use/tests/test_cli.py
@@ -1,0 +1,251 @@
+"""Tests for the CLI entry point (__main__.py)."""
+
+import logging
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from computer_use.__main__ import main
+
+ENGINE_PATH = "computer_use.core.engine.ComputerUseEngine"
+
+
+def _make_step_result(success, action_type_value, reasoning, error=None):
+    action_type = MagicMock()
+    action_type.value = action_type_value
+    action_taken = MagicMock()
+    action_taken.action_type = action_type
+    step = MagicMock()
+    step.success = success
+    step.action_taken = action_taken
+    step.reasoning = reasoning
+    step.error = error
+    return step
+
+
+class TestInfoMode:
+    def test_prints_platform_info_and_screen_size(self, capsys):
+        mock_engine = MagicMock()
+        mock_engine.get_platform_info.return_value = {
+            "platform": "linux",
+            "backend_available": True,
+            "accessibility": {
+                "api_name": "AT-SPI",
+                "available": True,
+            },
+        }
+        mock_engine.get_screen_size.return_value = (1920, 1080)
+
+        with (
+            patch("sys.argv", ["computer_use", "--info"]),
+            patch(ENGINE_PATH, return_value=mock_engine) as mock_cls,
+        ):
+            main()
+
+        mock_cls.assert_called_once_with(config_path=None)
+        out = capsys.readouterr().out
+        assert "Platform: linux" in out
+        assert "Backend available: True" in out
+        assert "AT-SPI" in out
+        assert "1920x1080" in out
+
+    def test_info_prints_accessibility_notes_when_present(self, capsys):
+        mock_engine = MagicMock()
+        mock_engine.get_platform_info.return_value = {
+            "platform": "wsl2",
+            "backend_available": True,
+            "accessibility": {
+                "api_name": "AT-SPI",
+                "available": False,
+                "notes": "requires dbus",
+            },
+        }
+        mock_engine.get_screen_size.return_value = (2560, 1440)
+
+        with (
+            patch("sys.argv", ["computer_use", "--info"]),
+            patch(ENGINE_PATH, return_value=mock_engine),
+        ):
+            main()
+
+        out = capsys.readouterr().out
+        assert "requires dbus" in out
+
+
+class TestScreenshotMode:
+    def test_saves_screenshot_bytes_to_file(self, capsys):
+        mock_screen = MagicMock()
+        mock_screen.image_bytes = b"\x89PNG_FAKE_DATA"
+        mock_screen.width = 1920
+        mock_screen.height = 1080
+
+        mock_engine = MagicMock()
+        mock_engine.screenshot.return_value = mock_screen
+
+        m = mock_open()
+        with (
+            patch("sys.argv", ["computer_use", "--screenshot", "/tmp/shot.png"]),
+            patch(ENGINE_PATH, return_value=mock_engine),
+            patch("builtins.open", m),
+        ):
+            main()
+
+        m.assert_called_once_with("/tmp/shot.png", "wb")
+        m().write.assert_called_once_with(b"\x89PNG_FAKE_DATA")
+        out = capsys.readouterr().out
+        assert "1920x1080" in out
+        assert "/tmp/shot.png" in out
+
+
+class TestTaskMode:
+    def test_runs_task_and_prints_step_results(self, capsys):
+        step1 = _make_step_result(True, "click", "Clicked the button")
+        step2 = _make_step_result(False, "type_text", "Typed into field", "timeout")
+
+        mock_engine = MagicMock()
+        mock_engine.get_platform.return_value = MagicMock(value="linux")
+        mock_engine.run_task.return_value = [step1, step2]
+
+        with (
+            patch(
+                "sys.argv",
+                ["computer_use", "--provider", "openai", "Open a browser"],
+            ),
+            patch(ENGINE_PATH, return_value=mock_engine) as mock_cls,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+
+        mock_cls.assert_called_once_with(config_path=None, provider="openai")
+        mock_engine.run_task.assert_called_once_with(
+            task="Open a browser",
+            max_steps=50,
+            verify=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Step 1: [OK] click" in out
+        assert "Step 2: [FAILED] type_text" in out
+        assert "Error: timeout" in out
+        assert "1/2 steps succeeded" in out
+
+    def test_all_steps_succeed_exits_zero(self):
+        step = _make_step_result(True, "click", "Done")
+        mock_engine = MagicMock()
+        mock_engine.get_platform.return_value = MagicMock(value="linux")
+        mock_engine.run_task.return_value = [step]
+
+        with (
+            patch("sys.argv", ["computer_use", "Do something"]),
+            patch(ENGINE_PATH, return_value=mock_engine),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+
+    def test_default_provider_is_anthropic(self):
+        step = _make_step_result(True, "click", "ok")
+        mock_engine = MagicMock()
+        mock_engine.get_platform.return_value = MagicMock(value="linux")
+        mock_engine.run_task.return_value = [step]
+
+        with (
+            patch("sys.argv", ["computer_use", "Do it"]),
+            patch(ENGINE_PATH, return_value=mock_engine) as mock_cls,
+        ):
+            with pytest.raises(SystemExit):
+                main()
+
+        assert mock_cls.call_args.kwargs["provider"] == "anthropic"
+
+    def test_no_verify_flag_passes_verify_false(self):
+        step = _make_step_result(True, "click", "ok")
+        mock_engine = MagicMock()
+        mock_engine.get_platform.return_value = MagicMock(value="linux")
+        mock_engine.run_task.return_value = [step]
+
+        with (
+            patch("sys.argv", ["computer_use", "--no-verify", "Do it"]),
+            patch(ENGINE_PATH, return_value=mock_engine),
+        ):
+            with pytest.raises(SystemExit):
+                main()
+
+        mock_engine.run_task.assert_called_once_with(
+            task="Do it",
+            max_steps=50,
+            verify=False,
+        )
+
+    def test_max_steps_arg_forwarded(self):
+        step = _make_step_result(True, "click", "ok")
+        mock_engine = MagicMock()
+        mock_engine.get_platform.return_value = MagicMock(value="linux")
+        mock_engine.run_task.return_value = [step]
+
+        with (
+            patch(
+                "sys.argv",
+                ["computer_use", "--max-steps", "10", "Do it"],
+            ),
+            patch(ENGINE_PATH, return_value=mock_engine),
+        ):
+            with pytest.raises(SystemExit):
+                main()
+
+        assert mock_engine.run_task.call_args.kwargs["max_steps"] == 10
+
+
+class TestNoArgs:
+    def test_no_args_causes_system_exit(self):
+        with patch("sys.argv", ["computer_use"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code != 0
+
+
+class TestVerboseFlag:
+    def test_verbose_sets_debug_logging(self):
+        mock_engine = MagicMock()
+        mock_engine.get_platform_info.return_value = {
+            "platform": "linux",
+            "backend_available": True,
+            "accessibility": {"api_name": "AT-SPI", "available": True},
+        }
+        mock_engine.get_screen_size.return_value = (1920, 1080)
+
+        with (
+            patch("sys.argv", ["computer_use", "--verbose", "--info"]),
+            patch(ENGINE_PATH, return_value=mock_engine),
+            patch("computer_use.__main__.logging") as mock_logging,
+        ):
+            mock_logging.DEBUG = logging.DEBUG
+            mock_logging.INFO = logging.INFO
+            main()
+
+        mock_logging.basicConfig.assert_called_once()
+        assert mock_logging.basicConfig.call_args.kwargs["level"] == logging.DEBUG
+
+    def test_without_verbose_sets_info_logging(self):
+        mock_engine = MagicMock()
+        mock_engine.get_platform_info.return_value = {
+            "platform": "linux",
+            "backend_available": True,
+            "accessibility": {"api_name": "AT-SPI", "available": True},
+        }
+        mock_engine.get_screen_size.return_value = (1920, 1080)
+
+        with (
+            patch("sys.argv", ["computer_use", "--info"]),
+            patch(ENGINE_PATH, return_value=mock_engine),
+            patch("computer_use.__main__.logging") as mock_logging,
+        ):
+            mock_logging.DEBUG = logging.DEBUG
+            mock_logging.INFO = logging.INFO
+            main()
+
+        mock_logging.basicConfig.assert_called_once()
+        assert mock_logging.basicConfig.call_args.kwargs["level"] == logging.INFO

--- a/computer_use/tests/test_core_loop.py
+++ b/computer_use/tests/test_core_loop.py
@@ -1,0 +1,218 @@
+"""Tests for the autonomous execution loop."""
+
+from unittest.mock import MagicMock, patch
+
+from computer_use.core.types import Action, ActionType, Element, Region, ScreenState
+from computer_use.providers.base import AgentDecision
+from computer_use.core.loop import run_core_loop, MAX_CONSECUTIVE_FAILURES
+
+
+def _make_screen():
+    return ScreenState(image_bytes=b"fake", width=1920, height=1080)
+
+
+def _make_decision(action_type=ActionType.CLICK, complete=False, confidence=0.9):
+    return AgentDecision(
+        action=Action(action_type=action_type, x=500, y=300),
+        reasoning="clicking the button",
+        is_task_complete=complete,
+        confidence=confidence,
+    )
+
+
+def _make_mocks():
+    capture = MagicMock()
+    capture.capture_full.return_value = _make_screen()
+    executor = MagicMock()
+    provider = MagicMock()
+    return capture, executor, provider
+
+
+@patch("computer_use.core.loop.time.sleep")
+class TestTaskCompletion:
+    def test_stops_when_task_marked_complete(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision(complete=True)
+
+        results = run_core_loop(capture, executor, None, provider, "do stuff", max_steps=10)
+
+        assert len(results) == 1
+        assert results[0].success is True
+        executor.execute_action.assert_not_called()
+
+    def test_runs_up_to_max_steps(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision()
+        provider.verify_action.return_value = (True, "ok")
+
+        results = run_core_loop(capture, executor, None, provider, "do stuff", max_steps=3)
+
+        assert len(results) == 3
+        assert executor.execute_action.call_count == 3
+
+
+@patch("computer_use.core.loop.time.sleep")
+class TestActionExecution:
+    def test_executes_decided_action(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        decision = _make_decision(ActionType.TYPE_TEXT)
+        provider.decide_action.return_value = decision
+        provider.verify_action.return_value = (True, "ok")
+
+        results = run_core_loop(capture, executor, None, provider, "type hello", max_steps=1)
+
+        executor.execute_action.assert_called_once_with(decision.action)
+        assert results[0].success is True
+
+    def test_records_action_failure(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision()
+        executor.execute_action.side_effect = Exception("click failed")
+
+        results = run_core_loop(capture, executor, None, provider, "click it", max_steps=1)
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert "click failed" in results[0].error
+
+
+@patch("computer_use.core.loop.time.sleep")
+class TestConsecutiveFailures:
+    def test_aborts_after_max_consecutive_action_failures(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision()
+        executor.execute_action.side_effect = Exception("boom")
+
+        results = run_core_loop(capture, executor, None, provider, "task", max_steps=10)
+
+        assert len(results) == MAX_CONSECUTIVE_FAILURES
+
+    def test_aborts_after_max_consecutive_provider_failures(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.side_effect = Exception("api down")
+
+        results = run_core_loop(capture, executor, None, provider, "task", max_steps=10)
+
+        assert len(results) == 0
+        assert provider.decide_action.call_count == MAX_CONSECUTIVE_FAILURES
+
+    def test_resets_failure_counter_on_success(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.verify_action.return_value = (True, "ok")
+
+        fail_decision = _make_decision()
+        ok_decision = _make_decision()
+        complete_decision = _make_decision(complete=True)
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise Exception("temporary fail")
+            if call_count == 3:
+                return ok_decision
+            return complete_decision
+
+        provider.decide_action.side_effect = side_effect
+
+        results = run_core_loop(capture, executor, None, provider, "task", max_steps=10)
+
+        assert any(r.success for r in results)
+
+
+@patch("computer_use.core.loop.time.sleep")
+class TestVerification:
+    def test_verification_failure_marks_step_unsuccessful(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision()
+        provider.verify_action.return_value = (False, "nothing changed")
+
+        results = run_core_loop(
+            capture, executor, None, provider, "task", max_steps=1, verify=True
+        )
+
+        assert results[0].success is False
+        assert "nothing changed" in results[0].error
+
+    def test_skips_verification_when_disabled(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision()
+
+        results = run_core_loop(
+            capture, executor, None, provider, "task", max_steps=1, verify=False
+        )
+
+        provider.verify_action.assert_not_called()
+        assert results[0].success is True
+
+    def test_verification_exception_assumes_success(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision()
+        provider.verify_action.side_effect = Exception("timeout")
+
+        results = run_core_loop(
+            capture, executor, None, provider, "task", max_steps=1, verify=True
+        )
+
+        assert results[0].success is True
+
+
+@patch("computer_use.core.loop.time.sleep")
+class TestGrounding:
+    def test_passes_elements_to_provider(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision(complete=True)
+
+        locator = MagicMock()
+        locator.is_available.return_value = True
+        elements = [
+            Element(name="OK", role="button", region=Region(x=10, y=20, width=50, height=25),
+                    confidence=0.95, source="accessibility")
+        ]
+        locator.find_all_elements.return_value = elements
+
+        run_core_loop(capture, executor, locator, provider, "task", max_steps=1)
+
+        call_kwargs = provider.decide_action.call_args
+        assert call_kwargs.kwargs.get("elements") == elements or call_kwargs[1].get("elements") == elements
+
+    def test_continues_without_elements_on_grounding_error(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.decide_action.return_value = _make_decision(complete=True)
+
+        locator = MagicMock()
+        locator.is_available.return_value = True
+        locator.find_all_elements.side_effect = Exception("atspi crash")
+
+        results = run_core_loop(capture, executor, locator, provider, "task", max_steps=1)
+
+        assert len(results) == 1
+
+
+@patch("computer_use.core.loop.time.sleep")
+class TestHistory:
+    def test_builds_history_across_steps(self, _sleep):
+        capture, executor, provider = _make_mocks()
+        provider.verify_action.return_value = (True, "ok")
+
+        call_num = 0
+        def decide(*args, **kwargs):
+            nonlocal call_num
+            call_num += 1
+            if call_num >= 3:
+                return _make_decision(complete=True)
+            return _make_decision()
+
+        provider.decide_action.side_effect = decide
+
+        results = run_core_loop(capture, executor, None, provider, "task", max_steps=5)
+
+        # The third call (complete) should have history from the first two steps
+        assert provider.decide_action.call_count == 3
+        # History is a mutable list passed by reference, so we check the final state
+        last_call = provider.decide_action.call_args_list[2]
+        history_arg = last_call.kwargs.get("history") or last_call[1].get("history")
+        assert len(history_arg) == 2
+        assert history_arg[0]["step"] == 1
+        assert history_arg[1]["step"] == 2

--- a/computer_use/tests/test_detect_platform.py
+++ b/computer_use/tests/test_detect_platform.py
@@ -1,0 +1,138 @@
+"""Tests for platform detection and backend factory."""
+
+import os
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from computer_use.core.types import Platform
+from computer_use.platform.detect import detect_platform, get_backend
+
+
+class TestDetectPlatform:
+    def test_wsl2_detected_via_env_and_proc_version(self):
+        with (
+            patch.dict(os.environ, {"WSL_DISTRO_NAME": "Ubuntu"}),
+            patch("sys.platform", "linux"),
+            patch(
+                "builtins.open",
+                mock_open(read_data="Linux 5.15.90.1-microsoft-standard-WSL2"),
+            ),
+        ):
+            assert detect_platform() == Platform.WSL2
+
+    def test_wsl2_detected_when_proc_version_unreadable(self):
+        with (
+            patch.dict(os.environ, {"WSL_DISTRO_NAME": "Ubuntu"}),
+            patch("sys.platform", "linux"),
+            patch("builtins.open", side_effect=OSError),
+        ):
+            assert detect_platform() == Platform.WSL2
+
+    def test_plain_linux_without_wsl_env(self):
+        env = os.environ.copy()
+        env.pop("WSL_DISTRO_NAME", None)
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.platform", "linux"),
+        ):
+            assert detect_platform() == Platform.LINUX
+
+    def test_macos_detected(self):
+        with patch("sys.platform", "darwin"):
+            assert detect_platform() == Platform.MACOS
+
+    def test_windows_detected(self):
+        with patch("sys.platform", "win32"):
+            assert detect_platform() == Platform.WINDOWS
+
+    def test_unsupported_platform_raises_runtime_error(self):
+        with patch("sys.platform", "aix"):
+            with pytest.raises(RuntimeError, match="Unsupported platform"):
+                detect_platform()
+
+    def test_wsl2_proc_version_without_microsoft_still_trusts_env(self):
+        with (
+            patch.dict(os.environ, {"WSL_DISTRO_NAME": "Debian"}),
+            patch("sys.platform", "linux"),
+            patch(
+                "builtins.open",
+                mock_open(read_data="Linux version 5.15 generic"),
+            ),
+        ):
+            result = detect_platform()
+            assert result == Platform.WSL2
+
+
+class TestGetBackend:
+    def test_wsl2_returns_wsl2_backend(self):
+        mock_cls = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"computer_use.platform.wsl2": MagicMock(WSL2Backend=mock_cls)},
+        ):
+            backend = get_backend(Platform.WSL2)
+            mock_cls.assert_called_once()
+            assert backend is mock_cls.return_value
+
+    def test_windows_returns_windows_backend(self):
+        mock_cls = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"computer_use.platform.windows": MagicMock(WindowsBackend=mock_cls)},
+        ):
+            backend = get_backend(Platform.WINDOWS)
+            mock_cls.assert_called_once()
+            assert backend is mock_cls.return_value
+
+    def test_macos_returns_macos_backend(self):
+        mock_cls = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"computer_use.platform.macos": MagicMock(MacOSBackend=mock_cls)},
+        ):
+            backend = get_backend(Platform.MACOS)
+            mock_cls.assert_called_once()
+            assert backend is mock_cls.return_value
+
+    def test_linux_returns_linux_backend(self):
+        mock_cls = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"computer_use.platform.linux": MagicMock(LinuxBackend=mock_cls)},
+        ):
+            backend = get_backend(Platform.LINUX)
+            mock_cls.assert_called_once()
+            assert backend is mock_cls.return_value
+
+    def test_none_platform_triggers_detection(self):
+        mock_cls = MagicMock()
+        with (
+            patch(
+                "computer_use.platform.detect.detect_platform",
+                return_value=Platform.LINUX,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"computer_use.platform.linux": MagicMock(LinuxBackend=mock_cls)},
+            ),
+        ):
+            backend = get_backend(None)
+            mock_cls.assert_called_once()
+            assert backend is mock_cls.return_value
+
+    def test_default_arg_is_none(self):
+        mock_cls = MagicMock()
+        with (
+            patch(
+                "computer_use.platform.detect.detect_platform",
+                return_value=Platform.MACOS,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"computer_use.platform.macos": MagicMock(MacOSBackend=mock_cls)},
+            ),
+        ):
+            backend = get_backend()
+            mock_cls.assert_called_once()
+            assert backend is mock_cls.return_value

--- a/computer_use/tests/test_engine.py
+++ b/computer_use/tests/test_engine.py
@@ -1,17 +1,28 @@
 """Tests for the ComputerUseEngine with mocked backends."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
 from computer_use.core.engine import (
     ComputerUseEngine,
+    _CacheContext,
     _LAYER2_MIN_CONFIDENCE,
     _PCT_BUCKET,
     _PASSTHROUGH_APPS,
+    _default_cache_path,
 )
-from computer_use.core.spatial_cache import MIN_NAV_HIT_COUNT
-from computer_use.core.types import Element, ForegroundWindow, Platform, Region, ScreenState
+from computer_use.core.errors import ConfigError, PlatformNotSupportedError
+from computer_use.core.spatial_cache import CacheEntry, MIN_NAV_HIT_COUNT
+from computer_use.core.types import (
+    Action,
+    ActionType,
+    Element,
+    ForegroundWindow,
+    Platform,
+    Region,
+    ScreenState,
+)
 
 
 @pytest.fixture
@@ -47,6 +58,133 @@ def mock_backend():
     return backend, capture, executor
 
 
+# ---------------------------------------------------------------------------
+# TestDefaultCachePath -- _default_cache_path() coverage
+# ---------------------------------------------------------------------------
+
+class TestDefaultCachePath:
+    """Covers lines 84-94: env var, Windows, XDG_DATA_HOME, default."""
+
+    @patch("computer_use.core.engine.os.makedirs")
+    @patch.dict("os.environ", {"AGENT_FORGE_DATA": "/custom/data"}, clear=False)
+    def test_agent_forge_data_env(self, mock_makedirs):
+        result = _default_cache_path()
+        assert result.startswith("/custom/data")
+        assert result.endswith("muscle_memory.db")
+        mock_makedirs.assert_called_once_with("/custom/data", exist_ok=True)
+
+    @patch("computer_use.core.engine.os.makedirs")
+    @patch("computer_use.core.engine.os.name", "nt")
+    @patch.dict("os.environ", {"APPDATA": "C:\\Users\\test\\AppData\\Roaming"}, clear=False)
+    def test_windows_uses_appdata(self, mock_makedirs):
+        # Remove AGENT_FORGE_DATA so it does not short-circuit
+        with patch.dict("os.environ", {}, clear=False):
+            if "AGENT_FORGE_DATA" in __import__("os").environ:
+                del __import__("os").environ["AGENT_FORGE_DATA"]
+            result = _default_cache_path()
+        assert "AgentForge" in result
+        assert result.endswith("muscle_memory.db")
+
+    @patch("computer_use.core.engine.os.makedirs")
+    @patch("computer_use.core.engine.os.name", "posix")
+    @patch.dict(
+        "os.environ",
+        {"XDG_DATA_HOME": "/home/user/.data"},
+        clear=False,
+    )
+    def test_xdg_data_home(self, mock_makedirs):
+        with patch.dict("os.environ", {}, clear=False):
+            if "AGENT_FORGE_DATA" in __import__("os").environ:
+                del __import__("os").environ["AGENT_FORGE_DATA"]
+            result = _default_cache_path()
+        assert "agent-forge" in result
+        assert result.endswith("muscle_memory.db")
+
+    @patch("computer_use.core.engine.os.makedirs")
+    @patch("computer_use.core.engine.os.name", "posix")
+    @patch("computer_use.core.engine.os.path.expanduser", return_value="/home/testuser")
+    def test_default_local_share(self, mock_expand, mock_makedirs):
+        with patch.dict("os.environ", {}, clear=False):
+            for key in ("AGENT_FORGE_DATA", "XDG_DATA_HOME"):
+                __import__("os").environ.pop(key, None)
+            result = _default_cache_path()
+        assert ".local" in result
+        assert "share" in result
+        assert "agent-forge" in result
+        assert result.endswith("muscle_memory.db")
+
+
+# ---------------------------------------------------------------------------
+# TestEngineInit -- __init__ and config loading coverage
+# ---------------------------------------------------------------------------
+
+class TestEngineInit:
+    """Covers line 122, config loading paths, PlatformNotSupportedError."""
+
+    def test_backend_not_available_raises(self, mock_backend):
+        backend, _, _ = mock_backend
+        backend.is_available.return_value = False
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.LINUX),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            with pytest.raises(PlatformNotSupportedError, match="not available"):
+                ComputerUseEngine()
+
+    def test_config_from_yaml_file(self, mock_backend):
+        backend, _, _ = mock_backend
+        yaml_content = "provider: anthropic\nfoo: bar\n"
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+            patch("builtins.open", mock_open(read_data=yaml_content)),
+            patch("computer_use.core.engine.yaml.safe_load", return_value={"provider": "anthropic", "foo": "bar"}),
+        ):
+            engine = ComputerUseEngine(config_path="/fake/config.yaml")
+        assert engine._config == {"provider": "anthropic", "foo": "bar"}
+        assert engine._provider_name == "anthropic"
+
+    def test_config_yaml_load_error_raises(self, mock_backend):
+        backend, _, _ = mock_backend
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+            patch("builtins.open", side_effect=IOError("no such file")),
+        ):
+            with pytest.raises(ConfigError, match="Cannot load config"):
+                ComputerUseEngine(config_path="/bad/path.yaml")
+
+    def test_config_default_missing_returns_empty(self, mock_backend):
+        backend, _, _ = mock_backend
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+            patch("computer_use.core.engine.os.path.exists", return_value=False),
+            patch("computer_use.core.engine.yaml"),
+        ):
+            engine = ComputerUseEngine()
+        assert engine._config == {}
+
+    def test_provider_passed_in_constructor(self, mock_backend):
+        backend, _, _ = mock_backend
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+            patch("computer_use.core.engine.yaml"),
+        ):
+            engine = ComputerUseEngine(provider="openai")
+        assert engine._provider_name == "openai"
+
+
+# ---------------------------------------------------------------------------
+# TestEngine -- basic engine API
+# ---------------------------------------------------------------------------
+
 class TestEngine:
     def _make_engine(self, mock_backend):
         backend, capture, executor = mock_backend
@@ -66,6 +204,25 @@ class TestEngine:
         assert screen.width == 1920
         assert screen.height == 1080
         capture.capture_full.assert_called_once()
+
+    def test_screenshot_stores_offset(self, mock_backend):
+        """screenshot() records virtual screen offset for coordinate translation."""
+        backend, capture, executor = mock_backend
+        capture.capture_full.return_value = ScreenState(
+            image_bytes=b"\x89PNG", width=1920, height=1080,
+            offset_x=100, offset_y=50,
+        )
+        backend.get_foreground_window.return_value = None
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            engine = ComputerUseEngine()
+        engine.screenshot()
+        assert engine._vs_offset_x == 100
+        assert engine._vs_offset_y == 50
 
     def test_screenshot_region(self, mock_backend):
         engine, capture, _ = self._make_engine(mock_backend)
@@ -103,6 +260,37 @@ class TestEngine:
         engine.scroll(100, 200, -3)
         executor.scroll.assert_called_once_with(100, 200, -3)
 
+    def test_drag(self, mock_backend):
+        """Covers lines 345-347: drag translates coords and delegates."""
+        engine, _, executor = self._make_engine(mock_backend)
+        engine.drag(10, 20, 300, 400, duration=0.3)
+        executor.drag.assert_called_once_with(10, 20, 300, 400, 0.3)
+
+    def test_drag_with_offset(self, mock_backend):
+        """drag() applies virtual screen offset to both start and end."""
+        backend, capture, executor = mock_backend
+        capture.capture_full.return_value = ScreenState(
+            image_bytes=b"\x89PNG", width=1920, height=1080,
+            offset_x=100, offset_y=50,
+        )
+        backend.get_foreground_window.return_value = None
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            engine = ComputerUseEngine()
+        engine.screenshot()
+        engine.drag(10, 20, 300, 400)
+        executor.drag.assert_called_once_with(110, 70, 400, 450, 0.5)
+
+    def test_move_mouse(self, mock_backend):
+        """move_mouse delegates to executor with hit_count from cache."""
+        engine, _, executor = self._make_engine(mock_backend)
+        engine.move_mouse(200, 300)
+        executor.move_mouse.assert_called_once_with(200, 300, hit_count=0)
+
     def test_get_platform(self, mock_backend):
         engine, _, _ = self._make_engine(mock_backend)
         assert engine.get_platform() == Platform.WSL2
@@ -117,11 +305,201 @@ class TestEngine:
         assert info["platform"] == "wsl2"
         assert info["backend_available"] is True
 
+    def test_execute_action(self, mock_backend):
+        """Covers line 679: execute_action delegates to executor."""
+        engine, _, executor = self._make_engine(mock_backend)
+        action = Action(action_type=ActionType.CLICK, x=100, y=200)
+        engine.execute_action(action)
+        executor.execute_action.assert_called_once_with(action)
+
     def test_run_task_without_provider_raises(self, mock_backend):
         engine, _, _ = self._make_engine(mock_backend)
         with pytest.raises(Exception):
             engine.run_task("Open Notepad")
 
+
+# ---------------------------------------------------------------------------
+# TestGetProvider -- _get_provider / _get_locator coverage
+# ---------------------------------------------------------------------------
+
+class TestProviderAndLocator:
+    """Covers lines 757, 764, 777-779, 687-699."""
+
+    def _make_engine(self, mock_backend, provider=None):
+        backend, capture, executor = mock_backend
+        backend.get_foreground_window.return_value = None
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            engine = ComputerUseEngine(provider=provider)
+        return engine, capture, executor
+
+    def test_get_provider_no_name_raises(self, mock_backend):
+        """No provider configured raises ConfigError (line 757)."""
+        engine, _, _ = self._make_engine(mock_backend)
+        # Force provider_name to None (yaml mock may set it to a MagicMock)
+        engine._provider_name = None
+        with pytest.raises(ConfigError, match="No LLM provider"):
+            engine._get_provider()
+
+    def test_get_provider_loads_from_registry(self, mock_backend):
+        """Provider is lazy-loaded via get_provider registry (line 764)."""
+        engine, _, _ = self._make_engine(mock_backend, provider="anthropic")
+        mock_prov = MagicMock()
+        with patch(
+            "computer_use.providers.registry.get_provider",
+            return_value=mock_prov,
+        ):
+            result = engine._get_provider()
+        assert result is mock_prov
+        # Second call returns cached instance
+        assert engine._get_provider() is mock_prov
+
+    def test_get_locator_import_error_returns_none(self, mock_backend):
+        """Grounding import failure returns None (lines 777-779)."""
+        engine, _, _ = self._make_engine(mock_backend)
+        engine._locator = None
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def fake_import(name, *args, **kwargs):
+            if "hybrid" in name:
+                raise ImportError("no grounding")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            result = engine._get_locator()
+        assert result is None
+
+    def test_find_element_no_locator_returns_none(self, mock_backend):
+        """find_element returns None when no locator available (lines 687-689)."""
+        engine, _, _ = self._make_engine(mock_backend)
+        engine._get_locator = lambda: None
+        result = engine.find_element("Save button")
+        assert result is None
+
+    def test_find_element_delegates_to_locator(self, mock_backend):
+        """find_element uses locator.find_element with screenshot (lines 690-691)."""
+        engine, capture, _ = self._make_engine(mock_backend)
+        locator = MagicMock()
+        expected = Element(
+            name="Save", role="Button",
+            region=Region(10, 20, 80, 30),
+            confidence=0.9, source="accessibility",
+        )
+        locator.find_element.return_value = expected
+        engine._get_locator = lambda: locator
+        result = engine.find_element("Save button")
+        assert result is expected
+        locator.find_element.assert_called_once()
+
+    def test_find_all_elements_no_locator_returns_empty(self, mock_backend):
+        """find_all_elements returns [] when no locator (lines 695-697)."""
+        engine, _, _ = self._make_engine(mock_backend)
+        engine._get_locator = lambda: None
+        result = engine.find_all_elements()
+        assert result == []
+
+    def test_find_all_elements_delegates_to_locator(self, mock_backend):
+        """find_all_elements uses locator (lines 698-699)."""
+        engine, capture, _ = self._make_engine(mock_backend)
+        locator = MagicMock()
+        locator.find_all_elements.return_value = [
+            Element(name="OK", role="Button", region=Region(0, 0, 50, 20),
+                    confidence=1.0, source="accessibility"),
+        ]
+        engine._get_locator = lambda: locator
+        result = engine.find_all_elements()
+        assert len(result) == 1
+        locator.find_all_elements.assert_called_once()
+
+    def test_click_element(self, mock_backend):
+        """click_element clicks center of element region (lines 703-704)."""
+        engine, _, executor = self._make_engine(mock_backend)
+        el = Element(
+            name="OK", role="Button",
+            region=Region(100, 200, 80, 40),
+            confidence=1.0, source="accessibility",
+        )
+        engine.click_element(el)
+        # center = (100 + 40, 200 + 20) = (140, 220)
+        executor.click.assert_called_once_with(140, 220, hit_count=0)
+
+
+# ---------------------------------------------------------------------------
+# TestRunTask -- run_task coverage
+# ---------------------------------------------------------------------------
+
+class TestRunTask:
+    """Covers lines 737-740: run_task imports and calls run_core_loop."""
+
+    def _make_engine(self, mock_backend):
+        backend, capture, executor = mock_backend
+        backend.get_foreground_window.return_value = None
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            engine = ComputerUseEngine(provider="anthropic")
+        return engine, capture, executor
+
+    def test_run_task_calls_core_loop(self, mock_backend):
+        engine, _, _ = self._make_engine(mock_backend)
+        mock_provider = MagicMock()
+        engine._provider = mock_provider
+        engine._locator = MagicMock()
+
+        with patch("computer_use.core.loop.run_core_loop", return_value=[]) as mock_loop:
+            results = engine.run_task("Open Notepad", max_steps=10, verify=False)
+        assert results == []
+        mock_loop.assert_called_once()
+        call_kwargs = mock_loop.call_args[1]
+        assert call_kwargs["task"] == "Open Notepad"
+        assert call_kwargs["max_steps"] == 10
+        assert call_kwargs["verify"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestConfigLoading -- _load_config coverage
+# ---------------------------------------------------------------------------
+
+class TestConfigLoading:
+    """Covers lines 791, 795-796: default path missing, YAML load error."""
+
+    def test_load_config_default_exists(self, mock_backend):
+        backend, _, _ = mock_backend
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+            patch("computer_use.core.engine.os.path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data="key: val\n")),
+            patch("computer_use.core.engine.yaml.safe_load", return_value={"key": "val"}),
+        ):
+            engine = ComputerUseEngine()
+        assert engine._config == {"key": "val"}
+
+    def test_load_config_yaml_returns_none(self, mock_backend):
+        """yaml.safe_load returning None should give empty dict (line 794)."""
+        backend, _, _ = mock_backend
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+            patch("builtins.open", mock_open(read_data="")),
+            patch("computer_use.core.engine.yaml.safe_load", return_value=None),
+        ):
+            engine = ComputerUseEngine(config_path="/some/config.yaml")
+        assert engine._config == {}
+
+
+# ---------------------------------------------------------------------------
+# TestMuscleMemoryIntegration
+# ---------------------------------------------------------------------------
 
 class TestMuscleMemoryIntegration:
     """Tests that the engine's muscle memory cache integrates correctly."""
@@ -212,6 +590,10 @@ class TestMuscleMemoryIntegration:
         assert last_call == ((300, 400,), {"hit_count": 0})
 
 
+# ---------------------------------------------------------------------------
+# TestThreeLayerResolution
+# ---------------------------------------------------------------------------
+
 class TestThreeLayerResolution:
     """Tests for the 3-layer cache resolution."""
 
@@ -272,6 +654,22 @@ class TestThreeLayerResolution:
         engine.click(100, 200)
         executor.click.assert_called_once_with(100, 200, hit_count=1)
 
+    def test_foreground_exception_falls_back(self, mock_backend):
+        """get_foreground_window raising an exception uses platform fallback (lines 182-183)."""
+        backend, capture, executor = mock_backend
+        backend.get_foreground_window.side_effect = RuntimeError("dbus failure")
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            engine = ComputerUseEngine()
+        engine.click(100, 200, element_hint="test")
+        executor.click.assert_called_once_with(100, 200, hit_count=0)
+        entry = engine._cache.lookup("wsl2", "test")
+        assert entry is not None
+
     def test_window_relative_coords_stored(self, mock_backend):
         """Cache uses window-relative coords so entries survive window moves."""
         fg = ForegroundWindow(
@@ -315,9 +713,6 @@ class TestThreeLayerResolution:
         engine, _, executor = self._make_engine(mock_backend, fg_window=fg)
 
         # 1000px wide, 3% bucket => 30px per bucket
-        # (100, 200) => pct (10%, 20%) => bucket @9%,18%
-        # (110, 210) => pct (11%, 21%) => bucket @9%,21% -- different Y bucket!
-        # Use coords that are in the same bucket:
         # (100, 200) => 10%, 20% => bucket @9%, 18%
         # (105, 205) => 10.5%, 20.5% => bucket @9%, 18%  (same)
         engine.click(100, 200)
@@ -379,6 +774,10 @@ class TestThreeLayerResolution:
         entry = engine._cache.lookup("wsl2", "test button")
         assert entry is not None
 
+
+# ---------------------------------------------------------------------------
+# TestNavigationBatch
+# ---------------------------------------------------------------------------
 
 class TestNavigationBatch:
     """Tests for the navigate_chain and navigate_to methods."""
@@ -465,6 +864,57 @@ class TestNavigationBatch:
         assert executor.click.call_count == 0
 
     @patch("computer_use.core.engine.time")
+    def test_navigate_chain_no_app_name_uses_platform(self, mock_time, mock_backend):
+        """Empty app_name and fg with no app_name falls to platform value (line 496)."""
+        _t = [0.0]
+        def _tick():
+            _t[0] += 2.0
+            return _t[0]
+        mock_time.monotonic.side_effect = _tick
+        mock_time.sleep = MagicMock()
+        # fg window exists (needed for _cache_to_screen) but has empty app_name
+        fg = ForegroundWindow(
+            app_name="", title="", x=0, y=0,
+            width=800, height=600,
+        )
+        engine, _, executor = self._make_engine(mock_backend, fg_window=fg)
+        self._warm_cache(engine, "wsl2", "btn", 100, 200)
+
+        result = engine.navigate_chain("", ["btn"])
+        assert result["completed"] == 1
+        assert result["stopped"] is False
+
+    @patch("computer_use.core.engine.time")
+    def test_navigate_chain_click_typeerror_fallback(self, mock_time, mock_backend):
+        """executor.click raises TypeError -> falls back without hit_count (lines 548-549)."""
+        _t = [0.0]
+        def _tick():
+            _t[0] += 2.0
+            return _t[0]
+        mock_time.monotonic.side_effect = _tick
+        mock_time.sleep = MagicMock()
+        fg = ForegroundWindow(
+            app_name="app.exe", title="test", x=0, y=0,
+            width=800, height=600,
+        )
+        engine, _, executor = self._make_engine(mock_backend, fg_window=fg)
+        self._warm_cache(engine, "app.exe", "btn_a", 100, 200)
+
+        # First call with hit_count raises TypeError, second call without it succeeds
+        call_count = [0]
+        def click_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if "hit_count" in kwargs:
+                raise TypeError("unexpected keyword argument 'hit_count'")
+        executor.click.side_effect = click_side_effect
+
+        result = engine.navigate_chain("app.exe", ["btn_a"])
+        assert result["completed"] == 1
+        assert result["stopped"] is False
+        # Should have been called twice: once with hit_count (TypeError), once without
+        assert executor.click.call_count == 2
+
+    @patch("computer_use.core.engine.time")
     def test_navigate_to_direct(self, mock_time, mock_backend):
         """Direct lookup works for single target."""
         _t = [0.0]
@@ -484,6 +934,74 @@ class TestNavigationBatch:
         assert result["completed"] == 1
         assert result["stopped"] is False
 
+    @patch("computer_use.core.engine.time")
+    def test_navigate_to_auto_detects_app(self, mock_time, mock_backend):
+        """navigate_to with no target_app uses fg window (lines 592-596)."""
+        _t = [0.0]
+        def _tick():
+            _t[0] += 2.0
+            return _t[0]
+        mock_time.monotonic.side_effect = _tick
+        mock_time.sleep = MagicMock()
+        fg = ForegroundWindow(
+            app_name="app.exe", title="test", x=0, y=0,
+            width=800, height=600,
+        )
+        engine, _, executor = self._make_engine(mock_backend, fg_window=fg)
+        self._warm_cache(engine, "app.exe", "ok btn", 100, 50)
+
+        result = engine.navigate_to("ok btn")
+        assert result["completed"] == 1
+
+    @patch("computer_use.core.engine.time")
+    def test_navigate_to_no_fg_uses_platform(self, mock_time, mock_backend):
+        """navigate_to with no fg app_name falls to platform name (line 596)."""
+        _t = [0.0]
+        def _tick():
+            _t[0] += 2.0
+            return _t[0]
+        mock_time.monotonic.side_effect = _tick
+        mock_time.sleep = MagicMock()
+        # fg window with empty app_name so navigate_to falls to platform value,
+        # but still has dimensions so _cache_to_screen can convert coords.
+        fg = ForegroundWindow(
+            app_name="", title="", x=0, y=0,
+            width=800, height=600,
+        )
+        engine, _, executor = self._make_engine(mock_backend, fg_window=fg)
+        self._warm_cache(engine, "wsl2", "btn", 50, 50)
+
+        result = engine.navigate_to("btn")
+        assert result["completed"] == 1
+
+    @patch("computer_use.core.engine.time")
+    def test_navigate_to_with_path_finding(self, mock_time, mock_backend):
+        """navigate_to uses BFS path finding when current_hint given (lines 600-608)."""
+        _t = [0.0]
+        def _tick():
+            _t[0] += 2.0
+            return _t[0]
+        mock_time.monotonic.side_effect = _tick
+        mock_time.sleep = MagicMock()
+        fg = ForegroundWindow(
+            app_name="app.exe", title="test", x=0, y=0,
+            width=800, height=600,
+        )
+        engine, _, executor = self._make_engine(mock_backend, fg_window=fg)
+        # Warm up entries
+        self._warm_cache(engine, "app.exe", "step_a", 100, 100)
+        self._warm_cache(engine, "app.exe", "step_b", 200, 200)
+
+        # Mock find_path to return a path: current -> step_a -> step_b
+        engine._cache.find_path = MagicMock(
+            return_value=[("app.exe", "start"), ("app.exe", "step_a"), ("app.exe", "step_b")]
+        )
+
+        result = engine.navigate_to("step_b", target_app="app.exe", current_hint="start")
+        assert result["completed"] == 2
+        assert result["stopped"] is False
+        engine._cache.find_path.assert_called_once()
+
     def test_cache_to_screen_roundtrip(self, mock_backend):
         """Window-relative cache coords convert correctly back to screen."""
         fg = ForegroundWindow(
@@ -498,6 +1016,22 @@ class TestNavigationBatch:
         sx, sy = result
         assert sx == 350  # 200 + 150
         assert sy == 350  # 100 + 250
+
+    def test_cache_to_screen_no_fg_returns_none(self, mock_backend):
+        """No foreground window -> returns None (line 381)."""
+        engine, _, _ = self._make_engine(mock_backend, fg_window=None)
+        result = engine._cache_to_screen(100, 200)
+        assert result is None
+
+    def test_cache_to_screen_zero_width_returns_none(self, mock_backend):
+        """fg window with width=0 -> returns None (line 380)."""
+        fg = ForegroundWindow(
+            app_name="app.exe", title="test", x=0, y=0,
+            width=0, height=600,
+        )
+        engine, _, _ = self._make_engine(mock_backend, fg_window=fg)
+        result = engine._cache_to_screen(100, 200)
+        assert result is None
 
     @patch("computer_use.core.engine.time")
     def test_navigate_chain_cross_app(self, mock_time, mock_backend):
@@ -520,17 +1054,10 @@ class TestNavigationBatch:
             width=400, height=300,
         )
         # get_foreground_window returns code.exe initially, then search.exe.
-        # navigate_chain calls _get_fg_window in:
-        #   1. _cache_to_screen (step 0)
-        #   2. rescale_coords fg (step 0)
-        #   3. _wait_for_nav_transition poll (between steps 0→1)
-        #   4. fg detection (step 1, i > 0)
-        #   5. _cache_to_screen (step 1)
-        #   6. rescale_coords fg (step 1)
         backend.get_foreground_window.side_effect = [
             fg_code,     # _cache_to_screen for step 0
             fg_code,     # rescale_coords fg for step 0
-            fg_search,   # _wait_for_nav_transition poll (step 0→1)
+            fg_search,   # _wait_for_nav_transition poll (step 0->1)
             fg_search,   # step 1: fg detection (i > 0)
             fg_search,   # _cache_to_screen for step 1
             fg_search,   # rescale_coords fg for step 1
@@ -576,7 +1103,7 @@ class TestNavigationBatch:
         backend.get_foreground_window.side_effect = [
             fg_code,     # _cache_to_screen for step 0
             fg_code,     # rescale_coords fg for step 0
-            fg_search,   # _wait_for_nav_transition poll (step 0→1)
+            fg_search,   # _wait_for_nav_transition poll (step 0->1)
             fg_search,   # step 1: fg detection (i > 0)
             fg_search,   # _cache_to_screen for step 1
             fg_search,   # rescale_coords fg for step 1
@@ -810,6 +1337,10 @@ class TestNavigationBatch:
         assert "out of bounds" in result["reason"]
         assert executor.click.call_count == 0
 
+
+# ---------------------------------------------------------------------------
+# TestLayer2Integration
+# ---------------------------------------------------------------------------
 
 class TestLayer2Integration:
     """Tests that Layer 2 (accessibility API) integrates correctly with the engine."""
@@ -1133,3 +1664,20 @@ class TestTemplateExecution:
 
         info, _ = engine._cache.get_template("counter")
         assert info["use_count"] == 2
+
+    @patch("computer_use.core.engine.time")
+    def test_template_step_exception_stops(self, mock_time, mock_backend):
+        """Exception during template step stops and reports reason (lines 654-659)."""
+        mock_time.time.return_value = 1000.0
+        mock_time.monotonic.return_value = 1000.0
+        mock_time.sleep = MagicMock()
+        engine, _, executor = self._make_engine(mock_backend)
+        executor.type_text.side_effect = RuntimeError("keyboard locked")
+
+        engine._cache.create_template("err-test", "app.exe", [
+            {"action": "type_text", "text": "oops", "wait_ms": 0},
+        ])
+        result = engine.execute_template("err-test")
+        assert result["stopped"] is True
+        assert result["completed"] == 0
+        assert "error" in result["reason"]

--- a/computer_use/tests/test_hybrid_locator.py
+++ b/computer_use/tests/test_hybrid_locator.py
@@ -1,0 +1,216 @@
+"""Tests for the hybrid element locator (accessibility-first, vision fallback)."""
+
+from unittest.mock import MagicMock, patch
+
+from computer_use.core.types import Element, Platform, Region, ScreenState
+
+
+def _make_screen():
+    return ScreenState(image_bytes=b"fake", width=1920, height=1080)
+
+
+def _make_element(name="Submit", confidence=0.9, source="accessibility"):
+    return Element(
+        name=name,
+        role="button",
+        region=Region(x=100, y=200, width=80, height=30),
+        confidence=confidence,
+        source=source,
+    )
+
+
+class TestFindElement:
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_accessibility_result_when_confident(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        expected = _make_element(confidence=0.9)
+        mock_a11y.find_element.return_value = expected
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        result = loc.find_element("Submit", _make_screen())
+        assert result is expected
+
+    @patch("computer_use.grounding.hybrid.VisionLocator")
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_falls_back_to_vision_on_low_confidence(self, mock_a11y_cls, mock_vision_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        mock_a11y.find_element.return_value = _make_element(confidence=0.3)
+        mock_a11y_cls.return_value = mock_a11y
+
+        vision_element = _make_element(name="Vision Submit", source="vision")
+        mock_vision = MagicMock()
+        mock_vision.find_element.return_value = vision_element
+        mock_vision_cls.return_value = mock_vision
+
+        loc = HybridLocator(Platform.LINUX, provider_name="anthropic", config={"key": "val"})
+        screen = _make_screen()
+        result = loc.find_element("Submit", screen)
+        assert result is vision_element
+
+    @patch("computer_use.grounding.hybrid.VisionLocator")
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_falls_back_to_vision_when_a11y_not_available(self, mock_a11y_cls, mock_vision_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+
+        vision_element = _make_element(source="vision")
+        mock_vision = MagicMock()
+        mock_vision.find_element.return_value = vision_element
+        mock_vision_cls.return_value = mock_vision
+
+        loc = HybridLocator(Platform.LINUX, provider_name="anthropic", config={"key": "val"})
+        result = loc.find_element("Button", _make_screen())
+        assert result is vision_element
+
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_none_when_a11y_not_found_and_no_vision(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        mock_a11y.find_element.return_value = None
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.find_element("Ghost", _make_screen()) is None
+
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_none_without_screen_and_no_a11y(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.find_element("Button", screen=None) is None
+
+
+class TestFindAllElements:
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_a11y_elements(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        elements = [_make_element("A"), _make_element("B")]
+        mock_a11y.find_all_elements.return_value = elements
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        result = loc.find_all_elements(_make_screen())
+        assert result == elements
+
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_empty_when_a11y_finds_nothing(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        mock_a11y.find_all_elements.return_value = []
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.find_all_elements(_make_screen()) == []
+
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_empty_when_a11y_not_available(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.find_all_elements(_make_screen()) == []
+
+
+class TestFindElementAt:
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_delegates_to_a11y(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        expected = _make_element()
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        mock_a11y.find_element_at.return_value = expected
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        screen = _make_screen()
+        result = loc.find_element_at(100, 200, screen)
+        assert result is expected
+        mock_a11y.find_element_at.assert_called_once_with(100, 200, screen)
+
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_returns_none_when_a11y_not_available(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.find_element_at(100, 200, _make_screen()) is None
+
+
+class TestIsAvailable:
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_true_when_a11y_available(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = True
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.is_available() is True
+
+    @patch("computer_use.grounding.hybrid.VisionLocator")
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_true_when_only_vision_available(self, mock_a11y_cls, mock_vision_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+        mock_vision_cls.return_value = MagicMock()
+
+        loc = HybridLocator(Platform.LINUX, provider_name="anthropic", config={"key": "val"})
+        assert loc.is_available() is True
+
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_false_when_nothing_available(self, mock_a11y_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX)
+        assert loc.is_available() is False
+
+
+class TestVisionInitFailure:
+    @patch("computer_use.grounding.hybrid.VisionLocator", side_effect=Exception("no key"))
+    @patch("computer_use.grounding.hybrid.AccessibilityLocator")
+    def test_handles_vision_init_failure_gracefully(self, mock_a11y_cls, mock_vision_cls):
+        from computer_use.grounding.hybrid import HybridLocator
+
+        mock_a11y = MagicMock()
+        mock_a11y.is_available.return_value = False
+        mock_a11y_cls.return_value = mock_a11y
+
+        loc = HybridLocator(Platform.LINUX, provider_name="anthropic", config={})
+        assert loc._vision is None
+        assert loc.is_available() is False

--- a/computer_use/tests/test_linux.py
+++ b/computer_use/tests/test_linux.py
@@ -9,6 +9,11 @@ import pytest
 from computer_use.core.errors import ActionError, ScreenCaptureError
 from computer_use.core.types import Region, ScreenState
 
+from computer_use.platform.linux import dbus_import, evdev_import, ecodes
+
+_has_dbus = dbus_import is not None
+_has_evdev = evdev_import is not None
+
 
 # -- Display session detection --
 
@@ -49,8 +54,10 @@ class TestCreateScreenCapture:
     def test_x11_returns_mss_capture(self, _mock):
         from computer_use.platform.linux import _create_screen_capture, MssScreenCapture
 
-        capture = _create_screen_capture()
-        assert isinstance(capture, MssScreenCapture)
+        mock_mss = MagicMock(spec=MssScreenCapture)
+        with patch("computer_use.platform.linux.MssScreenCapture", return_value=mock_mss):
+            capture = _create_screen_capture()
+        assert capture is mock_mss
 
     @patch("computer_use.platform.linux._is_wayland", return_value=True)
     @patch("shutil.which", side_effect=lambda cmd: "/usr/bin/grim" if cmd == "grim" else None)
@@ -191,8 +198,15 @@ class TestMssScreenCapture:
 
 
 class TestLinuxBackend:
+    @patch("computer_use.platform.linux._is_wayland", return_value=False)
     @patch("shutil.which", return_value="/usr/bin/xdotool")
-    def test_is_available_with_xdotool(self, _mock):
+    def test_is_available_with_xdotool_on_x11(self, _which, _wayland):
+        from computer_use.platform.linux import LinuxBackend
+        assert LinuxBackend().is_available() is True
+
+    @patch("computer_use.platform.linux._is_wayland", return_value=True)
+    @patch("computer_use.platform.linux._is_mutter_available", return_value=True)
+    def test_is_available_with_mutter_on_wayland(self, _mutter, _wayland):
         from computer_use.platform.linux import LinuxBackend
         assert LinuxBackend().is_available() is True
 
@@ -349,11 +363,13 @@ class TestBuildXkbCharMap:
             linux._xkb = original
 
 
+@pytest.mark.skipif(not _has_dbus, reason="dbus-python not installed")
 class TestMutterRemoteDesktopExecutor:
     def _make_executor(self):
         from computer_use.platform.linux import MutterRemoteDesktopExecutor
 
         with patch("computer_use.platform.linux._build_xkb_char_map", return_value=None), \
+             patch("computer_use.platform.linux.dbus_import") as mock_dbus, \
              patch("computer_use.platform.linux.MutterRemoteDesktopExecutor._setup_session"):
             ex = MutterRemoteDesktopExecutor()
             # Wire up a mock session manually
@@ -524,6 +540,7 @@ def _mock_evdev():
     return mouse, kbd
 
 
+@pytest.mark.skipif(not _has_evdev, reason="evdev not installed")
 class TestEvdevActionExecutor:
     def _make_executor(self):
         from computer_use.platform.linux import EvdevActionExecutor
@@ -672,14 +689,17 @@ class TestCreateActionExecutor:
         ex = _create_action_executor()
         assert isinstance(ex, LinuxActionExecutor)
 
+    @pytest.mark.skipif(not _has_dbus, reason="dbus-python not installed")
     @patch("computer_use.platform.linux._is_wayland", return_value=True)
     @patch("computer_use.platform.linux._is_mutter_available", return_value=True)
-    def test_wayland_gnome_returns_mutter(self, _mutter, _wayland):
+    @patch("computer_use.platform.linux.dbus_import")
+    def test_wayland_gnome_returns_mutter(self, _dbus, _mutter, _wayland):
         from computer_use.platform.linux import _create_action_executor, MutterRemoteDesktopExecutor
         with patch("computer_use.platform.linux.MutterRemoteDesktopExecutor._setup_session"):
             ex = _create_action_executor()
             assert isinstance(ex, MutterRemoteDesktopExecutor)
 
+    @pytest.mark.skipif(not _has_evdev, reason="evdev not installed")
     @patch("computer_use.platform.linux._is_wayland", return_value=True)
     @patch("computer_use.platform.linux._is_mutter_available", return_value=False)
     @patch("computer_use.platform.linux._find_evdev_mouse")

--- a/computer_use/tests/test_openai_provider.py
+++ b/computer_use/tests/test_openai_provider.py
@@ -1,0 +1,568 @@
+"""Tests for the OpenAI GPT-4o vision provider."""
+
+import base64
+import io
+import json
+import urllib.error
+import unittest
+from unittest.mock import MagicMock, patch
+
+from computer_use.core.errors import ProviderError
+from computer_use.core.types import (
+    ActionType,
+    Element,
+    Region,
+    ScreenState,
+)
+from computer_use.providers.openai import OpenAIProvider, API_URL
+
+
+def make_screen(width=1920, height=1080, image_bytes=b"\x89PNG\r\n"):
+    return ScreenState(image_bytes=image_bytes, width=width, height=height)
+
+
+def openai_response(content: str) -> dict:
+    return {
+        "choices": [
+            {"message": {"content": content}}
+        ]
+    }
+
+
+def mock_urlopen(response_dict):
+    body = json.dumps(response_dict).encode("utf-8")
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestCallApi(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test-key", model="gpt-4o")
+
+    @patch("urllib.request.urlopen")
+    def test_sends_bearer_auth_header(self, mock_open):
+        mock_open.return_value = mock_urlopen({"choices": []})
+        self.provider._call_api({"model": "gpt-4o"})
+
+        request_obj = mock_open.call_args[0][0]
+        self.assertEqual(request_obj.get_header("Authorization"), "Bearer sk-test-key")
+        self.assertEqual(request_obj.get_header("Content-type"), "application/json")
+
+    @patch("urllib.request.urlopen")
+    def test_sends_json_payload(self, mock_open):
+        mock_open.return_value = mock_urlopen({"choices": []})
+        payload = {"model": "gpt-4o", "max_tokens": 512, "messages": []}
+        self.provider._call_api(payload)
+
+        request_obj = mock_open.call_args[0][0]
+        sent_data = json.loads(request_obj.data.decode("utf-8"))
+        self.assertEqual(sent_data, payload)
+
+    @patch("urllib.request.urlopen")
+    def test_posts_to_openai_url(self, mock_open):
+        mock_open.return_value = mock_urlopen({"choices": []})
+        self.provider._call_api({"model": "gpt-4o"})
+
+        request_obj = mock_open.call_args[0][0]
+        self.assertEqual(request_obj.full_url, API_URL)
+
+    @patch("urllib.request.urlopen")
+    def test_returns_parsed_json(self, mock_open):
+        expected = {"choices": [{"message": {"content": "hello"}}]}
+        mock_open.return_value = mock_urlopen(expected)
+        result = self.provider._call_api({"model": "gpt-4o"})
+        self.assertEqual(result, expected)
+
+    @patch("urllib.request.urlopen")
+    def test_http_error_raises_provider_error(self, mock_open):
+        err = urllib.error.HTTPError(
+            url=API_URL, code=429, msg="Too Many Requests",
+            hdrs=None, fp=io.BytesIO(b"rate limited"),
+        )
+        mock_open.side_effect = err
+
+        with self.assertRaises(ProviderError) as ctx:
+            self.provider._call_api({"model": "gpt-4o"})
+        self.assertIn("429", str(ctx.exception))
+        self.assertIn("rate limited", str(ctx.exception))
+
+    @patch("urllib.request.urlopen")
+    def test_url_error_raises_provider_error(self, mock_open):
+        mock_open.side_effect = urllib.error.URLError("DNS failure")
+
+        with self.assertRaises(ProviderError) as ctx:
+            self.provider._call_api({"model": "gpt-4o"})
+        self.assertIn("connection error", str(ctx.exception))
+
+
+class TestExtractText(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    def test_extracts_from_choices_message_content(self):
+        resp = openai_response('{"action": "click"}')
+        self.assertEqual(self.provider._extract_text(resp), '{"action": "click"}')
+
+    def test_returns_empty_on_no_choices(self):
+        self.assertEqual(self.provider._extract_text({"choices": []}), "")
+        self.assertEqual(self.provider._extract_text({}), "")
+
+    def test_strips_whitespace(self):
+        resp = openai_response("  some text  \n")
+        self.assertEqual(self.provider._extract_text(resp), "some text")
+
+    def test_strips_code_fences(self):
+        fenced = "```json\n{\"x\": 1}\n```"
+        resp = openai_response(fenced)
+        self.assertEqual(self.provider._extract_text(resp), '{"x": 1}')
+
+    def test_strips_code_fences_without_language(self):
+        fenced = "```\n{\"x\": 1}\n```"
+        resp = openai_response(fenced)
+        self.assertEqual(self.provider._extract_text(resp), '{"x": 1}')
+
+    def test_no_stripping_when_no_fences(self):
+        resp = openai_response('{"plain": true}')
+        self.assertEqual(self.provider._extract_text(resp), '{"plain": true}')
+
+
+class TestParseAction(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    def test_click(self):
+        action = self.provider._parse_action({"action": "click", "x": 100, "y": 200})
+        self.assertEqual(action.action_type, ActionType.CLICK)
+        self.assertEqual(action.x, 100)
+        self.assertEqual(action.y, 200)
+
+    def test_type_text(self):
+        action = self.provider._parse_action({"action": "type_text", "text": "hello"})
+        self.assertEqual(action.action_type, ActionType.TYPE_TEXT)
+        self.assertEqual(action.text, "hello")
+
+    def test_key_press(self):
+        action = self.provider._parse_action({"action": "key_press", "keys": ["ctrl", "s"]})
+        self.assertEqual(action.action_type, ActionType.KEY_PRESS)
+        self.assertEqual(action.keys, ["ctrl", "s"])
+
+    def test_scroll(self):
+        action = self.provider._parse_action({"action": "scroll", "x": 50, "y": 50, "amount": -3})
+        self.assertEqual(action.action_type, ActionType.SCROLL)
+        self.assertEqual(action.scroll_amount, -3)
+
+    def test_drag(self):
+        data = {"action": "drag", "x": 10, "y": 20, "target_x": 100, "target_y": 200}
+        action = self.provider._parse_action(data)
+        self.assertEqual(action.action_type, ActionType.DRAG)
+        self.assertEqual(action.target_x, 100)
+        self.assertEqual(action.target_y, 200)
+
+    def test_wait_with_duration(self):
+        action = self.provider._parse_action({"action": "wait", "duration": 2.5})
+        self.assertEqual(action.action_type, ActionType.WAIT)
+        self.assertAlmostEqual(action.duration, 2.5)
+
+    def test_all_action_types_mapped(self):
+        for name in ["click", "double_click", "right_click", "type_text",
+                      "key_press", "scroll", "move", "drag", "wait"]:
+            action = self.provider._parse_action({"action": name})
+            self.assertIsNotNone(action.action_type)
+
+    def test_unknown_action_raises(self):
+        with self.assertRaises(ProviderError) as ctx:
+            self.provider._parse_action({"action": "fly"})
+        self.assertIn("fly", str(ctx.exception))
+
+
+class TestParseDecision(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    def test_done_action_marks_complete(self):
+        resp = openai_response(json.dumps({
+            "reasoning": "all done",
+            "action": {"action": "done"},
+            "confidence": 0.95,
+        }))
+        decision = self.provider._parse_decision(resp)
+        self.assertTrue(decision.is_task_complete)
+        self.assertEqual(decision.action.action_type, ActionType.WAIT)
+        self.assertEqual(decision.reasoning, "all done")
+        self.assertAlmostEqual(decision.confidence, 0.95)
+
+    def test_click_action_parsed(self):
+        resp = openai_response(json.dumps({
+            "reasoning": "clicking button",
+            "action": {"action": "click", "x": 500, "y": 300},
+            "confidence": 0.8,
+            "error": None,
+        }))
+        decision = self.provider._parse_decision(resp)
+        self.assertFalse(decision.is_task_complete)
+        self.assertEqual(decision.action.action_type, ActionType.CLICK)
+        self.assertEqual(decision.action.x, 500)
+        self.assertEqual(decision.reasoning, "clicking button")
+
+    def test_error_field_propagated(self):
+        resp = openai_response(json.dumps({
+            "reasoning": "something wrong",
+            "action": {"action": "click", "x": 1, "y": 1},
+            "confidence": 0.3,
+            "error": "button not visible",
+        }))
+        decision = self.provider._parse_decision(resp)
+        self.assertEqual(decision.error_detected, "button not visible")
+
+    def test_default_confidence_for_non_done(self):
+        resp = openai_response(json.dumps({
+            "reasoning": "go",
+            "action": {"action": "click", "x": 1, "y": 1},
+        }))
+        decision = self.provider._parse_decision(resp)
+        self.assertAlmostEqual(decision.confidence, 0.5)
+
+    def test_invalid_json_raises_provider_error(self):
+        resp = openai_response("not json at all")
+        with self.assertRaises(ProviderError) as ctx:
+            self.provider._parse_decision(resp)
+        self.assertIn("Cannot parse", str(ctx.exception))
+
+
+class TestParseElement(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    def test_parses_found_element(self):
+        resp = openai_response(json.dumps({
+            "x": 100, "y": 200, "width": 80, "height": 30,
+            "name": "Submit", "role": "button", "confidence": 0.9,
+        }))
+        elem = self.provider._parse_element(resp)
+        self.assertIsNotNone(elem)
+        self.assertEqual(elem.name, "Submit")
+        self.assertEqual(elem.role, "button")
+        self.assertEqual(elem.region.x, 100)
+        self.assertEqual(elem.region.y, 200)
+        self.assertEqual(elem.region.width, 80)
+        self.assertEqual(elem.region.height, 30)
+        self.assertAlmostEqual(elem.confidence, 0.9)
+        self.assertEqual(elem.source, "vision")
+
+    def test_not_found_returns_none(self):
+        resp = openai_response(json.dumps({"not_found": True}))
+        self.assertIsNone(self.provider._parse_element(resp))
+
+    def test_invalid_json_returns_none(self):
+        resp = openai_response("this is garbage")
+        self.assertIsNone(self.provider._parse_element(resp))
+
+    def test_missing_x_y_returns_none(self):
+        resp = openai_response(json.dumps({"name": "btn", "role": "button"}))
+        self.assertIsNone(self.provider._parse_element(resp))
+
+    def test_default_width_height(self):
+        resp = openai_response(json.dumps({"x": 10, "y": 20, "name": "a", "role": "b"}))
+        elem = self.provider._parse_element(resp)
+        self.assertEqual(elem.region.width, 50)
+        self.assertEqual(elem.region.height, 30)
+
+    def test_default_confidence(self):
+        resp = openai_response(json.dumps({"x": 10, "y": 20}))
+        elem = self.provider._parse_element(resp)
+        self.assertAlmostEqual(elem.confidence, 0.5)
+
+
+class TestDecideAction(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test-key", model="gpt-4o")
+
+    @patch("urllib.request.urlopen")
+    def test_payload_uses_image_url_format(self, mock_open):
+        screen = make_screen(image_bytes=b"fakepng")
+        api_resp = openai_response(json.dumps({
+            "reasoning": "click", "action": {"action": "click", "x": 1, "y": 1},
+            "confidence": 0.9,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "test task", [])
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+
+        messages = payload["messages"]
+        self.assertEqual(messages[0]["role"], "system")
+        user_msg = messages[1]
+        self.assertEqual(user_msg["role"], "user")
+        image_block = user_msg["content"][0]
+        self.assertEqual(image_block["type"], "image_url")
+        self.assertIn("data:image/png;base64,", image_block["image_url"]["url"])
+        self.assertEqual(image_block["image_url"]["detail"], "high")
+
+    @patch("urllib.request.urlopen")
+    def test_image_is_base64_encoded(self, mock_open):
+        raw = b"\x89PNG_CONTENT"
+        screen = make_screen(image_bytes=raw)
+        api_resp = openai_response(json.dumps({
+            "reasoning": "r", "action": {"action": "wait", "duration": 0},
+            "confidence": 0.9,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "task", [])
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        url = payload["messages"][1]["content"][0]["image_url"]["url"]
+        encoded = base64.b64encode(raw).decode("utf-8")
+        self.assertTrue(url.endswith(encoded))
+
+    @patch("urllib.request.urlopen")
+    def test_includes_screen_dimensions(self, mock_open):
+        screen = make_screen(width=2560, height=1440)
+        api_resp = openai_response(json.dumps({
+            "reasoning": "r", "action": {"action": "done"}, "confidence": 1.0,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "task", [])
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        text_block = payload["messages"][1]["content"][1]
+        self.assertIn("2560x1440", text_block["text"])
+
+    @patch("urllib.request.urlopen")
+    def test_includes_elements_when_provided(self, mock_open):
+        screen = make_screen()
+        elem = Element(
+            name="OK", role="button",
+            region=Region(x=10, y=20, width=60, height=25),
+            confidence=0.9, source="accessibility",
+        )
+        api_resp = openai_response(json.dumps({
+            "reasoning": "r", "action": {"action": "click", "x": 10, "y": 20},
+            "confidence": 0.9,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "click ok", [], elements=[elem])
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        content_blocks = payload["messages"][1]["content"]
+        element_text = content_blocks[2]["text"]
+        self.assertIn("OK (button)", element_text)
+        self.assertIn("(10,20)", element_text)
+
+    @patch("urllib.request.urlopen")
+    def test_includes_history_when_provided(self, mock_open):
+        screen = make_screen()
+        history = [
+            {"step": 1, "action": "click at 100,200", "success": True},
+            {"step": 2, "action": "type hello", "success": False},
+        ]
+        api_resp = openai_response(json.dumps({
+            "reasoning": "r", "action": {"action": "wait", "duration": 1},
+            "confidence": 0.5,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "task", history)
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        content_blocks = payload["messages"][1]["content"]
+        history_text = content_blocks[2]["text"]
+        self.assertIn("Step 1", history_text)
+        self.assertIn("OK", history_text)
+        self.assertIn("FAILED", history_text)
+
+    @patch("urllib.request.urlopen")
+    def test_limits_elements_to_20(self, mock_open):
+        screen = make_screen()
+        elements = [
+            Element(
+                name=f"elem{i}", role="button",
+                region=Region(x=i, y=i, width=10, height=10),
+                confidence=0.5, source="vision",
+            )
+            for i in range(30)
+        ]
+        api_resp = openai_response(json.dumps({
+            "reasoning": "r", "action": {"action": "click", "x": 1, "y": 1},
+            "confidence": 0.5,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "task", [], elements=elements)
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        content_blocks = payload["messages"][1]["content"]
+        element_text = content_blocks[2]["text"]
+        self.assertIn("elem19", element_text)
+        self.assertNotIn("elem20", element_text)
+
+    @patch("urllib.request.urlopen")
+    def test_limits_history_to_5(self, mock_open):
+        screen = make_screen()
+        history = [
+            {"step": i, "action": f"action_{i}", "success": True}
+            for i in range(10)
+        ]
+        api_resp = openai_response(json.dumps({
+            "reasoning": "r", "action": {"action": "done"}, "confidence": 1.0,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        self.provider.decide_action(screen, "task", history)
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        content_blocks = payload["messages"][1]["content"]
+        history_text = content_blocks[2]["text"]
+        self.assertNotIn("action_4", history_text)
+        self.assertIn("action_5", history_text)
+        self.assertIn("action_9", history_text)
+
+
+class TestLocateElement(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    @patch("urllib.request.urlopen")
+    def test_returns_element_on_success(self, mock_open):
+        api_resp = openai_response(json.dumps({
+            "x": 300, "y": 400, "width": 100, "height": 40,
+            "name": "Search", "role": "text_field", "confidence": 0.85,
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        screen = make_screen()
+        elem = self.provider.locate_element(screen, "search box")
+        self.assertIsNotNone(elem)
+        self.assertEqual(elem.name, "Search")
+        self.assertEqual(elem.region.x, 300)
+
+    @patch("urllib.request.urlopen")
+    def test_returns_none_when_not_found(self, mock_open):
+        api_resp = openai_response(json.dumps({"not_found": True}))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        screen = make_screen()
+        self.assertIsNone(self.provider.locate_element(screen, "invisible thing"))
+
+    @patch("urllib.request.urlopen")
+    def test_payload_includes_image_url_and_description(self, mock_open):
+        api_resp = openai_response(json.dumps({"not_found": True}))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        screen = make_screen(width=800, height=600, image_bytes=b"img")
+        self.provider.locate_element(screen, "the OK button")
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        user_content = payload["messages"][0]["content"]
+        self.assertEqual(user_content[0]["type"], "image_url")
+        text = user_content[1]["text"]
+        self.assertIn("the OK button", text)
+        self.assertIn("800x600", text)
+
+
+class TestVerifyAction(unittest.TestCase):
+    def setUp(self):
+        self.provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    @patch("urllib.request.urlopen")
+    def test_success_verification(self, mock_open):
+        api_resp = openai_response(json.dumps({
+            "success": True, "explanation": "dialog closed",
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        before = make_screen(image_bytes=b"before")
+        after = make_screen(image_bytes=b"after")
+        success, explanation = self.provider.verify_action(before, after, "dialog should close")
+        self.assertTrue(success)
+        self.assertEqual(explanation, "dialog closed")
+
+    @patch("urllib.request.urlopen")
+    def test_failure_verification(self, mock_open):
+        api_resp = openai_response(json.dumps({
+            "success": False, "explanation": "nothing changed",
+        }))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        before = make_screen()
+        after = make_screen()
+        success, explanation = self.provider.verify_action(before, after, "something")
+        self.assertFalse(success)
+        self.assertEqual(explanation, "nothing changed")
+
+    @patch("urllib.request.urlopen")
+    def test_falls_back_on_parse_error(self, mock_open):
+        api_resp = openai_response("totally broken json {{{")
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        before = make_screen()
+        after = make_screen()
+        success, explanation = self.provider.verify_action(before, after, "x")
+        self.assertTrue(success)
+        self.assertIn("inconclusive", explanation)
+
+    @patch("urllib.request.urlopen")
+    def test_falls_back_on_api_error(self, mock_open):
+        mock_open.side_effect = urllib.error.URLError("timeout")
+
+        before = make_screen()
+        after = make_screen()
+        success, explanation = self.provider.verify_action(before, after, "x")
+        self.assertTrue(success)
+        self.assertIn("inconclusive", explanation)
+
+    @patch("urllib.request.urlopen")
+    def test_payload_has_both_images(self, mock_open):
+        api_resp = openai_response(json.dumps({"success": True, "explanation": "ok"}))
+        mock_open.return_value = mock_urlopen(api_resp)
+
+        before = make_screen(image_bytes=b"BEFORE_IMG")
+        after = make_screen(image_bytes=b"AFTER_IMG")
+        self.provider.verify_action(before, after, "expected change")
+
+        request_obj = mock_open.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        content = payload["messages"][0]["content"]
+
+        image_urls = [
+            block["image_url"]["url"]
+            for block in content
+            if block.get("type") == "image_url"
+        ]
+        self.assertEqual(len(image_urls), 2)
+        before_b64 = base64.b64encode(b"BEFORE_IMG").decode("utf-8")
+        after_b64 = base64.b64encode(b"AFTER_IMG").decode("utf-8")
+        self.assertIn(before_b64, image_urls[0])
+        self.assertIn(after_b64, image_urls[1])
+
+
+class TestConstructor(unittest.TestCase):
+    def test_default_model(self):
+        p = OpenAIProvider(api_key="key")
+        self.assertEqual(p._model, "gpt-4o")
+
+    def test_custom_model(self):
+        p = OpenAIProvider(api_key="key", model="gpt-4-turbo")
+        self.assertEqual(p._model, "gpt-4-turbo")
+
+    def test_stores_api_key(self):
+        p = OpenAIProvider(api_key="sk-abc123")
+        self.assertEqual(p._api_key, "sk-abc123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/computer_use/tests/test_registry.py
+++ b/computer_use/tests/test_registry.py
@@ -1,0 +1,137 @@
+"""Tests for the provider registry."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from computer_use.core.errors import ConfigError
+from computer_use.providers.registry import get_provider, list_providers
+
+
+class TestListProviders:
+    def test_returns_both_registered_providers(self):
+        result = list_providers()
+        assert sorted(result) == ["anthropic", "openai"]
+
+    def test_contains_at_least_two_providers(self):
+        result = list_providers()
+        assert len(result) >= 2
+
+
+class TestGetProvider:
+    def test_unknown_provider_raises_config_error(self):
+        with pytest.raises(ConfigError, match="Unknown provider 'banana'"):
+            get_provider("banana", {})
+
+    def test_api_key_from_config(self):
+        fake_cls = MagicMock()
+        fake_module = MagicMock()
+        fake_module.AnthropicProvider = fake_cls
+
+        config = {
+            "providers": {
+                "anthropic": {"api_key": "sk-from-config"},
+            }
+        }
+
+        with patch("importlib.import_module", return_value=fake_module):
+            provider = get_provider("anthropic", config)
+
+        fake_cls.assert_called_once_with(api_key="sk-from-config")
+        assert provider is fake_cls.return_value
+
+    def test_api_key_from_env_var(self):
+        fake_cls = MagicMock()
+        fake_module = MagicMock()
+        fake_module.AnthropicProvider = fake_cls
+
+        with (
+            patch("importlib.import_module", return_value=fake_module),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-from-env"}),
+        ):
+            provider = get_provider("anthropic", {})
+
+        fake_cls.assert_called_once_with(api_key="sk-from-env")
+        assert provider is fake_cls.return_value
+
+    def test_config_key_takes_precedence_over_env(self):
+        fake_cls = MagicMock()
+        fake_module = MagicMock()
+        fake_module.AnthropicProvider = fake_cls
+
+        config = {
+            "providers": {
+                "anthropic": {"api_key": "sk-from-config"},
+            }
+        }
+
+        with (
+            patch("importlib.import_module", return_value=fake_module),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-from-env"}),
+        ):
+            get_provider("anthropic", config)
+
+        fake_cls.assert_called_once_with(api_key="sk-from-config")
+
+    def test_no_api_key_raises_config_error(self):
+        fake_module = MagicMock()
+        fake_module.AnthropicProvider = MagicMock()
+
+        env = os.environ.copy()
+        env.pop("ANTHROPIC_API_KEY", None)
+
+        with (
+            patch("importlib.import_module", return_value=fake_module),
+            patch.dict(os.environ, env, clear=True),
+        ):
+            with pytest.raises(ConfigError, match="No API key for 'anthropic'"):
+                get_provider("anthropic", {})
+
+    def test_model_from_config_is_passed(self):
+        fake_cls = MagicMock()
+        fake_module = MagicMock()
+        fake_module.OpenAIProvider = fake_cls
+
+        config = {
+            "providers": {
+                "openai": {
+                    "api_key": "sk-test",
+                    "model": "gpt-4o",
+                },
+            }
+        }
+
+        with patch("importlib.import_module", return_value=fake_module):
+            get_provider("openai", config)
+
+        fake_cls.assert_called_once_with(api_key="sk-test", model="gpt-4o")
+
+    def test_model_omitted_when_not_in_config(self):
+        fake_cls = MagicMock()
+        fake_module = MagicMock()
+        fake_module.AnthropicProvider = fake_cls
+
+        config = {
+            "providers": {
+                "anthropic": {"api_key": "sk-test"},
+            }
+        }
+
+        with patch("importlib.import_module", return_value=fake_module):
+            get_provider("anthropic", config)
+
+        fake_cls.assert_called_once_with(api_key="sk-test")
+        assert "model" not in fake_cls.call_args.kwargs
+
+    def test_dynamic_import_uses_correct_module_path(self):
+        fake_cls = MagicMock()
+        fake_module = MagicMock()
+        fake_module.OpenAIProvider = fake_cls
+
+        config = {"providers": {"openai": {"api_key": "sk-test"}}}
+
+        with patch("importlib.import_module", return_value=fake_module) as mock_import:
+            get_provider("openai", config)
+
+        mock_import.assert_called_once_with("computer_use.providers.openai")

--- a/computer_use/tests/test_vision_locator.py
+++ b/computer_use/tests/test_vision_locator.py
@@ -1,0 +1,105 @@
+"""Tests for the vision-based element locator."""
+
+from unittest.mock import MagicMock, patch
+
+from computer_use.core.types import Element, Region, ScreenState
+
+
+def _make_screen():
+    return ScreenState(image_bytes=b"fake", width=1920, height=1080)
+
+
+def _make_element(name="OK Button"):
+    return Element(
+        name=name,
+        role="button",
+        region=Region(x=100, y=200, width=80, height=30),
+        confidence=0.9,
+        source="vision",
+    )
+
+
+class TestVisionLocatorInit:
+    @patch("computer_use.providers.registry.get_provider")
+    def test_creates_provider_from_registry(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        mock_get.return_value = MagicMock()
+        loc = VisionLocator("anthropic", {"providers": {"anthropic": {"api_key": "k"}}})
+        mock_get.assert_called_once_with(
+            "anthropic", {"providers": {"anthropic": {"api_key": "k"}}}
+        )
+
+
+class TestFindElement:
+    @patch("computer_use.providers.registry.get_provider")
+    def test_delegates_to_provider_locate_element(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        provider = MagicMock()
+        expected = _make_element()
+        provider.locate_element.return_value = expected
+        mock_get.return_value = provider
+
+        loc = VisionLocator("anthropic", {})
+        screen = _make_screen()
+        result = loc.find_element("OK button", screen)
+
+        assert result is expected
+        provider.locate_element.assert_called_once_with(screen, "OK button")
+
+    @patch("computer_use.providers.registry.get_provider")
+    def test_returns_none_without_screen(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        mock_get.return_value = MagicMock()
+        loc = VisionLocator("anthropic", {})
+        assert loc.find_element("something", screen=None) is None
+
+
+class TestFindAllElements:
+    @patch("computer_use.providers.registry.get_provider")
+    def test_returns_empty_list(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        mock_get.return_value = MagicMock()
+        loc = VisionLocator("anthropic", {})
+        assert loc.find_all_elements(_make_screen()) == []
+
+
+class TestFindElementAt:
+    @patch("computer_use.providers.registry.get_provider")
+    def test_delegates_with_coordinate_description(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        provider = MagicMock()
+        expected = _make_element()
+        provider.locate_element.return_value = expected
+        mock_get.return_value = provider
+
+        loc = VisionLocator("anthropic", {})
+        screen = _make_screen()
+        result = loc.find_element_at(150, 250, screen)
+
+        assert result is expected
+        provider.locate_element.assert_called_once_with(
+            screen, "element at coordinates (150, 250)"
+        )
+
+    @patch("computer_use.providers.registry.get_provider")
+    def test_returns_none_without_screen(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        mock_get.return_value = MagicMock()
+        loc = VisionLocator("anthropic", {})
+        assert loc.find_element_at(100, 200, screen=None) is None
+
+
+class TestIsAvailable:
+    @patch("computer_use.providers.registry.get_provider")
+    def test_always_returns_true(self, mock_get):
+        from computer_use.grounding.vision import VisionLocator
+
+        mock_get.return_value = MagicMock()
+        loc = VisionLocator("anthropic", {})
+        assert loc.is_available() is True

--- a/computer_use/tests/test_wsl2.py
+++ b/computer_use/tests/test_wsl2.py
@@ -1,0 +1,608 @@
+"""Tests for the WSL2 platform backend."""
+
+import subprocess
+from unittest.mock import MagicMock, patch, mock_open, PropertyMock, call
+
+import pytest
+
+from computer_use.core.errors import ActionError, ScreenCaptureError
+from computer_use.core.types import Region, ScreenState
+from computer_use.platform.wsl2 import (
+    wsl_to_win_path,
+    win_to_wsl_path,
+    PersistentPowerShell,
+    WSL2ScreenCapture,
+    WSL2ActionExecutor,
+    WSL2Backend,
+    _get_windows_temp_dir,
+    _run_ps,
+    _run_ps_subprocess,
+    POWERSHELL,
+    VK_CODES,
+    SENDKEYS_MAP,
+    MODIFIER_MAP,
+)
+
+
+# --- Path conversion ---
+
+
+class TestWslToWinPath:
+    def test_mnt_drive_path(self):
+        assert wsl_to_win_path("/mnt/c/Users/test") == "C:\\Users\\test"
+
+    def test_mnt_drive_with_subdirs(self):
+        assert wsl_to_win_path("/mnt/d/some/deep/path") == "D:\\some\\deep\\path"
+
+    def test_non_mnt_path_unchanged(self):
+        assert wsl_to_win_path("/home/user/file.txt") == "/home/user/file.txt"
+
+    def test_mnt_root(self):
+        assert wsl_to_win_path("/mnt/c") == "C:"
+
+    def test_drive_letter_uppercased(self):
+        assert wsl_to_win_path("/mnt/e/data") == "E:\\data"
+
+
+class TestWinToWslPath:
+    def test_windows_drive_path(self):
+        assert win_to_wsl_path("C:\\Users\\test") == "/mnt/c/Users/test"
+
+    def test_drive_letter_lowered(self):
+        assert win_to_wsl_path("D:\\Files") == "/mnt/d/Files"
+
+    def test_no_colon_unchanged(self):
+        assert win_to_wsl_path("/some/unix/path") == "/some/unix/path"
+
+    def test_short_string_no_colon(self):
+        assert win_to_wsl_path("X") == "X"
+
+    def test_empty_string(self):
+        assert win_to_wsl_path("") == ""
+
+
+# --- PersistentPowerShell ---
+
+
+class TestPersistentPowerShell:
+    def _make_mock_proc(self, poll_return=None):
+        proc = MagicMock()
+        proc.poll.return_value = poll_return
+        proc.pid = 12345
+        proc.stdin = MagicMock()
+        proc.stdout = MagicMock()
+        proc.stderr = MagicMock()
+        return proc
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    def test_run_reads_until_sentinel(self, mock_popen):
+        proc = self._make_mock_proc()
+        mock_popen.return_value = proc
+
+        ps = PersistentPowerShell()
+
+        # Simulate stdout lines: output then sentinel
+        sentinel_holder = {}
+
+        def fake_write(text):
+            # Capture the sentinel from the written script
+            for line in text.strip().split("\n"):
+                if line.startswith("Write-Output '"):
+                    sentinel_holder["val"] = line.split("'")[1]
+
+        proc.stdin.write.side_effect = fake_write
+
+        def readline_gen():
+            yield "output line 1\n"
+            yield "output line 2\n"
+            yield sentinel_holder["val"] + "\n"
+
+        gen = readline_gen()
+        proc.stdout.readline.side_effect = lambda: next(gen)
+
+        result = ps.run("Get-Date")
+        assert result == "output line 1\noutput line 2"
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    def test_shutdown_terminates_process(self, mock_popen):
+        proc = self._make_mock_proc()
+        mock_popen.return_value = proc
+
+        ps = PersistentPowerShell()
+        # Force start
+        ps._start()
+        assert ps._started is True
+
+        ps.shutdown()
+        proc.stdin.close.assert_called_once()
+        proc.terminate.assert_called_once()
+        assert ps._proc is None
+        assert ps._started is False
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    def test_restart_on_broken_pipe(self, mock_popen):
+        first_proc = self._make_mock_proc()
+        second_proc = self._make_mock_proc()
+        mock_popen.side_effect = [first_proc, second_proc]
+
+        ps = PersistentPowerShell()
+
+        # First write raises BrokenPipeError, second (after restart) succeeds
+        first_proc.stdin.write.side_effect = BrokenPipeError("pipe broken")
+
+        sentinel_holder = {}
+
+        def capture_write(text):
+            for line in text.strip().split("\n"):
+                if line.startswith("Write-Output '"):
+                    sentinel_holder["val"] = line.split("'")[1]
+
+        second_proc.stdin.write.side_effect = capture_write
+
+        def readline_gen():
+            yield sentinel_holder["val"] + "\n"
+
+        gen = readline_gen()
+        second_proc.stdout.readline.side_effect = lambda: next(gen)
+
+        result = ps.run("test")
+        assert result == ""
+        # First proc should have been killed during restart
+        first_proc.kill.assert_called()
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    @patch("computer_use.platform.wsl2.time.monotonic")
+    def test_timeout_raises_runtime_error(self, mock_monotonic, mock_popen):
+        proc = self._make_mock_proc()
+        mock_popen.return_value = proc
+
+        ps = PersistentPowerShell()
+
+        proc.stdin.write.side_effect = lambda text: None
+
+        # monotonic: first call for deadline, then past deadline on loop check
+        mock_monotonic.side_effect = [0.0, 100.0]
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            ps.run("slow-script", timeout=5.0)
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    def test_process_death_raises(self, mock_popen):
+        proc = self._make_mock_proc(poll_return=None)
+        mock_popen.return_value = proc
+
+        ps = PersistentPowerShell()
+
+        proc.stdin.write.side_effect = lambda text: None
+
+        # Process dies mid-read
+        call_count = [0]
+
+        def poll_side_effect():
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return None  # alive during startup checks
+            return 1  # dead during readline loop
+
+        proc.poll.side_effect = poll_side_effect
+
+        with pytest.raises(RuntimeError, match="died unexpectedly"):
+            ps.run("doomed-script")
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    def test_is_alive_true_when_running(self, mock_popen):
+        proc = self._make_mock_proc(poll_return=None)
+        mock_popen.return_value = proc
+
+        ps = PersistentPowerShell()
+        ps._start()
+        assert ps.is_alive is True
+
+    @patch("computer_use.platform.wsl2.subprocess.Popen")
+    def test_is_alive_false_when_dead(self, mock_popen):
+        proc = self._make_mock_proc(poll_return=1)
+        mock_popen.return_value = proc
+
+        ps = PersistentPowerShell()
+        ps._start()
+        assert ps.is_alive is False
+
+    def test_is_alive_false_when_not_started(self):
+        ps = PersistentPowerShell()
+        assert ps.is_alive is False
+
+
+# --- WSL2ScreenCapture ---
+
+
+class TestWSL2ScreenCapture:
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", return_value="1920,1080,0,0")
+    @patch("builtins.open", mock_open(read_data=b"fake-png-data"))
+    @patch("os.unlink")
+    def test_capture_full_parses_dimensions(self, _unlink, mock_ps, _temp):
+        cap = WSL2ScreenCapture()
+        # Also mock get_scale_factor to avoid calling _run_ps again
+        with patch.object(cap, "get_scale_factor", return_value=1.0):
+            state = cap.capture_full()
+
+        assert state.width == 1920
+        assert state.height == 1080
+        assert state.offset_x == 0
+        assert state.offset_y == 0
+        assert state.image_bytes == b"fake-png-data"
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", return_value="3840,2160,100,200")
+    @patch("builtins.open", mock_open(read_data=b"img"))
+    @patch("os.unlink")
+    def test_capture_full_with_offset(self, _unlink, mock_ps, _temp):
+        cap = WSL2ScreenCapture()
+        with patch.object(cap, "get_scale_factor", return_value=1.5):
+            state = cap.capture_full()
+
+        assert state.width == 3840
+        assert state.height == 2160
+        assert state.offset_x == 100
+        assert state.offset_y == 200
+        assert state.scale_factor == 1.5
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("ps fail"))
+    def test_capture_full_raises_on_ps_error(self, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        with pytest.raises(ScreenCaptureError, match="Full screenshot failed"):
+            cap.capture_full()
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", return_value="200,100")
+    @patch("builtins.open", mock_open(read_data=b"region-data"))
+    @patch("os.unlink")
+    def test_capture_region(self, _unlink, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        region = Region(x=10, y=20, width=200, height=100)
+        with patch.object(cap, "get_scale_factor", return_value=1.0):
+            state = cap.capture_region(region)
+
+        assert state.width == 200
+        assert state.height == 100
+        assert state.image_bytes == b"region-data"
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_capture_region_raises_on_error(self, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        region = Region(x=0, y=0, width=100, height=100)
+        with pytest.raises(ScreenCaptureError, match="Region screenshot failed"):
+            cap.capture_region(region)
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", return_value="2560,1440")
+    def test_get_screen_size(self, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        w, h = cap.get_screen_size()
+        assert w == 2560
+        assert h == 1440
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_get_screen_size_raises_on_error(self, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        with pytest.raises(ScreenCaptureError, match="Cannot get screen size"):
+            cap.get_screen_size()
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", return_value="1.25")
+    def test_get_scale_factor(self, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        assert cap.get_scale_factor() == 1.25
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("no dpi"))
+    def test_get_scale_factor_defaults_on_error(self, _ps, _temp):
+        cap = WSL2ScreenCapture()
+        assert cap.get_scale_factor() == 1.0
+
+
+# --- WSL2ActionExecutor ---
+
+
+class TestWSL2ActionExecutor:
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_click_left(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.click(100, 200, button="left")
+        script = mock_ps.call_args[0][0]
+        assert "MOUSEEVENTF_LEFTDOWN" in script
+        assert "MOUSEEVENTF_LEFTUP" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_click_right(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.click(100, 200, button="right")
+        script = mock_ps.call_args[0][0]
+        assert "MOUSEEVENTF_RIGHTDOWN" in script
+        assert "MOUSEEVENTF_RIGHTUP" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_click_middle(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.click(100, 200, button="middle")
+        script = mock_ps.call_args[0][0]
+        assert "MOUSEEVENTF_MIDDLEDOWN" in script
+        assert "MOUSEEVENTF_MIDDLEUP" in script
+
+    def test_click_unknown_button_raises(self):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Unknown mouse button"):
+            exe.click(100, 200, button="extra")
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_click_wraps_error(self, _ps):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Click failed"):
+            exe.click(50, 50)
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_double_click(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.double_click(300, 400)
+        script = mock_ps.call_args[0][0]
+        # Count actual mouse_event calls (not the const declarations in the class)
+        assert script.count("[MouseInput]::mouse_event([MouseInput]::MOUSEEVENTF_LEFTDOWN") == 2
+        assert script.count("[MouseInput]::mouse_event([MouseInput]::MOUSEEVENTF_LEFTUP") == 2
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("err"))
+    def test_double_click_wraps_error(self, _ps):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Double-click failed"):
+            exe.double_click(10, 20)
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_type_text_escapes_special_chars(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.type_text("hello+world{test}")
+        script = mock_ps.call_args[0][0]
+        # + should become {+}, { should become {{}, } should become {}}
+        assert "{+}" in script
+        assert "{{}" in script  # escaped {
+        assert "{}}" in script  # escaped }
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_type_text_plain(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.type_text("abc123")
+        script = mock_ps.call_args[0][0]
+        assert "abc123" in script
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_type_text_wraps_error(self, _ps):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Type text failed"):
+            exe.type_text("oops")
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_key_press_sendkeys_route(self, mock_ps):
+        """ctrl+c should go through SendKeys path."""
+        exe = WSL2ActionExecutor()
+        exe.key_press(["ctrl", "c"])
+        script = mock_ps.call_args[0][0]
+        assert "SendKeys" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_key_press_keybd_route_for_win(self, mock_ps):
+        """Win key combos should use keybd_event."""
+        exe = WSL2ActionExecutor()
+        exe.key_press(["win", "d"])
+        script = mock_ps.call_args[0][0]
+        assert "keybd_event" in script
+        assert str(VK_CODES["win"]) in script
+        assert str(VK_CODES["d"]) in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_key_press_empty_list_noop(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.key_press([])
+        mock_ps.assert_not_called()
+
+    def test_key_press_keybd_unknown_key_raises(self):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Unknown key for keybd_event"):
+            exe._key_press_via_keybd(["win", "nonexistent_key"])
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_key_press_sendkeys_modifier_only(self, mock_ps):
+        """Pressing just a modifier should produce an empty key string."""
+        exe = WSL2ActionExecutor()
+        exe.key_press(["alt"])
+        script = mock_ps.call_args[0][0]
+        assert "SendKeys" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_key_press_sendkeys_multiple_regular(self, mock_ps):
+        """Multiple regular keys should be wrapped in parens."""
+        exe = WSL2ActionExecutor()
+        exe.key_press(["ctrl", "a", "b"])
+        script = mock_ps.call_args[0][0]
+        # a and b are regular keys, should be grouped: ^(ab)
+        assert "(ab)" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_scroll(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.scroll(500, 600, 3)
+        script = mock_ps.call_args[0][0]
+        # 3 * 120 = 360
+        assert "360" in script
+        assert "MOUSEEVENTF_WHEEL" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_scroll_negative(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.scroll(500, 600, -2)
+        script = mock_ps.call_args[0][0]
+        assert "-240" in script
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_scroll_wraps_error(self, _ps):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Scroll failed"):
+            exe.scroll(0, 0, 1)
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_drag(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.drag(10, 20, 300, 400, duration=0.5)
+        script = mock_ps.call_args[0][0]
+        assert "MOUSEEVENTF_LEFTDOWN" in script
+        assert "MOUSEEVENTF_LEFTUP" in script
+        assert "10" in script
+        assert "20" in script
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_drag_timeout_includes_duration(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.drag(0, 0, 100, 100, duration=2.0)
+        # timeout should be duration + 10
+        assert mock_ps.call_args[1]["timeout"] == 12.0
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_drag_wraps_error(self, _ps):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Drag failed"):
+            exe.drag(0, 0, 10, 10)
+
+    @patch("computer_use.platform.wsl2._run_ps")
+    def test_move_mouse(self, mock_ps):
+        exe = WSL2ActionExecutor()
+        exe.move_mouse(150, 250)
+        script = mock_ps.call_args[0][0]
+        assert "150" in script
+        assert "250" in script
+
+    @patch("computer_use.platform.wsl2._run_ps", side_effect=RuntimeError("fail"))
+    def test_move_mouse_wraps_error(self, _ps):
+        exe = WSL2ActionExecutor()
+        with pytest.raises(ActionError, match="Mouse move failed"):
+            exe.move_mouse(0, 0)
+
+
+# --- WSL2Backend ---
+
+
+class TestWSL2Backend:
+    @patch("shutil.which", return_value="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
+    def test_is_available_true(self, _which):
+        backend = WSL2Backend()
+        assert backend.is_available() is True
+        _which.assert_called_with("powershell.exe")
+
+    @patch("shutil.which", return_value=None)
+    def test_is_available_false(self, _which):
+        backend = WSL2Backend()
+        assert backend.is_available() is False
+
+    @patch.object(WSL2Backend, "_probe_bridge", return_value=False)
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    def test_get_screen_capture_cached(self, _temp, _bridge):
+        """Calling get_screen_capture twice returns the same instance."""
+        backend = WSL2Backend()
+        cap1 = backend.get_screen_capture()
+        cap2 = backend.get_screen_capture()
+        assert cap1 is cap2
+
+    @patch.object(WSL2Backend, "_probe_bridge", return_value=False)
+    def test_get_action_executor_cached(self, _bridge):
+        """Calling get_action_executor twice returns the same instance."""
+        backend = WSL2Backend()
+        exe1 = backend.get_action_executor()
+        exe2 = backend.get_action_executor()
+        assert exe1 is exe2
+
+
+# --- _get_windows_temp_dir ---
+
+
+class TestGetWindowsTempDir:
+    @patch("os.path.isdir")
+    def test_first_candidate_found(self, mock_isdir):
+        mock_isdir.return_value = True
+        with patch.dict("os.environ", {"USER": "testuser"}):
+            result = _get_windows_temp_dir()
+        assert result == "/mnt/c/Users/testuser/AppData/Local/Temp"
+
+    @patch("os.path.isdir")
+    def test_second_candidate_found(self, mock_isdir):
+        def isdir_side(path):
+            return path == "/mnt/c/Temp"
+
+        mock_isdir.side_effect = isdir_side
+        with patch.dict("os.environ", {"USER": "testuser"}):
+            result = _get_windows_temp_dir()
+        assert result == "/mnt/c/Temp"
+
+    @patch("os.path.isdir", return_value=False)
+    @patch("computer_use.platform.wsl2.subprocess.run")
+    def test_powershell_fallback(self, mock_run, _isdir):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="C:\\Users\\test\\AppData\\Local\\Temp\n"
+        )
+        with patch.dict("os.environ", {"USER": "testuser"}):
+            result = _get_windows_temp_dir()
+        assert result == "/mnt/c/Users/test/AppData/Local/Temp"
+
+    @patch("os.path.isdir", return_value=False)
+    @patch("computer_use.platform.wsl2.subprocess.run")
+    def test_raises_when_all_fail(self, mock_run, _isdir):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        with patch.dict("os.environ", {"USER": "testuser"}):
+            with pytest.raises(ScreenCaptureError, match="Cannot determine Windows temp"):
+                _get_windows_temp_dir()
+
+
+# --- _run_ps ---
+
+
+class TestRunPs:
+    @patch("computer_use.platform.wsl2._persistent_ps_lock", MagicMock())
+    @patch("computer_use.platform.wsl2._persistent_ps")
+    def test_tries_persistent_first(self, mock_ps_singleton):
+        mock_ps_singleton.run.return_value = "ok"
+        # Reset the module singleton so _run_ps sees our mock
+        with patch("computer_use.platform.wsl2._persistent_ps", mock_ps_singleton):
+            result = _run_ps("Get-Date")
+        assert result == "ok"
+        mock_ps_singleton.run.assert_called_once()
+
+    @patch("computer_use.platform.wsl2._run_ps_subprocess", return_value="fallback ok")
+    @patch("computer_use.platform.wsl2._persistent_ps_lock", MagicMock())
+    def test_falls_back_to_subprocess_on_error(self, mock_subprocess):
+        failing_ps = MagicMock()
+        failing_ps.run.side_effect = RuntimeError("persistent failed")
+        with patch("computer_use.platform.wsl2._persistent_ps", failing_ps):
+            result = _run_ps("Get-Date")
+        assert result == "fallback ok"
+        mock_subprocess.assert_called_once()
+
+
+# --- _run_ps_subprocess ---
+
+
+class TestRunPsSubprocess:
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2.subprocess.run")
+    @patch("builtins.open", mock_open())
+    @patch("os.unlink")
+    def test_success(self, _unlink, mock_run, _temp):
+        mock_run.return_value = MagicMock(returncode=0, stdout="result\n", stderr="")
+        result = _run_ps_subprocess("echo hello")
+        assert result == "result"
+
+    @patch("computer_use.platform.wsl2._get_windows_temp_dir", return_value="/mnt/c/tmp")
+    @patch("computer_use.platform.wsl2.subprocess.run")
+    @patch("builtins.open", mock_open())
+    @patch("os.unlink")
+    def test_nonzero_exit_raises(self, _unlink, mock_run, _temp):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="bad script")
+        with pytest.raises(RuntimeError, match="PowerShell error"):
+            _run_ps_subprocess("bad")


### PR DESCRIPTION
  3.10/3.11/3.12.
  Add pytest-cov with .coveragerc to exclude untestable platform
  modules
  (daemon.py, macos.py, windows.py). Add 11 new test files
  covering providers,
  registry, CLI, platform detection, vision locator, hybrid
  locator, core loop,
  WSL2 backend, accessibility locator, and engine facade. Fix
  pre-existing
  test_is_available_with_xdotool failure by mocking the Wayland
  detection.