### PR TITLE
Add copyright headers and update licensing attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 The Agent Forge Authors
+   Copyright 2026 Victor Santiago Montaño Diaz
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,9 @@
 Agent Forge
-Copyright 2026 The Agent Forge Authors
+Copyright 2026 Victor Santiago Montaño Diaz
 
-This product includes software developed by the Agent Forge project
-contributors (https://github.com/agent-forge/agent-forge).
+Agent Forge is an agent-agnostic meta-framework for creating agentic workflows.
+It includes a desktop automation engine for autonomous computer use.
+
+https://github.com/santiagomd11/Agent-Forge
 
 Licensed under the Apache License, Version 2.0.

--- a/computer_use/core/actions.py
+++ b/computer_use/core/actions.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Abstract action execution interface."""
 
 import time

--- a/computer_use/core/engine.py
+++ b/computer_use/core/engine.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Main engine facade -- the public API for the computer use engine."""
 
 import logging

--- a/computer_use/core/loop.py
+++ b/computer_use/core/loop.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The autonomous execution loop: screenshot -> decide -> act -> verify."""
 
 import logging

--- a/computer_use/core/screenshot.py
+++ b/computer_use/core/screenshot.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Abstract screenshot capture interface."""
 
 from abc import ABC, abstractmethod

--- a/computer_use/core/smooth_move.py
+++ b/computer_use/core/smooth_move.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Platform-agnostic smooth mouse movement using WindMouse + Fitts's Law.
 
 Pure math -- no platform imports. Callers inject their own move primitive

--- a/computer_use/core/spatial_cache.py
+++ b/computer_use/core/spatial_cache.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Muscle memory cache: SQLite + R-Tree spatial index.
 
 Learns from repeated mouse interactions so familiar UI targets are reached

--- a/computer_use/grounding/accessibility.py
+++ b/computer_use/grounding/accessibility.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """OS accessibility API element locator."""
 
 import logging

--- a/computer_use/grounding/base.py
+++ b/computer_use/grounding/base.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Abstract element locator interface."""
 
 from abc import ABC, abstractmethod

--- a/computer_use/grounding/hybrid.py
+++ b/computer_use/grounding/hybrid.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Hybrid element locator: accessibility-first, vision fallback."""
 
 import logging

--- a/computer_use/grounding/vision.py
+++ b/computer_use/grounding/vision.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """LLM vision-based element locator (fallback when accessibility API fails)."""
 
 import logging

--- a/computer_use/platform/base.py
+++ b/computer_use/platform/base.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Abstract platform backend combining screenshot and action capabilities."""
 
 from abc import ABC, abstractmethod

--- a/computer_use/platform/detect.py
+++ b/computer_use/platform/detect.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Platform detection logic."""
 
 import os

--- a/computer_use/platform/linux.py
+++ b/computer_use/platform/linux.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Linux platform backend. Supports X11 (mss/xdotool) and Wayland (Mutter RemoteDesktop/evdev)."""
 
 import io

--- a/computer_use/platform/macos.py
+++ b/computer_use/platform/macos.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """macOS platform backend using screencapture and osascript/cliclick."""
 
 import io

--- a/computer_use/platform/windows.py
+++ b/computer_use/platform/windows.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Windows native platform backend using ctypes for direct Win32 API access."""
 
 import ctypes

--- a/computer_use/platform/wsl2.py
+++ b/computer_use/platform/wsl2.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """WSL2 platform backend using PowerShell bridge to control Windows desktop."""
 
 import atexit

--- a/computer_use/providers/anthropic.py
+++ b/computer_use/providers/anthropic.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Anthropic Claude vision provider."""
 
 import base64

--- a/computer_use/providers/base.py
+++ b/computer_use/providers/base.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Abstract LLM vision provider interface."""
 
 from abc import ABC, abstractmethod

--- a/computer_use/providers/openai.py
+++ b/computer_use/providers/openai.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """OpenAI GPT-4o vision provider."""
 
 import base64

--- a/computer_use/providers/registry.py
+++ b/computer_use/providers/registry.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Victor Santiago Montaño Diaz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Provider factory and registry."""
 
 import importlib

--- a/forge/Prompts/00_Workflow_Fixer.md
+++ b/forge/Prompts/00_Workflow_Fixer.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 ---
 name: workflow-fixer
 description: |

--- a/forge/Prompts/01_Senior_Prompt_Engineer.md
+++ b/forge/Prompts/01_Senior_Prompt_Engineer.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 # Senior Prompt Engineer
 
 ## Context

--- a/forge/Prompts/02_Workflow_Architect.md
+++ b/forge/Prompts/02_Workflow_Architect.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 ---
 name: workflow-architect
 description: |

--- a/forge/Prompts/03_Prompt_Writer.md
+++ b/forge/Prompts/03_Prompt_Writer.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 ---
 name: prompt-writer
 description: |

--- a/forge/Prompts/04_Quality_Reviewer.md
+++ b/forge/Prompts/04_Quality_Reviewer.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 ---
 name: quality-reviewer
 description: |

--- a/forge/Prompts/05_Computer_Use_Agent.md
+++ b/forge/Prompts/05_Computer_Use_Agent.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 # Computer Use Agent
 
 ## Context

--- a/forge/agentic.md
+++ b/forge/agentic.md
@@ -1,3 +1,6 @@
+<!-- Copyright 2026 Victor Santiago Montaño Diaz
+     Licensed under the Apache License, Version 2.0 -->
+
 # Agent Forge, Meta-Workflow Orchestrator
 
 ## Trigger Commands


### PR DESCRIPTION
## Summary

- Update LICENSE copyright from "The Agent Forge Authors" to "Victor Santiago Montano Diaz"
- Update NOTICE file with author name, project description, and repo link
- Add Apache 2.0 copyright headers to all 20 core Python source files (computer_use/)
- Add copyright comment headers to all 7 forge prompt/orchestrator markdown files

## Files changed (29)

- `LICENSE` - copyright line updated
- `NOTICE` - full rewrite with author attribution
- `computer_use/core/*.py` (6 files) - copyright header added
- `computer_use/platform/*.py` (6 files) - copyright header added
- `computer_use/grounding/*.py` (4 files) - copyright header added
- `computer_use/providers/*.py` (4 files) - copyright header added
- `forge/agentic.md` + `forge/Prompts/*.md` (7 files) - copyright comment added