### PR TITLE
Add forge API integration: agent service, execution, and ID-based folders

### DIFF
--- a/api/Agent_Forge_API.postman_collection.json
+++ b/api/Agent_Forge_API.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "name": "Agent Forge API - Phase A",
-    "description": "Phase A (Agents) API collection for the Agent Forge orchestration platform.\n\nCovers: Health, Agents (CRUD + run), Runs (lifecycle + control), Computer Use (status).\n\nRun order matters -- requests use collection variables set by earlier requests.",
+    "name": "Agent Forge API",
+    "description": "E2E test suite for the Agent Forge API.\n\nRun order matters -- requests use collection variables set by earlier requests.\n\nFlow: Health -> Create Agent -> Poll Ready -> Get -> Cosmetic Update -> Substantive Update -> Poll Updated -> Busy Update (409) -> Run Agent -> List Runs -> List Agents -> Minimal Create -> Validation Tests -> Delete Tests -> Runs -> Computer Use.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -19,6 +19,22 @@
     },
     {
       "key": "delete_agent_id",
+      "value": ""
+    },
+    {
+      "key": "poll_count",
+      "value": "0"
+    },
+    {
+      "key": "steps_agent_id",
+      "value": ""
+    },
+    {
+      "key": "steps_poll_count",
+      "value": "0"
+    },
+    {
+      "key": "busy_agent_id",
       "value": ""
     }
   ],
@@ -95,6 +111,7 @@
                   "",
                   "var json = pm.response.json();",
                   "pm.collectionVariables.set('agent_id', json.id);",
+                  "pm.collectionVariables.set('poll_count', 0);",
                   "",
                   "pm.test('Agent has id', function() {",
                   "    pm.expect(json.id).to.be.a('string');",
@@ -111,10 +128,6 @@
                   "",
                   "pm.test('Agent status is creating', function() {",
                   "    pm.expect(json.status).to.eql('creating');",
-                  "});",
-                  "",
-                  "pm.test('Agent has forge_path field', function() {",
-                  "    pm.expect(json).to.have.property('forge_path');",
                   "});",
                   "",
                   "pm.test('Agent has timestamps', function() {",
@@ -138,80 +151,10 @@
           ]
         },
         {
-          "name": "Create Agent - Minimal",
-          "request": {
-            "method": "POST",
-            "url": "{{base_url}}/api/agents",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"name\": \"Summarize Text\",\n  \"description\": \"Summarize any given text into bullet points.\"\n}"
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('Status is 201', function() {",
-                  "    pm.response.to.have.status(201);",
-                  "});",
-                  "",
-                  "var json = pm.response.json();",
-                  "",
-                  "pm.test('Agent created with defaults', function() {",
-                  "    pm.expect(json.type).to.eql('agent');",
-                  "    pm.expect(json.status).to.eql('creating');",
-                  "    pm.expect(json.provider).to.eql('anthropic');",
-                  "    pm.expect(json.computer_use).to.eql(false);",
-                  "    pm.expect(json.samples).to.be.an('array').that.is.empty;",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
-          "name": "Create Agent - Empty Name Fails",
-          "request": {
-            "method": "POST",
-            "url": "{{base_url}}/api/agents",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"name\": \"\",\n  \"description\": \"\"\n}"
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('Status is 422 (validation error)', function() {",
-                  "    pm.response.to.have.status(422);",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
-          "name": "List Agents",
+          "name": "Poll Agent Ready",
           "request": {
             "method": "GET",
-            "url": "{{base_url}}/api/agents"
+            "url": "{{base_url}}/api/agents/{{agent_id}}"
           },
           "event": [
             {
@@ -222,21 +165,25 @@
                   "    pm.response.to.have.status(200);",
                   "});",
                   "",
-                  "pm.test('Returns non-empty array', function() {",
-                  "    var json = pm.response.json();",
-                  "    pm.expect(json).to.be.an('array');",
-                  "    pm.expect(json.length).to.be.at.least(2);",
-                  "});",
+                  "var json = pm.response.json();",
+                  "var pollCount = parseInt(pm.collectionVariables.get('poll_count') || 0) + 1;",
+                  "pm.collectionVariables.set('poll_count', pollCount);",
                   "",
-                  "pm.test('Each agent has required fields', function() {",
-                  "    var json = pm.response.json();",
-                  "    json.forEach(function(agent) {",
-                  "        pm.expect(agent).to.have.property('id');",
-                  "        pm.expect(agent).to.have.property('name');",
-                  "        pm.expect(agent).to.have.property('type');",
-                  "        pm.expect(agent).to.have.property('status');",
+                  "if (json.status === 'creating') {",
+                  "    if (pollCount > 30) {",
+                  "        pm.expect.fail('Forge timed out after 30 polls');",
+                  "    } else {",
+                  "        console.log('Agent still creating, poll #' + pollCount);",
+                  "        postman.setNextRequest('Poll Agent Ready');",
+                  "    }",
+                  "} else if (json.status === 'ready') {",
+                  "    pm.test('Agent forged successfully', function() {",
+                  "        pm.expect(json.status).to.eql('ready');",
                   "    });",
-                  "});"
+                  "    pm.collectionVariables.set('poll_count', 0);",
+                  "} else if (json.status === 'error') {",
+                  "    pm.expect.fail('Forge failed: ' + JSON.stringify(json.forge_config));",
+                  "}"
                 ],
                 "type": "text/javascript"
               }
@@ -281,6 +228,502 @@
                   "    pm.expect(json).to.have.property('model');",
                   "    pm.expect(json).to.have.property('created_at');",
                   "    pm.expect(json).to.have.property('updated_at');",
+                  "});",
+                  "",
+                  "pm.test('forge_path is string (contains agent ID when populated)', function() {",
+                  "    var json = pm.response.json();",
+                  "    if (json.forge_path && json.forge_path.length > 0) {",
+                  "        pm.expect(json.forge_path).to.include(json.id);",
+                  "    }",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update Agent - Cosmetic (Name Only)",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/agents/{{agent_id}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Research Topic (Renamed)\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Name updated', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.name).to.eql('Research Topic (Renamed)');",
+                  "});",
+                  "",
+                  "pm.test('Status stays ready (cosmetic update)', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.status).to.eql('ready');",
+                  "});",
+                  "",
+                  "pm.test('ID unchanged', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.id).to.eql(pm.collectionVariables.get('agent_id'));",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update Agent - Substantive (Description)",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/agents/{{agent_id}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Research a given topic thoroughly using academic and industry sources. Produce a structured report with executive summary, key findings with supporting evidence, and an annotated bibliography.\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Status is updating (forge re-triggered)', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.status).to.eql('updating');",
+                  "});",
+                  "",
+                  "pm.test('Description updated', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.description).to.include('annotated bibliography');",
+                  "});",
+                  "",
+                  "pm.test('ID unchanged', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.id).to.eql(pm.collectionVariables.get('agent_id'));",
+                  "});",
+                  "",
+                  "pm.collectionVariables.set('poll_count', 0);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Poll Agent Updated",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/agents/{{agent_id}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "var pollCount = parseInt(pm.collectionVariables.get('poll_count') || 0) + 1;",
+                  "pm.collectionVariables.set('poll_count', pollCount);",
+                  "",
+                  "if (json.status === 'updating') {",
+                  "    if (pollCount > 30) {",
+                  "        pm.expect.fail('Forge update timed out after 30 polls');",
+                  "    } else {",
+                  "        console.log('Agent still updating, poll #' + pollCount);",
+                  "        postman.setNextRequest('Poll Agent Updated');",
+                  "    }",
+                  "} else if (json.status === 'ready') {",
+                  "    pm.test('Agent updated successfully', function() {",
+                  "        pm.expect(json.status).to.eql('ready');",
+                  "    });",
+                  "    pm.collectionVariables.set('poll_count', 0);",
+                  "} else if (json.status === 'error') {",
+                  "    pm.expect.fail('Forge update failed: ' + JSON.stringify(json.forge_config));",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update Agent - Busy (409)",
+          "request": {
+            "method": "PUT",
+            "url": "{{base_url}}/api/agents/{{busy_agent_id}}",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"This should be rejected\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "pm.sendRequest({",
+                  "    url: pm.collectionVariables.get('base_url') + '/api/agents',",
+                  "    method: 'POST',",
+                  "    header: { 'Content-Type': 'application/json' },",
+                  "    body: { mode: 'raw', raw: JSON.stringify({ name: 'Busy Agent', description: 'Still creating' }) }",
+                  "}, function(err, res) {",
+                  "    pm.collectionVariables.set('busy_agent_id', res.json().id);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 409', function() {",
+                  "    pm.response.to.have.status(409);",
+                  "});",
+                  "",
+                  "pm.test('Error code is AGENT_BUSY', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.error.code).to.eql('AGENT_BUSY');",
+                  "});",
+                  "",
+                  "pm.test('Error mentions status', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json.error.message).to.include('creating');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Run Agent (Standalone)",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/agents/{{agent_id}}/run",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"inputs\": {\n    \"topic\": \"Quantum computing in drug discovery\"\n  }\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 202', function() {",
+                  "    pm.response.to.have.status(202);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('run_id', json.run_id);",
+                  "",
+                  "pm.test('Run has id', function() {",
+                  "    pm.expect(json.run_id).to.be.a('string');",
+                  "    pm.expect(json.run_id).to.have.lengthOf.above(0);",
+                  "});",
+                  "",
+                  "pm.test('Run status is queued', function() {",
+                  "    pm.expect(json.status).to.eql('queued');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "List Agent Runs",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/agents/{{agent_id}}/runs"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Returns runs array with at least one run', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.be.an('array');",
+                  "    pm.expect(json.length).to.be.at.least(1);",
+                  "});",
+                  "",
+                  "pm.test('Each run has required fields', function() {",
+                  "    var json = pm.response.json();",
+                  "    json.forEach(function(run) {",
+                  "        pm.expect(run).to.have.property('id');",
+                  "        pm.expect(run).to.have.property('status');",
+                  "        pm.expect(run).to.have.property('agent_id');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "List Agents",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/agents"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Returns non-empty array', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.be.an('array');",
+                  "    pm.expect(json.length).to.be.at.least(1);",
+                  "});",
+                  "",
+                  "pm.test('Each agent has required fields', function() {",
+                  "    var json = pm.response.json();",
+                  "    json.forEach(function(agent) {",
+                  "        pm.expect(agent).to.have.property('id');",
+                  "        pm.expect(agent).to.have.property('name');",
+                  "        pm.expect(agent).to.have.property('type');",
+                  "        pm.expect(agent).to.have.property('status');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Create Agent - Minimal",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/agents",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Summarize Text\",\n  \"description\": \"Summarize any given text into bullet points.\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 201', function() {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "",
+                  "pm.test('Agent created with defaults', function() {",
+                  "    pm.expect(json.type).to.eql('agent');",
+                  "    pm.expect(json.status).to.eql('creating');",
+                  "    pm.expect(json.provider).to.eql('anthropic');",
+                  "    pm.expect(json.computer_use).to.eql(false);",
+                  "    pm.expect(json.samples).to.be.an('array').that.is.empty;",
+                  "    pm.expect(json.steps).to.be.an('array').that.is.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Create Agent - Empty Name Fails",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/agents",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"\",\n  \"description\": \"\"\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 422 (validation error)', function() {",
+                  "    pm.response.to.have.status(422);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Create Agent - With Steps",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/agents",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Data Pipeline\",\n  \"description\": \"Extract data from a CSV, transform it by cleaning and normalizing, then load it into a summary report.\",\n  \"steps\": [\"Extract data from CSV\", \"Clean and normalize data\", \"Generate summary report\"]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 201', function() {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "pm.collectionVariables.set('steps_agent_id', json.id);",
+                  "pm.collectionVariables.set('steps_poll_count', '0');",
+                  "",
+                  "pm.test('Agent has steps', function() {",
+                  "    pm.expect(json.steps).to.be.an('array').with.lengthOf(3);",
+                  "    pm.expect(json.steps[0]).to.eql('Extract data from CSV');",
+                  "    pm.expect(json.steps[1]).to.eql('Clean and normalize data');",
+                  "    pm.expect(json.steps[2]).to.eql('Generate summary report');",
+                  "});",
+                  "",
+                  "pm.test('Status is creating', function() {",
+                  "    pm.expect(json.status).to.eql('creating');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Poll Agent With Steps Ready",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/agents/{{steps_agent_id}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "var count = parseInt(pm.collectionVariables.get('steps_poll_count') || '0');",
+                  "",
+                  "if (json.status === 'creating' && count < 30) {",
+                  "    pm.collectionVariables.set('steps_poll_count', String(count + 1));",
+                  "    setTimeout(function() { postman.setNextRequest('Poll Agent With Steps Ready'); }, 5000);",
+                  "} else {",
+                  "    pm.test('Agent is ready (or error)', function() {",
+                  "        pm.expect(['ready', 'error']).to.include(json.status);",
+                  "    });",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Run Agent - With Steps",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/agents/{{steps_agent_id}}/run",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"inputs\": {\"csv_data\": \"name,age,score\\nAlice,30,95\\nBob,25,87\"}\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 202', function() {",
+                  "    pm.response.to.have.status(202);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "",
+                  "pm.test('Has run_id', function() {",
+                  "    pm.expect(json.run_id).to.be.a('string');",
+                  "});",
+                  "",
+                  "pm.test('Status is queued', function() {",
+                  "    pm.expect(json.status).to.eql('queued');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -312,51 +755,6 @@
                   "    var json = pm.response.json();",
                   "    pm.expect(json.error.message).to.be.a('string');",
                   "    pm.expect(json.error.message).to.include('nonexistent-id');",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
-          "name": "Update Agent",
-          "request": {
-            "method": "PUT",
-            "url": "{{base_url}}/api/agents/{{agent_id}}",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"name\": \"Research Topic (Updated)\",\n  \"description\": \"Updated description with more detail about the research process.\"\n}"
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('Status is 200', function() {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test('Name updated', function() {",
-                  "    var json = pm.response.json();",
-                  "    pm.expect(json.name).to.eql('Research Topic (Updated)');",
-                  "});",
-                  "",
-                  "pm.test('Description updated', function() {",
-                  "    var json = pm.response.json();",
-                  "    pm.expect(json.description).to.include('Updated description');",
-                  "});",
-                  "",
-                  "pm.test('ID unchanged', function() {",
-                  "    var json = pm.response.json();",
-                  "    pm.expect(json.id).to.eql(pm.collectionVariables.get('agent_id'));",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -400,45 +798,6 @@
           ]
         },
         {
-          "name": "Run Agent (Standalone)",
-          "request": {
-            "method": "POST",
-            "url": "{{base_url}}/api/agents/{{agent_id}}/run",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"inputs\": {\n    \"topic\": \"Quantum computing in drug discovery\"\n  }\n}"
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('Status is 202', function() {",
-                  "    pm.response.to.have.status(202);",
-                  "});",
-                  "",
-                  "var json = pm.response.json();",
-                  "pm.collectionVariables.set('run_id', json.run_id);",
-                  "",
-                  "pm.test('Run created with queued status', function() {",
-                  "    pm.expect(json.run_id).to.be.a('string');",
-                  "    pm.expect(json.run_id).to.have.lengthOf.above(0);",
-                  "    pm.expect(json.status).to.eql('queued');",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
           "name": "Run Agent - 404",
           "request": {
             "method": "POST",
@@ -466,41 +825,6 @@
                   "pm.test('Error code is AGENT_NOT_FOUND', function() {",
                   "    var json = pm.response.json();",
                   "    pm.expect(json.error.code).to.eql('AGENT_NOT_FOUND');",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ]
-        },
-        {
-          "name": "List Agent Runs",
-          "request": {
-            "method": "GET",
-            "url": "{{base_url}}/api/agents/{{agent_id}}/runs"
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test('Status is 200', function() {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test('Returns runs array with at least one run', function() {",
-                  "    var json = pm.response.json();",
-                  "    pm.expect(json).to.be.an('array');",
-                  "    pm.expect(json.length).to.be.at.least(1);",
-                  "});",
-                  "",
-                  "pm.test('Each run has required fields', function() {",
-                  "    var json = pm.response.json();",
-                  "    json.forEach(function(run) {",
-                  "        pm.expect(run).to.have.property('id');",
-                  "        pm.expect(run).to.have.property('status');",
-                  "        pm.expect(run).to.have.property('agent_id');",
-                  "    });",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -698,8 +1022,13 @@
             "method": "GET",
             "url": {
               "raw": "{{base_url}}/api/runs?status=queued",
-              "host": ["{{base_url}}"],
-              "path": ["api", "runs"],
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "runs"
+              ],
               "query": [
                 {
                   "key": "status",

--- a/api/docs/API_ARCHITECTURE.md
+++ b/api/docs/API_ARCHITECTURE.md
@@ -53,7 +53,6 @@ The core loop: user describes a goal, forge builds an agent, user runs it.
 - Projects, canvas, DAG
 - Connecting agents together
 - Approval gate nodes (added in Phase B with projects)
-- Visual frontend (React + React Flow)
 
 ### Phase B: Projects + Canvas (MVP-B)
 
@@ -151,7 +150,7 @@ graph TB
 An agent is a **complete forge-generated workflow**. Not a prompt -- a prompt is just a file. An agent is the whole thing:
 
 ```
-output/{agent-name}/
+output/{agent-id}/
 ├── agentic.md              # How the agent works (orchestrator)
 ├── agent/Prompts/          # The prompts it uses internally
 │   ├── 01_Research_Analyst.md
@@ -159,6 +158,8 @@ output/{agent-name}/
 │   └── 03_Academic_Writer.md
 └── ...
 ```
+
+API-created agents use the agent's UUID as the folder name (`output/{agent-id}/`) to enable reliable cleanup on deletion. Standalone forge workflows (created via `forge/agentic.md`) continue to use kebab-case names (`output/{workflow-name}/`).
 
 The user describes what the agent should accomplish in plain language. Forge runs its generation process and creates the full agent folder -- orchestrator, prompts, quality checks, everything.
 
@@ -209,7 +210,7 @@ Two types of data, two storage strategies:
 
 | What | Where | Why |
 |---|---|---|
-| **Agent definition** (agentic.md + prompts) | Filesystem: `output/{agent-name}/` | Can be large, git-trackable, human-readable, editable, works standalone |
+| **Agent definition** (agentic.md + prompts) | Filesystem: `output/{agent-id}/` | Can be large, git-trackable, human-readable, editable, works standalone |
 | **Agent metadata** (name, type, model, path) | DB: `agents` table | Queryable, drives the UI and canvas |
 | **Runtime outputs** (what agents produce when run) | DB: `agent_runs.outputs` as JSON | Structured, flows through the DAG, displayed in UI |
 | **Binary artifacts** (PDFs, images -- future) | Filesystem: `data/artifacts/{run_id}/` | Too large for DB, referenced via JSON in outputs |
@@ -218,14 +219,14 @@ The `agents` table stores a `forge_path` that points to the agent's folder on di
 
 ```
 output/
-  research-topic/                     # Agent: "Research Topic"
+  a1b2c3d4-e5f6.../                   # API agent (UUID as folder name)
     agentic.md                        # Internal orchestrator
     agent/Prompts/
       01_Research_Analyst.md
       02_Outline_Architect.md
       03_Academic_Writer.md
 
-  summarize-text/                     # Agent: "Summarize Text" (simple)
+  my-workflow/                        # Standalone forge workflow (kebab-case name)
     agentic.md                        # One-step orchestrator
     agent/Prompts/
       01_Summarizer.md
@@ -455,16 +456,17 @@ api/
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/agents` | Create a new agent (triggers forge) |
+| `POST` | `/api/agents` | Create a new agent (triggers forge in background) |
 | `GET` | `/api/agents` | List all agents |
 | `GET` | `/api/agents/{id}` | Get agent by ID |
-| `DELETE` | `/api/agents/{id}` | Delete agent (removes files + DB record) |
-| `POST` | `/api/agents/{id}/run` | Run an agent directly |
+| `PUT` | `/api/agents/{id}` | Update agent metadata |
+| `DELETE` | `/api/agents/{id}` | Delete agent (removes output folder via `forge_path` + DB record) |
+| `POST` | `/api/agents/{id}/run` | Run an agent (must be status "ready") |
 | `GET` | `/api/agents/{id}/runs` | List runs of this agent |
 
 #### Create Agent
 
-The user describes what the agent should do. The API triggers forge to create the full agent.
+The user describes what the agent should do. The API triggers forge to create the full agent. Forge runs as a background task via `forge/api-generate.md` (non-interactive, 5-step orchestrator).
 
 ```json
 POST /api/agents
@@ -472,15 +474,24 @@ POST /api/agents
 {
   "name": "Research Topic",
   "description": "Research a given topic using multiple sources. Produce a structured summary with key findings, supporting evidence, and a list of sources.",
+  "steps": ["Research sources", "Synthesize findings", "Format report"],
   "samples": [
     "## Quantum Computing in Healthcare\n\n### Key Findings\n1. Drug discovery acceleration..."
-  ]
+  ],
+  "computer_use": false,
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-6"
 }
 ```
 
-`samples` is optional. When provided, forge uses them to calibrate the generated prompts.
+Only `name` is required. All other fields are optional:
+- `steps` -- explicit workflow steps; if omitted, forge infers them from the description (default: [])
+- `samples` -- quality examples for forge to calibrate prompts
+- `computer_use` -- whether the agent uses desktop automation (default: false)
+- `provider` -- LLM provider key (default: "anthropic")
+- `model` -- model identifier (default: "claude-sonnet-4-6")
 
-The API returns immediately with the agent ID and status "creating":
+The API returns immediately with the agent ID and status "creating". Forge generation runs as a background task:
 
 ```json
 {
@@ -499,7 +510,7 @@ Connect via WebSocket at `/api/ws/agents/{id}` for creation progress. When forge
   "status": "ready",
   "description": "Research a given topic using multiple sources...",
   "type": "agent",
-  "forge_path": "output/research-topic/",
+  "forge_path": "output/{agent-id}/",
   "input_schema": [
     { "name": "topic", "type": "text", "required": true }
   ],
@@ -709,18 +720,16 @@ sequenceDiagram
     API-->>FE: {id, status: "creating"}
     FE->>API: WS connect /api/ws/agents/{id}
 
-    API->>Forge: Generate agent from description
-    Note over Forge: Forge runs its generation process:
-    Forge->>Forge: 1. Analyze complexity
-    Forge-->>FE: WS agent_progress "Analyzing description..."
-    Forge->>Forge: 2. Design internal architecture
-    Forge->>Forge: 3. Generate agentic.md (internal orchestrator)
+    API->>Forge: BackgroundTask: CLIAgentProvider spawns claude -p<br/>"Read forge/api-generate.md and generate agent from: {JSON}"
+    Note over Forge: forge/api-generate.md (non-interactive, 5 steps):
+    Forge->>Forge: 1. Parse JSON input (id, name, description, samples, computer_use)
+    Forge->>Forge: 2. Analyze complexity, infer schemas, determine agent roster
+    Forge->>Forge: 3. Generate agentic.md from scaffold template
     Forge-->>FE: WS agent_progress "Generating orchestrator..."
-    Forge->>Forge: 4. Generate prompt files
+    Forge->>Forge: 4. Generate prompt files via 03_Prompt_Writer.md
     Forge-->>FE: WS agent_progress "Generating prompts..."
-    Forge->>FS: Write output/research-topic/agentic.md
-    Forge->>FS: Write output/research-topic/agent/Prompts/*.md
-    Forge-->>API: Done. Path: output/research-topic/
+    Forge->>FS: 5. Write output/{agent-id}/ folder
+    Forge-->>API: JSON: {forge_path, forge_config, input_schema, output_schema}
 
     API->>API: Update agent (status: ready, forge_path, schemas)
     API-->>FE: WS agent_ready {id, input_schema, output_schema}
@@ -887,6 +896,18 @@ async def execute(agent, inputs, callback):
 ```
 
 The `CLIAgentProvider` spawns the configured CLI tool (Claude Code, Codex, Aider, etc.) as a subprocess, sends the prompt, and captures the output. Provider selection is config-driven via `providers.yaml`.
+
+The provider strips the `CLAUDECODE` environment variable from subprocess calls to prevent nested-session detection errors when the API server is launched from within a Claude Code session.
+
+### Forge Entry Point
+
+Agent creation uses `forge/api-generate.md` -- a non-interactive 5-step orchestrator designed for programmatic invocation. Unlike the interactive `forge/agentic.md` (which asks the user questions), `api-generate.md` accepts a JSON payload and produces a complete agent folder without any user interaction. The `AgentService` invokes it via:
+
+```
+claude -p "Read forge/api-generate.md and generate an agent from: {JSON}" --dangerously-skip-permissions --output-format json
+```
+
+The JSON payload contains `id`, `name`, `description`, `samples`, and `computer_use`. When `id` is provided, forge uses `output/{id}/` as the output folder (enabling reliable cleanup on agent deletion). The output is a JSON object with `forge_path`, `forge_config`, `input_schema`, and `output_schema`.
 
 ### DAG Engine -- Phase B
 

--- a/api/docs/PHASE_A_AGENTS.md
+++ b/api/docs/PHASE_A_AGENTS.md
@@ -81,7 +81,7 @@ graph TB
 An agent is a **complete forge-generated workflow**. Not a prompt -- a prompt is just a file. An agent is the whole thing:
 
 ```
-output/{agent-name}/
+output/{agent-id}/
 ├── agentic.md              # How the agent works (orchestrator)
 ├── agent/Prompts/          # The prompts it uses internally
 │   ├── 01_Research_Analyst.md
@@ -89,6 +89,8 @@ output/{agent-name}/
 │   └── 03_Academic_Writer.md
 └── ...
 ```
+
+API-created agents use the agent's UUID as the folder name (`output/{agent-id}/`) to enable reliable cleanup on deletion. Standalone forge workflows (created via `forge/agentic.md`) continue to use kebab-case names (`output/{workflow-name}/`).
 
 The user describes what the agent should accomplish in plain language. Forge runs its generation process and creates the full agent folder -- orchestrator, prompts, quality checks, everything.
 
@@ -121,9 +123,9 @@ sequenceDiagram
     Forge->>Forge: Generate agentic.md
     Forge->>Forge: Generate prompt files
     Forge-->>User: WS agent_progress {step: "generating prompts..."}
-    Forge->>Forge: Write files to output/{agent-name}/
+    Forge->>Forge: Write files to output/{agent-id}/
 
-    Forge-->>API: Agent folder ready at output/{agent-name}/
+    Forge-->>API: Agent folder ready at output/{agent-id}/
     API->>API: Save metadata + forge_path to DB
     API-->>User: WS agent_ready {id, input_schema, output_schema}
     User->>User: Agent ready -- run directly
@@ -137,7 +139,7 @@ Two types of data, two storage strategies:
 
 | What | Where | Why |
 |---|---|---|
-| **Agent definition** (agentic.md + prompts) | Filesystem: `output/{agent-name}/` | Can be large, git-trackable, human-readable, editable, works standalone |
+| **Agent definition** (agentic.md + prompts) | Filesystem: `output/{agent-id}/` | Can be large, git-trackable, human-readable, editable, works standalone |
 | **Agent metadata** (name, type, model, path) | DB: `agents` table | Queryable, drives the UI |
 | **Runtime outputs** (what agents produce when run) | DB: `agent_runs.outputs` as JSON | Structured, displayed in UI |
 | **Binary artifacts** (PDFs, images -- future) | Filesystem: `data/artifacts/{run_id}/` | Too large for DB, referenced via JSON in outputs |
@@ -146,14 +148,14 @@ The `agents` table stores a `forge_path` that points to the agent's folder on di
 
 ```
 output/
-  research-topic/                     # Agent: "Research Topic"
+  a1b2c3d4-e5f6.../                   # API agent (UUID as folder name)
     agentic.md                        # Internal orchestrator
     agent/Prompts/
       01_Research_Analyst.md
       02_Outline_Architect.md
       03_Academic_Writer.md
 
-  summarize-text/                     # Agent: "Summarize Text" (simple)
+  my-workflow/                        # Standalone forge workflow (kebab-case name)
     agentic.md                        # One-step orchestrator
     agent/Prompts/
       01_Summarizer.md
@@ -319,11 +321,12 @@ api/
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/agents` | Create a new agent (triggers forge) |
+| `POST` | `/api/agents` | Create a new agent (triggers forge in background) |
 | `GET` | `/api/agents` | List all agents |
 | `GET` | `/api/agents/{id}` | Get agent by ID |
-| `DELETE` | `/api/agents/{id}` | Delete agent (removes files + DB record) |
-| `POST` | `/api/agents/{id}/run` | Run an agent directly |
+| `PUT` | `/api/agents/{id}` | Update agent metadata |
+| `DELETE` | `/api/agents/{id}` | Delete agent (removes output folder via `forge_path` + DB record) |
+| `POST` | `/api/agents/{id}/run` | Run an agent (must be status "ready") |
 | `GET` | `/api/agents/{id}/runs` | List runs of this agent |
 
 ### Create Agent
@@ -336,15 +339,24 @@ POST /api/agents
 {
   "name": "Research Topic",
   "description": "Research a given topic using multiple sources. Produce a structured summary with key findings, supporting evidence, and a list of sources.",
+  "steps": ["Research sources", "Synthesize findings", "Format report"],
   "samples": [
     "## Quantum Computing in Healthcare\n\n### Key Findings\n1. Drug discovery acceleration..."
-  ]
+  ],
+  "computer_use": false,
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-6"
 }
 ```
 
-`samples` is optional. When provided, forge uses them to calibrate the generated prompts.
+Only `name` is required. All other fields are optional:
+- `steps` -- explicit workflow steps; if omitted, forge infers them from the description (default: [])
+- `samples` -- quality examples for forge to calibrate prompts
+- `computer_use` -- whether the agent uses desktop automation (default: false)
+- `provider` -- LLM provider key (default: "anthropic")
+- `model` -- model identifier (default: "claude-sonnet-4-6")
 
-The API returns immediately with the agent ID and status "creating":
+The API returns immediately with the agent ID and status "creating". Forge generation runs as a background task:
 
 ```json
 {
@@ -363,7 +375,7 @@ Connect via WebSocket at `/api/ws/agents/{id}` for creation progress. When forge
   "status": "ready",
   "description": "Research a given topic using multiple sources...",
   "type": "agent",
-  "forge_path": "output/research-topic/",
+  "forge_path": "output/{agent-id}/",
   "input_schema": [
     { "name": "topic", "type": "text", "required": true }
   ],
@@ -511,18 +523,14 @@ sequenceDiagram
     API-->>User: {id, status: "creating"}
     User->>API: WS connect /api/ws/agents/{id}
 
-    API->>Forge: Generate agent from description
-    Note over Forge: Forge runs its generation process:
-    Forge->>Forge: 1. Analyze complexity
-    Forge-->>User: WS agent_progress "Analyzing description..."
-    Forge->>Forge: 2. Design internal architecture
-    Forge->>Forge: 3. Generate agentic.md (internal orchestrator)
-    Forge-->>User: WS agent_progress "Generating orchestrator..."
-    Forge->>Forge: 4. Generate prompt files
-    Forge-->>User: WS agent_progress "Generating prompts..."
-    Forge->>FS: Write output/research-topic/agentic.md
-    Forge->>FS: Write output/research-topic/agent/Prompts/*.md
-    Forge-->>API: Done. Path: output/research-topic/
+    API->>Forge: BackgroundTask: CLIAgentProvider spawns claude -p<br/>"Read forge/api-generate.md and generate agent from: {JSON}"
+    Note over Forge: forge/api-generate.md (non-interactive, 5 steps):
+    Forge->>Forge: 1. Parse JSON input (id, name, description, samples, computer_use)
+    Forge->>Forge: 2. Analyze complexity, infer schemas, determine agent roster
+    Forge->>Forge: 3. Generate agentic.md from scaffold template
+    Forge->>Forge: 4. Generate prompt files via 03_Prompt_Writer.md
+    Forge->>FS: 5. Write output/{agent-id}/ folder
+    Forge-->>API: JSON: {forge_path, forge_config, input_schema, output_schema}
 
     API->>API: Update agent (status: ready, forge_path, schemas)
     API-->>User: WS agent_ready {id, input_schema, output_schema}
@@ -639,6 +647,18 @@ async def execute(agent, inputs, callback):
 ```
 
 The `CLIAgentProvider` spawns the configured CLI tool (Claude Code, Codex, Aider, etc.) as a subprocess, sends the prompt, and captures the output. Provider selection is config-driven via `providers.yaml`.
+
+The provider strips the `CLAUDECODE` environment variable from subprocess calls to prevent nested-session detection errors when the API server is launched from within a Claude Code session.
+
+### Forge Entry Point
+
+Agent creation uses `forge/api-generate.md` -- a non-interactive 5-step orchestrator designed for programmatic invocation. Unlike the interactive `forge/agentic.md` (which asks the user questions), `api-generate.md` accepts a JSON payload and produces a complete agent folder without any user interaction. The `AgentService` invokes it via:
+
+```
+claude -p "Read forge/api-generate.md and generate an agent from: {JSON}" --dangerously-skip-permissions --output-format json
+```
+
+The JSON payload contains `id`, `name`, `description`, `samples`, and `computer_use`. When `id` is provided, forge uses `output/{id}/` as the output folder (enabling reliable cleanup on agent deletion). The output is a JSON object with `forge_path`, `forge_config`, `input_schema`, and `output_schema`.
 
 ---
 

--- a/api/engine/providers.py
+++ b/api/engine/providers.py
@@ -6,12 +6,29 @@ means editing that YAML file, zero code changes.
 
 import asyncio
 import json
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import AsyncIterator
 
 import yaml
+
+
+class ProviderError(RuntimeError):
+    """Raised when a CLI provider exits with non-zero status.
+
+    Carries stdout, stderr, and exit_code for debugging.
+    """
+
+    def __init__(self, provider_name: str, exit_code: int, stdout: str, stderr: str):
+        self.provider_name = provider_name
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__(
+            f"Provider '{provider_name}' failed (exit {exit_code}): {stderr}"
+        )
 
 
 @dataclass
@@ -83,6 +100,11 @@ class CLIAgentProvider:
         except FileNotFoundError:
             return False
 
+    @staticmethod
+    def _clean_env() -> dict[str, str]:
+        """Build a subprocess environment without session-nesting env vars."""
+        return {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
     def _build_args(self, prompt: str, workspace: str | None = None) -> list[str]:
         """Replace placeholders in the config args."""
         result = []
@@ -107,6 +129,7 @@ class CLIAgentProvider:
             self.config.command,
             *args,
             cwd=workspace,
+            env=self._clean_env(),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -124,9 +147,11 @@ class CLIAgentProvider:
             )
 
         if proc.returncode != 0:
-            error_msg = stderr.decode().strip() if stderr else "Unknown error"
-            raise RuntimeError(
-                f"Provider '{self.config.name}' failed (exit {proc.returncode}): {error_msg}"
+            raise ProviderError(
+                provider_name=self.config.name,
+                exit_code=proc.returncode,
+                stdout=stdout.decode().strip() if stdout else "",
+                stderr=stderr.decode().strip() if stderr else "Unknown error",
             )
 
         return stdout.decode().strip()
@@ -145,6 +170,7 @@ class CLIAgentProvider:
             self.config.command,
             *args,
             cwd=workspace,
+            env=self._clean_env(),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ from api.websocket.manager import ConnectionManager
 from api.engine.executor import AgentExecutor
 from api.engine.providers import CLIAgentProvider, load_provider_config
 from api.services.computer_use_service import ComputerUseService
+from api.services.agent_service import AgentService
 from api.services.execution_service import ExecutionService
 from api.routes import health, agents, projects, runs, computer_use, ws
 
@@ -44,6 +45,11 @@ def create_app(db: Optional[Database] = None) -> FastAPI:
 
         async def emit(run_id, event_type, data):
             await app.state.ws_manager.emit(run_id, event_type, data)
+
+        app.state.agent_service = AgentService(
+            agent_repo=app.state.agent_repo,
+            provider=provider,
+        )
 
         app.state.execution_service = ExecutionService(
             agent_repo=app.state.agent_repo,

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -17,6 +17,7 @@ class SchemaField(BaseModel):
 class AgentCreate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     description: str = Field(default="", max_length=10000)
+    steps: list[str] = []
     samples: list[str] = []
     computer_use: bool = False
     provider: str = "anthropic"
@@ -26,6 +27,8 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=200)
     description: Optional[str] = Field(default=None, max_length=10000)
+    status: Optional[str] = None
+    steps: Optional[list[str]] = None
     samples: Optional[list[str]] = None
     input_schema: Optional[list[SchemaField]] = None
     output_schema: Optional[list[SchemaField]] = None
@@ -41,6 +44,7 @@ class Agent(BaseModel):
     type: AgentType
     status: str = "creating"
     forge_path: str = ""
+    steps: list[str] = []
     samples: list[str] = []
     input_schema: list[SchemaField] = []
     output_schema: list[SchemaField] = []

--- a/api/persistence/database.py
+++ b/api/persistence/database.py
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS agents (
     type TEXT NOT NULL DEFAULT 'agent',
     status TEXT NOT NULL DEFAULT 'creating',
     forge_path TEXT DEFAULT '',
+    steps TEXT DEFAULT '[]',
     samples TEXT DEFAULT '[]',
     input_schema TEXT DEFAULT '[]',
     output_schema TEXT DEFAULT '[]',

--- a/api/persistence/repositories.py
+++ b/api/persistence/repositories.py
@@ -30,6 +30,7 @@ def _row_to_agent(row) -> dict:
         "type": row["type"],
         "status": row["status"],
         "forge_path": row["forge_path"],
+        "steps": _parse_json(row["steps"]),
         "samples": _parse_json(row["samples"]),
         "input_schema": _parse_json(row["input_schema"]),
         "output_schema": _parse_json(row["output_schema"]),
@@ -98,6 +99,7 @@ class AgentRepository:
         type: str = "agent",
         status: str = "creating",
         forge_path: str = "",
+        steps: list[str] | None = None,
         samples: list[str] | None = None,
         input_schema: list[dict] | None = None,
         output_schema: list[dict] | None = None,
@@ -109,11 +111,12 @@ class AgentRepository:
         agent_id = _uuid()
         now = _now()
         await self.db.conn.execute(
-            """INSERT INTO agents (id, name, description, type, status, forge_path, samples, input_schema,
+            """INSERT INTO agents (id, name, description, type, status, forge_path, steps, samples, input_schema,
                output_schema, computer_use, forge_config, provider, model, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 agent_id, name, description, type, status, forge_path,
+                json.dumps(steps or []),
                 json.dumps(samples or []),
                 json.dumps(input_schema or []),
                 json.dumps(output_schema or []),
@@ -143,7 +146,7 @@ class AgentRepository:
         if not existing:
             return None
 
-        json_fields = {"samples", "input_schema", "output_schema", "forge_config"}
+        json_fields = {"steps", "samples", "input_schema", "output_schema", "forge_config"}
         sets = []
         values = []
         for key, value in fields.items():

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -1,6 +1,9 @@
 """Agent CRUD routes."""
 
-from fastapi import APIRouter, Request
+import shutil
+from pathlib import Path
+
+from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import JSONResponse
 
 from api.models.agent import AgentCreate, AgentUpdate, AgentRunRequest
@@ -16,16 +19,19 @@ def _not_found(agent_id: str):
 
 
 @router.post("", status_code=201)
-async def create_agent(body: AgentCreate, request: Request):
-    repo = request.app.state.agent_repo
-    agent = await repo.create(
+async def create_agent(body: AgentCreate, request: Request, background_tasks: BackgroundTasks):
+    agent_service = request.app.state.agent_service
+    agent = await agent_service.create_agent(
         name=body.name,
         description=body.description,
+        steps=body.steps,
         samples=body.samples,
         computer_use=body.computer_use,
         provider=body.provider,
         model=body.model,
     )
+    # Trigger forge generation in the background
+    background_tasks.add_task(agent_service.run_forge, agent["id"])
     return agent
 
 
@@ -44,14 +50,46 @@ async def get_agent(agent_id: str, request: Request):
     return agent
 
 
+_SUBSTANTIVE_FIELDS = {"description", "steps", "samples", "computer_use"}
+
+
 @router.put("/{agent_id}")
-async def update_agent(agent_id: str, body: AgentUpdate, request: Request):
+async def update_agent(
+    agent_id: str, body: AgentUpdate, request: Request,
+    background_tasks: BackgroundTasks,
+):
     repo = request.app.state.agent_repo
+    agent_service = request.app.state.agent_service
+
     fields = body.model_dump(exclude_none=True)
     if "input_schema" in fields:
         fields["input_schema"] = [s.model_dump() if hasattr(s, "model_dump") else s for s in fields["input_schema"]]
     if "output_schema" in fields:
         fields["output_schema"] = [s.model_dump() if hasattr(s, "model_dump") else s for s in fields["output_schema"]]
+
+    substantive_changes = _SUBSTANTIVE_FIELDS & fields.keys()
+
+    # If substantive change, check agent isn't busy
+    if substantive_changes:
+        current = await repo.get(agent_id)
+        if not current:
+            return _not_found(agent_id)
+        if current["status"] in ("creating", "updating"):
+            return JSONResponse(
+                status_code=409,
+                content={"error": {"code": "AGENT_BUSY", "message": f"Agent is '{current['status']}', cannot update substantive fields now", "details": {}}},
+            )
+        # Set status to updating and trigger forge
+        fields["status"] = "updating"
+        agent = await repo.update(agent_id, **fields)
+        if not agent:
+            return _not_found(agent_id)
+        background_tasks.add_task(
+            agent_service.run_update, agent_id, current, fields,
+        )
+        return agent
+
+    # Cosmetic update only
     agent = await repo.update(agent_id, **fields)
     if not agent:
         return _not_found(agent_id)
@@ -61,19 +99,37 @@ async def update_agent(agent_id: str, body: AgentUpdate, request: Request):
 @router.delete("/{agent_id}", status_code=204)
 async def delete_agent(agent_id: str, request: Request):
     repo = request.app.state.agent_repo
-    deleted = await repo.delete(agent_id)
-    if not deleted:
+    agent = await repo.get(agent_id)
+    if not agent:
         return _not_found(agent_id)
+    # Clean up the output folder if it exists
+    forge_path = agent.get("forge_path", "")
+    if forge_path:
+        path = Path(forge_path)
+        if path.exists() and path.is_dir():
+            shutil.rmtree(path)
+    await repo.delete(agent_id)
 
 
 @router.post("/{agent_id}/run", status_code=202)
-async def run_agent(agent_id: str, body: AgentRunRequest, request: Request):
+async def run_agent(agent_id: str, body: AgentRunRequest, request: Request, background_tasks: BackgroundTasks):
     agent_repo = request.app.state.agent_repo
     run_repo = request.app.state.run_repo
+    execution_service = request.app.state.execution_service
+
     agent = await agent_repo.get(agent_id)
     if not agent:
         return _not_found(agent_id)
+
+    if agent["status"] != "ready":
+        return JSONResponse(
+            status_code=409,
+            content={"error": {"code": "AGENT_NOT_READY", "message": f"Agent is '{agent['status']}', must be 'ready' to run", "details": {}}},
+        )
+
     run = await run_repo.create(agent_id=agent_id, inputs=body.inputs)
+    # Trigger execution in the background
+    background_tasks.add_task(execution_service.run_standalone_agent, run["id"])
     return {"run_id": run["id"], "status": run["status"]}
 
 

--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -1,34 +1,224 @@
-"""Agent service -- wraps repository + forge analysis."""
+"""Agent service -- wraps repository + forge generation."""
 
+import json
+import logging
+from pathlib import Path
+
+from api.engine.providers import CLIAgentProvider, ProviderError
 from api.persistence.repositories import AgentRepository
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Resolve project root (Agent-Forge/) relative to this file
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 class AgentService:
-    """Business logic for agent management. In future, calls forge to analyze
-    descriptions and generate forge_config."""
+    """Business logic for agent creation. Calls forge to generate agent folders."""
 
-    def __init__(self, agent_repo: AgentRepository):
+    def __init__(self, agent_repo: AgentRepository, provider: CLIAgentProvider):
         self.agent_repo = agent_repo
+        self.provider = provider
 
-    async def analyze_and_create(self, name: str, description: str, **kwargs) -> dict:
-        """Create an agent. In future, sends description to forge for analysis."""
-        # MVP: forge analysis is stubbed. Returns simple config.
-        forge_config = self._stub_forge_analysis(description)
-        input_schema = kwargs.pop("input_schema", [])
-        output_schema = kwargs.pop("output_schema", [])
-
+    async def create_agent(
+        self,
+        name: str,
+        description: str,
+        steps: list | None = None,
+        samples: list | None = None,
+        computer_use: bool = False,
+        provider: str = "anthropic",
+        model: str = "claude-sonnet-4-6",
+    ) -> dict:
+        """Create an agent record with status 'creating'."""
         return await self.agent_repo.create(
             name=name,
             description=description,
-            forge_config=forge_config,
-            input_schema=input_schema,
-            output_schema=output_schema,
-            **kwargs,
+            status="creating",
+            steps=steps,
+            samples=samples,
+            computer_use=computer_use,
+            provider=provider,
+            model=model,
         )
 
-    def _stub_forge_analysis(self, description: str) -> dict:
-        """Stub forge analysis. Will be replaced with real forge integration."""
-        word_count = len(description.split())
-        if word_count > 50:
-            return {"complexity": "multi_step", "agents": 2, "steps": 3}
-        return {"complexity": "simple", "agents": 1, "steps": 1}
+    async def run_forge(self, agent_id: str) -> None:
+        """Run forge to generate the agent folder. Updates agent status on completion.
+
+        Called as a background task after the HTTP response is sent.
+        """
+        agent = await self.agent_repo.get(agent_id)
+        if not agent:
+            logger.error("Agent %s not found for forge generation", agent_id)
+            return
+
+        try:
+            forge_input = {
+                "id": agent_id,
+                "name": agent["name"],
+                "description": agent["description"],
+                "samples": agent.get("samples") or [],
+                "computer_use": agent.get("computer_use", False),
+            }
+            if agent.get("steps"):
+                forge_input["steps"] = agent["steps"]
+
+            prompt = (
+                f"Read forge/api-generate.md and generate an agent from: "
+                f"{json.dumps(forge_input)}"
+            )
+
+            logger.info("Running forge for agent %s (%s)", agent_id, agent["name"])
+            raw_output = await self.provider.execute(
+                prompt=prompt,
+                workspace=str(PROJECT_ROOT),
+                timeout=600,  # forge generation can take a while
+            )
+
+            # Parse the JSON output from forge
+            forge_result = self._parse_forge_output(raw_output)
+
+            # Update the agent with forge results
+            await self.agent_repo.update(
+                agent_id,
+                status="ready",
+                forge_path=forge_result.get("forge_path", ""),
+                forge_config=forge_result.get("forge_config", {}),
+                input_schema=forge_result.get("input_schema", []),
+                output_schema=forge_result.get("output_schema", []),
+            )
+            logger.info("Forge completed for agent %s -- status: ready", agent_id)
+
+        except ProviderError as e:
+            logger.exception("Forge generation failed for agent %s", agent_id)
+            await self.agent_repo.update(
+                agent_id,
+                status="error",
+                forge_config={
+                    "error": str(e),
+                    "stdout": e.stdout,
+                    "stderr": e.stderr,
+                    "exit_code": e.exit_code,
+                },
+            )
+        except Exception as e:
+            logger.exception("Forge generation failed for agent %s", agent_id)
+            await self.agent_repo.update(
+                agent_id,
+                status="error",
+                forge_config={"error": str(e)},
+            )
+
+    async def run_update(
+        self, agent_id: str, old_agent: dict, new_fields: dict
+    ) -> None:
+        """Re-run forge to update an existing agent's workflow.
+
+        Called as a background task when substantive fields change.
+        Status flow: ready → updating → ready/error.
+        """
+        agent = await self.agent_repo.get(agent_id)
+        if not agent:
+            logger.error("Agent %s not found for forge update", agent_id)
+            return
+
+        try:
+            # Build the update input for forge/api-update.md
+            original = {
+                "name": old_agent.get("name", ""),
+                "description": old_agent.get("description", ""),
+                "steps": old_agent.get("steps") or [],
+                "samples": old_agent.get("samples") or [],
+                "computer_use": old_agent.get("computer_use", False),
+            }
+            updated = {}
+            for key in ("description", "steps", "samples", "computer_use"):
+                if key in new_fields:
+                    updated[key] = new_fields[key]
+
+            update_input = {
+                "forge_path": old_agent.get("forge_path", ""),
+                "original": original,
+                "updated": updated,
+            }
+
+            prompt = (
+                f"Read forge/api-update.md and update an existing agent from: "
+                f"{json.dumps(update_input)}"
+            )
+
+            logger.info("Running forge update for agent %s (%s)", agent_id, agent["name"])
+            raw_output = await self.provider.execute(
+                prompt=prompt,
+                workspace=str(PROJECT_ROOT),
+                timeout=600,
+            )
+
+            forge_result = self._parse_forge_output(raw_output)
+
+            await self.agent_repo.update(
+                agent_id,
+                status="ready",
+                forge_path=forge_result.get("forge_path", ""),
+                forge_config=forge_result.get("forge_config", {}),
+                input_schema=forge_result.get("input_schema", []),
+                output_schema=forge_result.get("output_schema", []),
+            )
+            logger.info("Forge update completed for agent %s -- status: ready", agent_id)
+
+        except ProviderError as e:
+            logger.exception("Forge update failed for agent %s", agent_id)
+            await self.agent_repo.update(
+                agent_id,
+                status="error",
+                forge_config={
+                    "error": str(e),
+                    "stdout": e.stdout,
+                    "stderr": e.stderr,
+                    "exit_code": e.exit_code,
+                },
+            )
+        except Exception as e:
+            logger.exception("Forge update failed for agent %s", agent_id)
+            await self.agent_repo.update(
+                agent_id,
+                status="error",
+                forge_config={"error": str(e)},
+            )
+
+    def _parse_forge_output(self, raw_output: str) -> dict:
+        """Extract the JSON result from forge output.
+
+        Forge may output the JSON wrapped in Claude's JSON output format,
+        or it may be raw JSON. Handle both cases.
+        """
+        # Try direct JSON parse first
+        try:
+            parsed = json.loads(raw_output)
+            # Claude --output-format json wraps in {"type":"result","result":"..."}
+            if isinstance(parsed, dict) and "result" in parsed:
+                inner = parsed["result"]
+                if isinstance(inner, str):
+                    return json.loads(inner)
+                return inner
+            return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Try to find JSON object in the output (forge prints it last)
+        lines = raw_output.strip().split("\n")
+        for i in range(len(lines) - 1, -1, -1):
+            line = lines[i].strip()
+            if line.startswith("{"):
+                try:
+                    # Try joining from this line to the end
+                    candidate = "\n".join(lines[i:])
+                    return json.loads(candidate)
+                except json.JSONDecodeError:
+                    try:
+                        return json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+        raise ValueError(f"Could not parse forge output as JSON: {raw_output[:500]}")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -61,12 +61,17 @@ async def app(db):
     from api.engine.executor import AgentExecutor
     from api.engine.providers import CLIAgentProvider, ProviderConfig
     from api.services.computer_use_service import ComputerUseService
+    from api.services.agent_service import AgentService
     from api.services.execution_service import ExecutionService
     from unittest.mock import AsyncMock
 
     application.state.ws_manager = ConnectionManager()
 
     provider = AsyncMock(spec=CLIAgentProvider)
+    application.state.agent_service = AgentService(
+        agent_repo=application.state.agent_repo,
+        provider=provider,
+    )
     cu_service = ComputerUseService()
     executor = AgentExecutor(provider=provider, computer_use_service=cu_service)
 

--- a/api/tests/test_agents.py
+++ b/api/tests/test_agents.py
@@ -43,6 +43,26 @@ class TestAgentCreate:
         })
         assert resp.status_code == 422
 
+    @pytest.mark.asyncio
+    async def test_create_agent_with_steps(self, client):
+        resp = await client.post("/api/agents", json={
+            "name": "Multi Step",
+            "description": "Do a multi-step task",
+            "steps": ["Research sources", "Synthesize findings", "Format report"],
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["steps"] == ["Research sources", "Synthesize findings", "Format report"]
+
+    @pytest.mark.asyncio
+    async def test_create_agent_without_steps_defaults_empty(self, client):
+        resp = await client.post("/api/agents", json={
+            "name": "No Steps",
+            "description": "Simple task",
+        })
+        assert resp.status_code == 201
+        assert resp.json()["steps"] == []
+
 
 class TestAgentGet:
 
@@ -83,9 +103,89 @@ class TestAgentUpdate:
         assert resp.json()["name"] == "New"
 
     @pytest.mark.asyncio
+    async def test_update_agent_status(self, client):
+        create = await client.post("/api/agents", json={"name": "S", "description": ""})
+        agent_id = create.json()["id"]
+        assert create.json()["status"] == "creating"
+        resp = await client.put(f"/api/agents/{agent_id}", json={"status": "ready"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
+    @pytest.mark.asyncio
     async def test_update_nonexistent_returns_404(self, client):
         resp = await client.put("/api/agents/nonexistent", json={"name": "X"})
         assert resp.status_code == 404
+
+
+class TestAgentUpdateTriggersForge:
+
+    @pytest.mark.asyncio
+    async def test_substantive_update_sets_status_updating(self, client, app):
+        """Updating description on a ready agent sets status to 'updating'."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "old"})
+        agent_id = create.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        resp = await client.put(f"/api/agents/{agent_id}", json={"description": "new desc"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "updating"
+
+    @pytest.mark.asyncio
+    async def test_cosmetic_update_keeps_status(self, client, app):
+        """Updating only name on a ready agent keeps the current status."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "d"})
+        agent_id = create.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        resp = await client.put(f"/api/agents/{agent_id}", json={"name": "NewName"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
+    @pytest.mark.asyncio
+    async def test_update_creating_agent_returns_409(self, client, app):
+        """Cannot update substantive fields while agent is still creating."""
+        # Create via repo to avoid background task changing status
+        agent = await app.state.agent_repo.create(name="T", description="d", status="creating")
+        agent_id = agent["id"]
+        resp = await client.put(f"/api/agents/{agent_id}", json={"description": "new"})
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "AGENT_BUSY"
+
+    @pytest.mark.asyncio
+    async def test_update_updating_agent_returns_409(self, client, app):
+        """Cannot update substantive fields while agent is already updating."""
+        agent = await app.state.agent_repo.create(name="T", description="d", status="updating")
+        agent_id = agent["id"]
+        resp = await client.put(f"/api/agents/{agent_id}", json={"description": "new"})
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "AGENT_BUSY"
+
+    @pytest.mark.asyncio
+    async def test_cosmetic_update_allowed_during_creating(self, client):
+        """Name-only update is allowed even when agent is creating."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "d"})
+        agent_id = create.json()["id"]
+        resp = await client.put(f"/api/agents/{agent_id}", json={"name": "NewName"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "NewName"
+
+    @pytest.mark.asyncio
+    async def test_samples_update_triggers_forge(self, client, app):
+        """Updating samples on a ready agent sets status to 'updating'."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "d"})
+        agent_id = create.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        resp = await client.put(f"/api/agents/{agent_id}", json={"samples": ["example"]})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "updating"
+
+    @pytest.mark.asyncio
+    async def test_steps_update_triggers_forge(self, client, app):
+        """Updating steps on a ready agent sets status to 'updating'."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "d"})
+        agent_id = create.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        resp = await client.put(f"/api/agents/{agent_id}", json={"steps": ["Step 1", "Step 2"]})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "updating"
 
 
 class TestAgentDelete:
@@ -104,15 +204,40 @@ class TestAgentDelete:
         resp = await client.delete("/api/agents/nonexistent")
         assert resp.status_code == 404
 
+    @pytest.mark.asyncio
+    async def test_delete_agent_removes_output_folder(self, client, app, tmp_path):
+        """Deleting an agent also removes its output folder."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "d"})
+        agent_id = create.json()["id"]
+        # Simulate forge having created an output folder
+        output_dir = tmp_path / agent_id
+        output_dir.mkdir()
+        (output_dir / "agentic.md").write_text("test")
+        await app.state.agent_repo.update(agent_id, forge_path=str(output_dir))
+
+        resp = await client.delete(f"/api/agents/{agent_id}")
+        assert resp.status_code == 204
+        assert not output_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_agent_no_forge_path_still_works(self, client):
+        """Deleting an agent with empty forge_path still succeeds."""
+        create = await client.post("/api/agents", json={"name": "T", "description": "d"})
+        agent_id = create.json()["id"]
+        resp = await client.delete(f"/api/agents/{agent_id}")
+        assert resp.status_code == 204
+
 
 class TestAgentRun:
 
     @pytest.mark.asyncio
-    async def test_run_agent_standalone(self, client):
+    async def test_run_agent_standalone(self, client, app):
         create = await client.post("/api/agents", json={
             "name": "T", "description": "do something",
         })
         agent_id = create.json()["id"]
+        # Agent starts as "creating"; set to "ready" via repo before running
+        await app.state.agent_repo.update(agent_id, status="ready")
         resp = await client.post(f"/api/agents/{agent_id}/run", json={
             "inputs": {"topic": "AI Safety"},
         })
@@ -122,14 +247,27 @@ class TestAgentRun:
         assert data["status"] == "queued"
 
     @pytest.mark.asyncio
+    async def test_run_agent_not_ready_returns_409(self, client):
+        create = await client.post("/api/agents", json={
+            "name": "T", "description": "do something",
+        })
+        agent_id = create.json()["id"]
+        # Agent is still "creating", should return 409
+        resp = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "AGENT_NOT_READY"
+
+    @pytest.mark.asyncio
     async def test_run_nonexistent_agent_returns_404(self, client):
         resp = await client.post("/api/agents/nonexistent/run", json={"inputs": {}})
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_list_agent_runs(self, client):
+    async def test_list_agent_runs(self, client, app):
         create = await client.post("/api/agents", json={"name": "T", "description": ""})
         agent_id = create.json()["id"]
+        # Set to ready so runs can be created
+        await app.state.agent_repo.update(agent_id, status="ready")
         await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         resp = await client.get(f"/api/agents/{agent_id}/runs")

--- a/api/tests/test_runs.py
+++ b/api/tests/test_runs.py
@@ -30,9 +30,11 @@ class TestProjectRuns:
 class TestRunGet:
 
     @pytest.mark.asyncio
-    async def test_get_run(self, client):
+    async def test_get_run(self, client, app):
         agent = await client.post("/api/agents", json={"name": "T", "description": ""})
-        run = await client.post(f"/api/agents/{agent.json()['id']}/run", json={"inputs": {}})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         run_id = run.json()["run_id"]
         resp = await client.get(f"/api/runs/{run_id}")
         assert resp.status_code == 200
@@ -47,19 +49,21 @@ class TestRunGet:
 class TestRunList:
 
     @pytest.mark.asyncio
-    async def test_list_runs(self, client):
+    async def test_list_runs(self, client, app):
         agent = await client.post("/api/agents", json={"name": "T", "description": ""})
-        tid = agent.json()["id"]
-        await client.post(f"/api/agents/{tid}/run", json={"inputs": {}})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         resp = await client.get("/api/runs")
         assert resp.status_code == 200
         assert len(resp.json()) >= 1
 
     @pytest.mark.asyncio
-    async def test_list_runs_filter_by_status(self, client):
+    async def test_list_runs_filter_by_status(self, client, app):
         agent = await client.post("/api/agents", json={"name": "T", "description": ""})
-        tid = agent.json()["id"]
-        await client.post(f"/api/agents/{tid}/run", json={"inputs": {}})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         resp = await client.get("/api/runs", params={"status": "queued"})
         assert resp.status_code == 200
         assert all(r["status"] == "queued" for r in resp.json())

--- a/api/tests/test_services.py
+++ b/api/tests/test_services.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from api.engine.providers import (
-    CLIAgentProvider, ProviderConfig, build_agent_prompt,
+    CLIAgentProvider, ProviderConfig, ProviderError, build_agent_prompt,
     load_provider_config, _load_providers_yaml,
 )
 from api.services.computer_use_service import ComputerUseService
@@ -185,6 +185,24 @@ class TestBuildAgentPrompt:
 
 class TestCLIAgentProvider:
 
+    def test_clean_env_strips_claudecode(self):
+        config = ProviderConfig(name="Test", command="echo", args=[])
+        provider = CLIAgentProvider(config)
+        os.environ["CLAUDECODE"] = "1"
+        try:
+            env = provider._clean_env()
+            assert "CLAUDECODE" not in env
+            assert "PATH" in env
+        finally:
+            del os.environ["CLAUDECODE"]
+
+    def test_clean_env_passes_through_normal_vars(self):
+        config = ProviderConfig(name="Test", command="echo", args=[])
+        provider = CLIAgentProvider(config)
+        env = provider._clean_env()
+        assert "HOME" in env
+        assert "PATH" in env
+
     def test_build_args_replaces_prompt(self):
         config = ProviderConfig(
             name="Test",
@@ -270,16 +288,21 @@ class TestCLIAgentProvider:
         assert result == '{"result": "done"}'
 
     @pytest.mark.asyncio
-    async def test_execute_raises_on_nonzero_exit(self):
-        """Non-zero exit code raises RuntimeError with stderr."""
+    async def test_execute_raises_provider_error_on_nonzero_exit(self):
+        """Non-zero exit code raises ProviderError with stdout, stderr, exit_code."""
         config = ProviderConfig(
-            name="False",
+            name="Fail",
             command="bash",
-            args=["-c", "echo {{prompt}} >&2; exit 1"],
+            args=["-c", "echo partial-output; echo {{prompt}} >&2; exit 1"],
         )
         provider = CLIAgentProvider(config)
-        with pytest.raises(RuntimeError, match="failed.*exit 1"):
+        with pytest.raises(ProviderError) as exc_info:
             await provider.execute("error msg")
+        err = exc_info.value
+        assert err.exit_code == 1
+        assert "partial-output" in err.stdout
+        assert "error msg" in err.stderr
+        assert "Fail" in str(err)
 
     @pytest.mark.asyncio
     async def test_execute_raises_on_timeout(self):
@@ -370,6 +393,214 @@ class TestComputerUseService:
         agent = {"id": "a1", "name": "T", "description": ""}
         result = await service.run_agent(agent, {}, callback)
         assert result["success"] is False
+
+
+class TestAgentService:
+
+    @pytest.mark.asyncio
+    async def test_create_agent_sets_creating_status(self, db):
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+
+        agent = await service.create_agent(name="Test", description="A test agent")
+        assert agent["status"] == "creating"
+        assert agent["name"] == "Test"
+
+    @pytest.mark.asyncio
+    async def test_run_forge_updates_agent_to_ready(self, db):
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+
+        forge_output = '{"result": "{\\"forge_path\\": \\"output/test/\\", \\"forge_config\\": {\\"complexity\\": \\"simple\\", \\"steps\\": 1, \\"prompts\\": [\\"01_Test.md\\"]}, \\"input_schema\\": [{\\"name\\": \\"topic\\", \\"type\\": \\"text\\", \\"required\\": true}], \\"output_schema\\": [{\\"name\\": \\"result\\", \\"type\\": \\"text\\"}]}"}'
+        provider.execute = AsyncMock(return_value=forge_output)
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Test", description="A test agent")
+        assert agent["status"] == "creating"
+
+        await service.run_forge(agent["id"])
+
+        updated = await agent_repo.get(agent["id"])
+        assert updated["status"] == "ready"
+        assert updated["forge_path"] == "output/test/"
+        assert updated["forge_config"]["complexity"] == "simple"
+        assert len(updated["input_schema"]) == 1
+        assert len(updated["output_schema"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_run_forge_passes_agent_id_to_provider(self, db):
+        """Forge prompt must include the agent ID so output goes to output/{id}/."""
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+
+        forge_output = '{"forge_path": "output/test/", "forge_config": {}, "input_schema": [], "output_schema": []}'
+        provider.execute = AsyncMock(return_value=forge_output)
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Test", description="A test agent")
+
+        await service.run_forge(agent["id"])
+
+        # Verify the prompt sent to forge includes the agent ID
+        call_args = provider.execute.call_args
+        prompt = call_args.kwargs.get("prompt") or call_args[1].get("prompt") or call_args[0][0]
+        assert agent["id"] in prompt
+
+    @pytest.mark.asyncio
+    async def test_run_forge_sets_error_on_failure(self, db):
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+        provider.execute = AsyncMock(side_effect=RuntimeError("forge crashed"))
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Test", description="A test agent")
+
+        await service.run_forge(agent["id"])
+
+        updated = await agent_repo.get(agent["id"])
+        assert updated["status"] == "error"
+        assert "forge crashed" in updated["forge_config"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_forge_stores_provider_error_details(self, db):
+        """When forge fails with ProviderError, store stdout, stderr, exit_code."""
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+        provider.execute = AsyncMock(
+            side_effect=ProviderError(
+                provider_name="Claude Code",
+                exit_code=1,
+                stdout="partial forge output here",
+                stderr="Error: something went wrong in forge",
+            )
+        )
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Test", description="A test agent")
+
+        await service.run_forge(agent["id"])
+
+        updated = await agent_repo.get(agent["id"])
+        assert updated["status"] == "error"
+        assert updated["forge_config"]["exit_code"] == 1
+        assert "partial forge output" in updated["forge_config"]["stdout"]
+        assert "something went wrong" in updated["forge_config"]["stderr"]
+        assert "Claude Code" in updated["forge_config"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_forge_parses_raw_json(self, db):
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+
+        # Raw JSON (not wrapped in Claude output format)
+        raw_json = '{"forge_path": "output/raw/", "forge_config": {"complexity": "simple", "steps": 1, "prompts": ["01_Agent.md"]}, "input_schema": [], "output_schema": []}'
+        provider.execute = AsyncMock(return_value=raw_json)
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Raw", description="test")
+
+        await service.run_forge(agent["id"])
+
+        updated = await agent_repo.get(agent["id"])
+        assert updated["status"] == "ready"
+        assert updated["forge_path"] == "output/raw/"
+
+    @pytest.mark.asyncio
+    async def test_run_update_sets_updating_then_ready(self, db):
+        """Substantive update triggers forge update and transitions updating → ready."""
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+
+        forge_output = '{"forge_path": "output/test/", "forge_config": {"complexity": "simple", "steps": 1, "prompts": ["01_Test.md"]}, "input_schema": [{"name": "topic", "type": "text", "required": true}], "output_schema": [{"name": "result", "type": "text"}]}'
+        provider.execute = AsyncMock(return_value=forge_output)
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Test", description="Original desc")
+        # Simulate agent already ready
+        await agent_repo.update(agent["id"], status="ready", forge_path="output/test/")
+
+        old_agent = await agent_repo.get(agent["id"])
+        # Route applies new fields + sets status=updating before calling run_update
+        await agent_repo.update(agent["id"], description="Updated desc", status="updating")
+
+        await service.run_update(
+            agent["id"],
+            old_agent=old_agent,
+            new_fields={"description": "Updated desc"},
+        )
+
+        updated = await agent_repo.get(agent["id"])
+        assert updated["status"] == "ready"
+        assert updated["description"] == "Updated desc"
+        provider.execute.assert_called_once()
+        # Verify the prompt references api-update.md
+        call_args = provider.execute.call_args
+        assert "api-update.md" in call_args.kwargs.get("prompt", call_args.args[0] if call_args.args else "")
+
+    @pytest.mark.asyncio
+    async def test_run_update_sets_error_on_failure(self, db):
+        """When forge update fails, status goes to error."""
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+        provider.execute = AsyncMock(side_effect=ProviderError(
+            provider_name="Claude Code", exit_code=1,
+            stdout="partial", stderr="update failed",
+        ))
+
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+        agent = await service.create_agent(name="Test", description="Original")
+        await agent_repo.update(agent["id"], status="ready", forge_path="output/test/")
+
+        await service.run_update(
+            agent["id"],
+            old_agent=await agent_repo.get(agent["id"]),
+            new_fields={"description": "New desc"},
+        )
+
+        updated = await agent_repo.get(agent["id"])
+        assert updated["status"] == "error"
+        assert updated["forge_config"]["exit_code"] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_update_nonexistent_agent(self, db):
+        """run_update on nonexistent agent logs error, doesn't crash."""
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+
+        await service.run_update("nonexistent-id", old_agent={}, new_fields={})
+        provider.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_forge_nonexistent_agent(self, db):
+        from api.persistence.repositories import AgentRepository
+        from api.services.agent_service import AgentService
+        agent_repo = AgentRepository(db)
+        provider = AsyncMock(spec=CLIAgentProvider)
+        service = AgentService(agent_repo=agent_repo, provider=provider)
+
+        # Should not raise, just log error
+        await service.run_forge("nonexistent-id")
+        provider.execute.assert_not_called()
 
 
 class TestExecutionService:

--- a/forge/agentic.md
+++ b/forge/agentic.md
@@ -22,55 +22,50 @@ Requirements   Architecture    Orchestrator    Agents       Commands     Scaffol
 
 ## Step 1: Gather Requirements
 
-**Purpose:** Understand what the user wants to automate and how.
+**Purpose:** Understand what the user wants to automate and what good output looks like.
 
-**On trigger, ask ONE question at a time. Wait for each response.**
+**Ask for the description first. Wait for the response before continuing.**
 
 Question 1:
 ```
-What is the purpose of this workflow? Describe what it should accomplish
-in 2-3 sentences.
+Describe the workflow you want to build. What should it accomplish?
 ```
 
-Question 2:
+**After receiving the description:**
+
+Analyze the description. Try to infer: the major phases of work, what inputs the workflow takes, what outputs it produces, whether desktop interaction is needed, and who will use it. If the description gives you enough to infer all of this, proceed directly to compiling the requirements summary without asking further questions.
+
+If the description is ambiguous about the process (you cannot tell what the major steps are or how the work flows), ask one follow-up:
+
 ```
-Who is the user of this workflow? (e.g., "me for personal use",
-"a team of developers", "students learning a topic")
+Can you describe the main steps or phases of the work? What does someone
+currently do manually that this workflow should handle?
 ```
 
-Question 3:
-```
-Describe the main steps or phases of the work. What does someone
-currently do manually that this workflow should automate or orchestrate?
-```
+Only ask this if you genuinely cannot infer the process from the description. Do not ask it as a formality.
 
-Question 4:
-```
-Are there any points where a human MUST review/approve before continuing?
-If yes, describe them.
-```
+**Optionally accept quality samples:**
 
-Question 5:
-```
-What are the expected outputs? Describe the files, folders, or artifacts
-this workflow should produce.
-```
+If the user wants to provide examples of what good output looks like, accept them. Each sample may include an optional short label describing what it shows. Quality samples are not required. If the user does not offer them, do not ask.
 
-Question 6:
-```
-Where should the generated workflow project be created?
-Default: output/{workflow-name}/
-```
+**Conventions (not questions):**
 
-Question 7:
-```
-Does this workflow need to interact with the desktop? For example: open
-applications, click buttons, fill forms, navigate GUIs, or automate
-tasks that require seeing the screen. If yes, describe what it needs to do.
-Default: No (generate-only workflow)
-```
+- Output location is always `output/{kebab-case-name}/`. Do not ask.
+- Computer use is a flag. If the description mentions desktop interaction (opening apps, clicking buttons, filling forms, navigating GUIs, automating tasks that require seeing the screen), set computer_use to true. Otherwise default to false. Do not ask.
+- Approval gates, user type, and output structure are determined in Step 2. Do not ask.
 
-**After all questions answered:** Compile a requirements summary. Present it to the user for confirmation.
+**Compile a requirements summary containing:**
+
+1. **Name.** A kebab-case name inferred from the description.
+2. **Purpose.** 2-3 sentences describing what the workflow accomplishes.
+3. **Steps (inferred).** The major phases of work as you understand them. Mark as "inferred" if not stated explicitly.
+4. **Inputs.** What the user provides to start the workflow.
+5. **Outputs.** Files, folders, or artifacts the workflow produces.
+6. **Computer use.** true or false, with the reason.
+7. **Quality samples.** Any provided examples (or "none").
+8. **Output location.** `output/{name}/`
+
+Present the summary to the user for confirmation.
 
 **Save:** Hold requirements summary in context for subsequent steps.
 
@@ -165,7 +160,7 @@ For each agent identified in Step 2:
    - Actual Input section with placeholders
    - Expected Workflow section
 2. Number the prompt files sequentially: `01_{Agent_Name}.md`, `02_{Agent_Name}.md`, etc.
-3. If the workflow needs desktop interaction (identified in Step 1, Question 7), generate a `05_Computer_Use_Agent.md` prompt based on `forge/Prompts/05_Computer_Use_Agent.md`. Adapt it to the specific workflow's desktop tasks.
+3. If the workflow needs desktop interaction (computer_use flag set in Step 1), generate a `05_Computer_Use_Agent.md` prompt based on `forge/Prompts/05_Computer_Use_Agent.md`. Adapt it to the specific workflow's desktop tasks.
 
 **Save:** `output/{workflow-name}/agent/Prompts/{NN}_{Agent_Name}.md` for each agent
 
@@ -364,7 +359,7 @@ The `agentic.md` file is the **single source of truth** for any workflow. Slash 
 
 | Step | Check |
 |------|-------|
-| 01 | All 6 questions answered? Requirements clear? |
+| 01 | Description provided? Steps inferred or clarified? Requirements summary confirmed? |
 | 02 | Architecture reviewed? Patterns identified? Agents listed? |
 | 03 | Orchestrator follows template? All steps present? Gates correct? |
 | 04 | All agents generated? Each has all required sections? |

--- a/forge/api-generate.md
+++ b/forge/api-generate.md
@@ -1,0 +1,302 @@
+# API Generate, Programmatic Agent Generation
+
+## Purpose
+
+This file is the non-interactive entry point for agent generation. The API calls this
+instead of `agentic.md` when it needs to generate an agent folder from structured input
+without human interaction.
+
+Invoke via:
+```
+claude -p "Read forge/api-generate.md and generate an agent from: {JSON}"
+```
+
+Where `{JSON}` is a JSON object conforming to the input format described below.
+
+---
+
+## Input Format
+
+Accept a JSON object with the following fields:
+
+```json
+{
+  "id": "optional-unique-id",
+  "name": "kebab-case-agent-name",
+  "description": "Plain-language description of what the agent should accomplish.",
+  "samples": [
+    {
+      "content": "Example of what good output looks like.",
+      "label": "Optional short label describing what this sample shows."
+    }
+  ],
+  "computer_use": false
+}
+```
+
+**Required:** `name`, `description`
+
+**Optional:** `id` (string, when provided use `output/{id}/` as the output folder instead of `output/{name}/`), `samples` (array, may be empty or omitted), `computer_use` (boolean, defaults to false)
+
+**Validation:**
+- If `name` is missing or empty, derive it from the description: take the first 4-5 significant words, lowercase, hyphens between words.
+- If `description` is missing or empty, write an error JSON to stdout and stop: `{"error": "description is required"}`.
+- `samples` items may be strings (treated as content with no label) or objects with `content` and optional `label` fields.
+- `computer_use` defaults to false if not provided.
+
+---
+
+## What This Orchestrator Does
+
+This orchestrator runs a focused subset of the full forge generation process:
+
+1. Analyze the description to determine complexity and steps.
+2. Design the agent architecture.
+3. Generate `agentic.md` for the agent.
+4. Generate agent prompt files.
+5. Write all files to `output/{name}/`.
+6. Print a structured JSON result to stdout.
+
+**Skipped (non-interactive mode):**
+- Interactive questions
+- Approval gates and user confirmation prompts
+- CLI command files (`.claude/commands/`)
+- Project scaffold files (README.md, CLAUDE.md)
+- Scripts and utils directories
+- Quality review step
+
+The output is a lean, runnable agent folder: an orchestrator and prompt files. That is
+all the execution service needs to run the agent.
+
+---
+
+## Step 1: Parse and Validate Input
+
+Read the JSON input provided after "generate an agent from:".
+
+Extract:
+- `id` (string, optional -- when present, use as the output folder name instead of `name`)
+- `name` (string, kebab-case)
+- `description` (string)
+- `samples` (array, may be empty)
+- `computer_use` (boolean, default false)
+
+Determine the output folder name: if `id` is present and non-empty, use `id`; otherwise use `name` (kebab-cased). Call this `folder_name` and use `output/{folder_name}/` as the output path throughout.
+
+If `description` is missing or empty:
+```json
+{"error": "description is required"}
+```
+Print this and stop.
+
+Normalize `name` to kebab-case if it is not already (lowercase, spaces to hyphens, remove special characters).
+
+**Hold the parsed input in context. Do not print anything to the user.**
+
+---
+
+## Step 2: Analyze Complexity
+
+**Read:** `forge/Prompts/02_Workflow_Architect.md`
+
+Analyze the description to determine:
+
+1. **Complexity level.** One of:
+   - `simple`: The task is a single, bounded operation. One step, one prompt. Example: "Summarize this text in bullet points."
+   - `multi_step`: The task has multiple phases that build on each other. 2-5 steps, 2-4 prompts. Example: "Research a topic and write a structured report."
+
+2. **Steps.** The major phases of the work (2-5 for multi-step, 1 for simple). Each step should produce one clear artifact.
+
+3. **Agent roster.** Which specialized agents are needed and what expertise each covers. Use the guidance in `forge/Prompts/02_Workflow_Architect.md`:
+   - Simple: 1 agent.
+   - Multi-step: 2-4 agents, each covering a distinct expertise area.
+   - Not every step needs an agent. Mechanical steps (file writing, format conversion) need none.
+
+4. **Input schema.** What inputs the agent needs when it runs. Infer from the description. Each input has a name and type (text, file, number, boolean).
+
+5. **Output schema.** What the agent produces. Infer from the description. Each output has a name and type.
+
+6. **Computer use.** Use the `computer_use` flag from the input. Do not infer from the description in API mode (the caller sets this explicitly).
+
+**Save in context:**
+```
+complexity: simple | multi_step
+steps: [{number, name, description, agent_name or null}]
+agents: [{name, role, expertise}]
+input_schema: [{name, type, required}]
+output_schema: [{name, type}]
+computer_use: true | false
+```
+
+---
+
+## Step 3: Generate the Agent Orchestrator
+
+**Read:** `forge/utils/scaffold/agentic.md.template`
+
+Generate `agentic.md` for the agent using the template as structural guide.
+
+**Rules for API-mode orchestrators:**
+
+- Remove the "After Each Step" approval protocol block entirely. The execution service does not wait for human approval.
+- Remove approval gate markers (⏸). Replace any gate steps with direct save-and-continue steps.
+- Keep the trigger commands section but use API-style triggers:
+  - `run {agent-name}`
+  - `execute {agent-name}`
+- Each step should have: a purpose description, which prompt to read (if applicable), numbered workflow actions, and a save directive.
+- The output structure should reference `output/{folder_name}/` paths.
+- Include the Quality Checks table.
+- If `computer_use` is true, include the Computer Use Configuration section from the template.
+
+**Generated orchestrators must be self-contained.** No references to `forge/`, `forge/patterns/`, or `forge/examples/`. The agent folder must work without Agent Forge installed.
+
+**Save:** `output/{folder_name}/agentic.md`
+
+---
+
+## Step 4: Generate Agent Prompts
+
+**Read:** `forge/Prompts/03_Prompt_Writer.md`
+**Read:** `forge/utils/scaffold/agent-prompt.md.template`
+
+For complex or domain-specific prompts, also read `forge/Prompts/01_Senior_Prompt_Engineer.md` for craft guidance.
+
+For each agent in the roster from Step 2:
+
+1. Generate a complete prompt following the canonical template:
+   - Context (role and expertise, 2-4 sentences, second person)
+   - Input and Outputs (concrete, specific, measurable)
+   - Quality Requirements (numerical thresholds where possible)
+   - Clarifications (if the domain benefits from it)
+   - Quality Examples (good and bad samples, if the domain benefits from it)
+   - Rules (Always/Never, at least 3 each, actionable behaviors)
+   - Actual Input (placeholders matching what the orchestrator passes)
+   - Expected Workflow (numbered list, starts with input validation)
+
+2. If `computer_use` is true, also generate a Computer Use Agent prompt based on `forge/Prompts/05_Computer_Use_Agent.md`. Adapt it to the specific desktop tasks described.
+
+3. Calibrate prompts against quality samples if provided. For each sample:
+   - Read the content and label.
+   - Identify the patterns, structure, tone, and level of detail that characterize it.
+   - Add Quality Requirements and Quality Examples to the relevant prompt(s) that encode these characteristics concretely. Do not copy the sample verbatim into the prompt. Extract what makes it good and express that as a rule or requirement.
+
+4. Number prompt files sequentially: `01_{Agent_Name}.md`, `02_{Agent_Name}.md`, etc.
+
+**Save:** `output/{folder_name}/agent/Prompts/{NN}_{Agent_Name}.md` for each agent
+
+---
+
+## Step 5: Write Output and Return JSON
+
+Create the output directory structure:
+
+```
+output/{folder_name}/
+├── agentic.md
+└── agent/
+    └── Prompts/
+        ├── 01_{Agent_Name}.md
+        └── ...
+```
+
+Write all files. Do not create scripts/, utils/, README.md, CLAUDE.md, or .claude/ directories. Those are for the interactive forge flow.
+
+After writing all files, print a single JSON object to stdout. This is the only output the API reads.
+
+```json
+{
+  "forge_path": "output/{folder_name}/",
+  "forge_config": {
+    "complexity": "simple | multi_step",
+    "steps": 1,
+    "prompts": ["01_Agent_Name.md"]
+  },
+  "input_schema": [
+    { "name": "input_name", "type": "text", "required": true }
+  ],
+  "output_schema": [
+    { "name": "output_name", "type": "text" }
+  ]
+}
+```
+
+**Field definitions:**
+
+- `forge_path`: Relative path to the generated agent folder from the repo root.
+- `forge_config.complexity`: `"simple"` or `"multi_step"`.
+- `forge_config.steps`: Number of steps in the generated `agentic.md`.
+- `forge_config.prompts`: List of generated prompt filenames in `agent/Prompts/`.
+- `input_schema`: Inferred inputs the agent needs at runtime. Each item has `name`, `type` (one of: `text`, `file`, `number`, `boolean`), and `required` (boolean).
+- `output_schema`: Inferred outputs the agent produces. Each item has `name` and `type`.
+
+Print only this JSON object. No preamble, no summary, no explanation. The API parses this directly.
+
+---
+
+## Quality Standards
+
+Generated agents must meet the same quality bar as agents created interactively through `agentic.md`.
+
+**Orchestrators:**
+- Each step has a purpose, numbered actions, and a save directive.
+- Steps are atomic (one phase of work per step).
+- The output structure diagram matches the actual files generated.
+- No references to files outside the agent folder.
+
+**Prompts:**
+- All required sections present (Context, Input/Output, Quality Requirements, Rules, Actual Input, Expected Workflow).
+- Context is specific (expertise, not generic "AI assistant").
+- Quality Requirements use measurable thresholds.
+- Rules are actionable behaviors, not aspirations.
+- Actual Input placeholders match what the orchestrator passes at runtime.
+- No emojis, no em-dashes, no AI attribution.
+- Plain English throughout.
+
+**Self-containment:**
+- The generated agent folder must work without Agent Forge installed.
+- No references to `forge/`, `forge/patterns/`, or `forge/examples/` inside the generated files.
+
+---
+
+## Clarifications
+
+### Simple vs Multi-Step
+
+When in doubt, prefer simple. A simple one-step agent with a well-written prompt delivers
+more reliably than a multi-step agent with unnecessary phases.
+
+Good signals for multi-step:
+- The description implies distinct phases that each require different expertise (research, then write, then review).
+- The output of one phase is the input to the next in a meaningful way.
+- A single prompt would need to hold too much context at once.
+
+Good signals for simple:
+- The task is a bounded transformation (input X produces output Y).
+- One area of expertise covers the whole task.
+- The description fits in a single, clear prompt.
+
+### Calibrating From Samples
+
+Quality samples are calibration signals, not templates to copy. When a sample is provided:
+
+- Identify structural patterns: Does it use specific section headers? A particular list format? A fixed length?
+- Identify quality signals: What makes this sample good? Level of detail, citation style, specific terminology?
+- Encode these as rules or Quality Requirements in the relevant prompt.
+
+Do not add a "Quality Examples" section to a prompt that pastes the user's sample verbatim. Instead, derive the principles from the sample and express them as measurable criteria.
+
+### Naming Conventions
+
+Follow the same naming conventions as the full forge flow:
+- Agent folder: when `id` is provided, use the `id`; otherwise kebab-case matching the `name` field.
+- Prompt files: zero-padded with underscores (`01_Research_Analyst.md`).
+- Step names in agentic.md: Title Case.
+- Output files produced by the agent: lowercase with hyphens or numbered prefixes.
+
+### Computer Use in API Mode
+
+When `computer_use` is true, include a Computer Use Agent prompt based on
+`forge/Prompts/05_Computer_Use_Agent.md`. Adapt the desktop task description from the
+agent description. Include the Computer Use Configuration section in `agentic.md`.
+
+List `05_Computer_Use_Agent.md` in `forge_config.prompts` in the JSON output.

--- a/forge/api-update.md
+++ b/forge/api-update.md
@@ -1,0 +1,443 @@
+# API Update, Programmatic Agent Update
+
+## Purpose
+
+This file is the non-interactive entry point for updating an existing agent workflow.
+The API calls this instead of `api-generate.md` when requirements change on an agent
+that already has a generated folder at `forge_path`.
+
+Invoke via:
+```
+claude -p "Read forge/api-update.md and update an existing agent from: {JSON}"
+```
+
+Where `{JSON}` is a JSON object conforming to the input format described below.
+
+---
+
+## Input Format
+
+Accept a JSON object with the following fields:
+
+```json
+{
+  "forge_path": "output/agent-name/",
+  "original": {
+    "name": "agent-name",
+    "description": "Original description used when the agent was created.",
+    "samples": [],
+    "computer_use": false
+  },
+  "updated": {
+    "description": "New description reflecting changed requirements.",
+    "samples": ["new sample"],
+    "computer_use": true
+  }
+}
+```
+
+**Required:** `forge_path`, `original.name`, `updated` (at least one field inside it)
+
+**Optional fields inside `updated`:** Any subset of `description`, `samples`, `computer_use`.
+Only include the fields that changed. Fields absent from `updated` are treated as unchanged.
+
+**Validation:**
+- If `forge_path` is missing or empty, write an error JSON to stdout and stop:
+  `{"error": "forge_path is required"}`
+- If `original.name` is missing or empty, write an error JSON to stdout and stop:
+  `{"error": "original.name is required"}`
+- If `updated` is missing or empty (no fields changed), write an error JSON to stdout and stop:
+  `{"error": "updated must contain at least one changed field"}`
+- If the directory at `forge_path` does not exist, write an error JSON to stdout and stop:
+  `{"error": "forge_path does not exist: output/agent-name/"}`
+- `samples` items may be strings (treated as content with no label) or objects with
+  `content` and optional `label` fields. This matches the format used by `api-generate.md`.
+
+---
+
+## What This Orchestrator Does
+
+This orchestrator reads an existing agent folder, computes what changed, and applies
+targeted edits. It does not regenerate from scratch unless the change requires it.
+
+1. Parse and validate input.
+2. Read the existing workflow files at `forge_path`.
+3. Diff the original fields against the updated fields.
+4. Classify the change as a patch or a full regeneration.
+5. Apply the update: patch affected files, or regenerate if needed.
+6. Print a structured JSON result to stdout.
+
+**Skipped (non-interactive mode):**
+- Interactive questions
+- Approval gates and user confirmation prompts
+- CLI command files (`.claude/commands/`)
+- Project scaffold files (README.md, CLAUDE.md)
+- Scripts and utils directories
+- Quality review step
+
+The output is the same JSON format as `api-generate.md`. The API handles both responses
+identically.
+
+---
+
+## Step 1: Parse and Validate Input
+
+Read the JSON input provided after "update an existing agent from:".
+
+Extract:
+- `forge_path` (string, path to the existing agent folder)
+- `original` (object with `name`, `description`, `samples`, `computer_use`)
+- `updated` (object with any subset of `description`, `samples`, `computer_use`)
+
+Run validation in this order:
+
+1. If `forge_path` is missing or empty:
+   ```json
+   {"error": "forge_path is required"}
+   ```
+   Print this and stop.
+
+2. If `original.name` is missing or empty:
+   ```json
+   {"error": "original.name is required"}
+   ```
+   Print this and stop.
+
+3. If `updated` is missing or has no keys:
+   ```json
+   {"error": "updated must contain at least one changed field"}
+   ```
+   Print this and stop.
+
+4. If the directory at `forge_path` does not exist on disk:
+   ```json
+   {"error": "forge_path does not exist: <value>"}
+   ```
+   Print this and stop.
+
+Build a change set: a list of field names that differ between `original` and `updated`.
+For each field in `updated`, compare its value to the same field in `original`.
+
+**Comparison rules:**
+- `description`: strings differ if they are not identical.
+- `samples`: arrays differ if their length or any item content differs.
+- `computer_use`: booleans differ if one is true and the other is false.
+
+**Hold the parsed input and change set in context. Do not print anything to the user.**
+
+---
+
+## Step 2: Read Existing Workflow Files
+
+Read every file in the existing agent folder at `forge_path`:
+
+1. Read `{forge_path}/agentic.md`. This is required. If it does not exist, stop:
+   ```json
+   {"error": "agentic.md not found at forge_path"}
+   ```
+
+2. List all files under `{forge_path}/agent/Prompts/`. Read each one.
+   If the directory does not exist or is empty, note this. It is not a hard error,
+   but it means there are no prompts to patch.
+
+**Hold the file contents in context.**
+
+**While reading, note:**
+- How many steps the orchestrator has.
+- Which agent prompts exist and what their numbered names are.
+- Whether `computer_use` is already configured (look for a Computer Use Configuration
+  section in `agentic.md` or a `05_Computer_Use_Agent.md` prompt file).
+- The current complexity: `simple` (1 step, 1 prompt) or `multi_step` (2+ steps).
+
+---
+
+## Step 3: Classify the Change
+
+Use the change set from Step 1 and the existing workflow state from Step 2 to decide
+whether to patch or fully regenerate.
+
+### Patch (targeted edits to existing files)
+
+Apply a patch when the change is additive or refinable within the current structure:
+
+- Only `description` changed, and the new description implies the same number of steps
+  and the same areas of expertise as the original.
+- Only `samples` changed (new or updated calibration examples).
+- `computer_use` changed from false to true, and the existing structure is otherwise
+  valid (orchestrator and at least one prompt exist).
+- `computer_use` changed from true to false.
+- A combination of the above.
+
+A description change is safe to patch when:
+- The original and updated descriptions both imply the same complexity level
+  (`simple` or `multi_step`).
+- The core task is the same but the wording, scope, or domain has shifted moderately.
+- No new phases of work appear that would require a new step or a new agent.
+
+### Full Regeneration
+
+Regenerate the entire agent folder (using the same approach as `api-generate.md`) when:
+
+- The updated description implies a different complexity level than the original
+  (e.g., a single-step task becomes a multi-step workflow, or a multi-step workflow
+  collapses to a single step).
+- The updated description introduces fundamentally different phases of work that
+  require new agents not present in the current roster.
+- The existing files are structurally broken: `agentic.md` is missing required sections,
+  fewer than the expected number of prompt files exist, or cross-references are broken.
+
+**When in doubt, patch.** A patch that is slightly too conservative is safer than a
+regeneration that discards existing customizations. Only regenerate when the gap between
+the original and updated requirements is large enough that patching would require
+rewriting more than half of every affected file.
+
+**Save in context:**
+```
+update_mode: patch | regenerate
+change_set: [list of changed field names]
+affected_files: [list of files that need changes]
+```
+
+---
+
+## Step 4: Apply the Update
+
+### If update_mode is patch
+
+Apply targeted edits to each affected file. Do not touch files that are not affected
+by the change set.
+
+**Description changed:**
+
+1. Read the existing agent prompt(s) in `{forge_path}/agent/Prompts/`.
+2. Identify sections that are driven by the description: Context, Actual Input,
+   Expected Workflow, and (if present) Quality Requirements.
+3. Rewrite only those sections to reflect the updated description.
+   Keep all other sections (Rules, Quality Examples, Clarifications) intact unless
+   they directly contradict the new description.
+4. In `agentic.md`, update the step purpose lines and any narrative text that
+   references the original description. Do not change the step count or structure.
+
+**Samples changed:**
+
+Read the updated samples. For each sample:
+- Identify the patterns, structure, tone, and level of detail that characterize it.
+- Express these as updated Quality Requirements or Quality Examples in the relevant
+  prompt(s).
+- Do not copy the sample verbatim into the prompt. Derive the principles and express
+  them as measurable criteria.
+
+If samples were removed (present in `original.samples` but absent from `updated.samples`),
+remove only the Quality Requirements and Quality Examples that were derived from
+those specific samples. Keep any requirements that reflect general quality standards.
+
+**`computer_use` changed from false to true:**
+
+1. Read `forge/Prompts/05_Computer_Use_Agent.md`.
+2. Generate a Computer Use Agent prompt adapted to the agent's description.
+   Save it as `{forge_path}/agent/Prompts/05_Computer_Use_Agent.md`.
+3. Add a Computer Use Configuration section to `{forge_path}/agentic.md`.
+   Place it after the last step and before the Quality Checks table.
+
+**`computer_use` changed from true to false:**
+
+1. Delete `{forge_path}/agent/Prompts/05_Computer_Use_Agent.md` if it exists.
+2. Remove the Computer Use Configuration section from `{forge_path}/agentic.md`.
+
+**Multiple fields changed:**
+
+Apply each change in the order listed above. After all changes are applied, do a
+consistency pass: verify that cross-references between `agentic.md` and the prompt
+files are intact.
+
+### If update_mode is regenerate
+
+Run the same process as `api-generate.md` Steps 2 through 4, using the updated fields
+as the input. Use `original.name` as the agent name (do not rename the folder).
+
+Write the new files to `{forge_path}`, overwriting the existing files. Do not create
+scripts/, utils/, README.md, CLAUDE.md, or .claude/ directories.
+
+---
+
+## Step 5: Write Output and Return JSON
+
+After all files are written, print a single JSON object to stdout. This is the only
+output the API reads.
+
+```json
+{
+  "forge_path": "output/{name}/",
+  "forge_config": {
+    "complexity": "simple | multi_step",
+    "steps": 1,
+    "prompts": ["01_Agent_Name.md"]
+  },
+  "input_schema": [
+    { "name": "input_name", "type": "text", "required": true }
+  ],
+  "output_schema": [
+    { "name": "output_name", "type": "text" }
+  ]
+}
+```
+
+This format is identical to the output of `api-generate.md`. The API handles both
+responses the same way.
+
+**Field definitions:**
+
+- `forge_path`: The value from the input `forge_path` field, unchanged.
+- `forge_config.complexity`: The complexity of the workflow after the update
+  (`"simple"` or `"multi_step"`).
+- `forge_config.steps`: Number of steps in `agentic.md` after the update.
+- `forge_config.prompts`: List of prompt filenames in `agent/Prompts/` after the
+  update, reflecting any additions or removals.
+- `input_schema`: Inferred inputs the agent needs at runtime. Derive from the updated
+  description. Each item has `name`, `type` (one of: `text`, `file`, `number`,
+  `boolean`), and `required` (boolean).
+- `output_schema`: Inferred outputs the agent produces. Derive from the updated
+  description. Each item has `name` and `type`.
+
+Print only this JSON object. No preamble, no summary, no explanation. The API parses
+this directly.
+
+---
+
+## Quality Standards
+
+Updated agents must meet the same quality bar as agents created through `api-generate.md`.
+
+**Patch quality:**
+- Only files in the change set are touched.
+- All required prompt sections remain present after the patch (Context, Input/Output,
+  Quality Requirements, Rules, Actual Input, Expected Workflow).
+- Cross-references between `agentic.md` and prompt files are intact after the patch.
+- Existing customizations in unaffected sections are preserved exactly.
+
+**Regeneration quality:**
+- All standards from `api-generate.md` Quality Standards apply.
+- The agent name and `forge_path` are preserved. The folder is not renamed.
+
+**Self-containment (both modes):**
+- The updated agent folder must work without Agent Forge installed.
+- No references to `forge/`, `forge/patterns/`, or `forge/examples/` inside the
+  generated files.
+
+---
+
+## Clarifications
+
+### Patch vs Regeneration Decision Examples
+
+**Patch (description change, same complexity):**
+
+Original: "Summarize customer support tickets into bullet points."
+Updated: "Summarize customer support tickets into bullet points, grouping related
+issues by category and flagging urgent ones."
+
+The task is still a single-step summarization. The added requirements (grouping,
+flagging) affect what the prompt must instruct the agent to do, not how many steps
+or agents exist. Patch the Context, Quality Requirements, and Expected Workflow
+sections of the existing prompt.
+
+**Regenerate (description change, complexity shift):**
+
+Original: "Summarize customer support tickets into bullet points."
+Updated: "Analyze customer support tickets, identify root causes, and produce a
+weekly trend report with recommendations for the support team."
+
+The updated description implies three distinct phases (analyze, identify trends,
+write recommendations) that each require different expertise. The original single-step
+structure cannot accommodate this. Regenerate.
+
+**Patch (computer_use added):**
+
+Original `computer_use`: false
+Updated `computer_use`: true
+
+The workflow logic does not change. Add the Computer Use Agent prompt and the
+configuration section in `agentic.md`. All other files stay the same.
+
+**Patch (samples updated, nothing else):**
+
+The agent description and structure are unchanged. New samples refine the quality
+expectations. Update Quality Requirements and Quality Examples in the affected
+prompt(s) to reflect what the new samples demonstrate. No structural changes.
+
+### Preserving Existing Customizations
+
+When patching, treat each prompt section as independently owned. A section that is
+not driven by a changed field must not be modified, even if you think it could be
+improved. The minimal fix principle applies: change only what the updated requirements
+require.
+
+If a section is both affected by the change and contains customizations that are still
+valid, keep the customizations and add or modify only the parts that the change requires.
+
+### Deriving Input and Output Schema After an Update
+
+After a patch, re-derive the `input_schema` and `output_schema` from the updated
+description. Do not copy the original schema forward if the description changed. The
+schema reflects what the agent needs at runtime, which may shift even for moderate
+description changes.
+
+After a regeneration, the schema is derived fresh from the updated description,
+following the same rules as `api-generate.md` Step 2.
+
+### Naming Conventions
+
+Follow the same conventions as `api-generate.md`:
+- Agent folder: kebab-case, matches `original.name`. Never rename the folder.
+- Prompt files: zero-padded with underscores (`01_Research_Analyst.md`).
+- Step names in `agentic.md`: Title Case.
+- Output files produced by the agent: lowercase with hyphens or numbered prefixes.
+
+### Computer Use in Patch Mode
+
+When adding computer use to an existing agent, adapt the Computer Use Agent prompt
+to the specific desktop tasks described in the updated description. Do not use a
+generic Computer Use prompt. Read `forge/Prompts/05_Computer_Use_Agent.md` for the
+structural template, then tailor it to the agent's domain.
+
+---
+
+## Actual Input
+
+**UPDATE REQUEST:**
+```json
+{
+  "forge_path": "[Path to the existing agent folder, e.g., output/ticket-summarizer/]",
+  "original": {
+    "name": "[Agent name in kebab-case, e.g., ticket-summarizer]",
+    "description": "[Original description used when the agent was created]",
+    "samples": [],
+    "computer_use": false
+  },
+  "updated": {
+    "description": "[New description reflecting changed requirements, if changed]",
+    "samples": ["[New sample content, if samples changed]"],
+    "computer_use": true
+  }
+}
+```
+
+---
+
+## Expected Workflow
+
+1. Read the JSON input provided after "update an existing agent from:".
+2. Validate all required fields. If any validation fails, print the error JSON and stop.
+3. Build the change set: list the fields that differ between `original` and `updated`.
+4. Read `{forge_path}/agentic.md` and all prompt files in `{forge_path}/agent/Prompts/`.
+5. Classify the change as patch or regeneration using the rules in Step 3.
+6. If patch: identify the specific files and sections affected by each changed field.
+7. If patch: apply targeted edits to each affected file. Leave unaffected files and
+   sections untouched.
+8. If regenerate: run the full generation process from `api-generate.md` Steps 2
+   through 4, using the updated fields and `original.name` as the agent name.
+   Overwrite existing files at `forge_path`.
+9. Run a consistency pass: verify that all cross-references between `agentic.md` and
+   prompt files are intact. Verify that all required prompt sections are present.
+10. Derive the `input_schema` and `output_schema` from the updated description.
+11. Print the output JSON to stdout. No other output.


### PR DESCRIPTION
## Summary

- Implement agent creation/update flows with background forge generation via `agent_service.py`
- Add run execution service for standalone agent runs with output capture
- Use agent ID for output folder naming (`output/{id}/`) for reliable cleanup on delete
- Delete endpoint removes output folder via `forge_path` before DB record deletion
- Add `forge/api-generate.md` and `forge/api-update.md` orchestrator specs
- Update Postman collection with 29 E2E tests including forge_path verification
- Update architecture docs (API_ARCHITECTURE.md, PHASE_A_AGENTS.md)

## Test plan

- [x] 145 unit tests passing
- [x] 27/29 Postman E2E tests passing (2 cancel-run timing failures are pre-existing)
- [x] Review forge generation end-to-end with real Claude provider
- [x] Verify delete cleanup removes output folders correctly in production