### PR TITLE
Per-step computer use, forge pipeline fixes, run timeout fixes

### DIFF
--- a/api/Agent_Forge_API.postman_collection.json
+++ b/api/Agent_Forge_API.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Agent Forge API",
-    "description": "E2E test suite for the Agent Forge API.\n\nRun order matters -- requests use collection variables set by earlier requests.\n\nFlow: Health -> Create Agent -> Poll Ready -> Get -> Cosmetic Update -> Substantive Update -> Poll Updated -> Busy Update (409) -> Run Agent -> List Runs -> List Agents -> Minimal Create -> Validation Tests -> Delete Tests -> Runs -> Computer Use.",
+    "description": "E2E test suite for the Agent Forge API.\n\nRun order matters -- requests use collection variables set by earlier requests.\n\nFlow: Providers -> Health -> Create Agent -> Poll Ready -> Get -> Cosmetic Update -> Substantive Update -> Poll Updated -> Busy Update (409) -> Run Agent -> List Runs -> List Agents -> Minimal Create -> Validation Tests -> Delete Tests -> Runs -> Computer Use.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -39,6 +39,67 @@
     }
   ],
   "item": [
+    {
+      "name": "Providers",
+      "item": [
+        {
+          "name": "List Providers",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/providers"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "",
+                  "pm.test('Returns non-empty array', function() {",
+                  "    pm.expect(json).to.be.an('array');",
+                  "    pm.expect(json.length).to.be.at.least(1);",
+                  "});",
+                  "",
+                  "pm.test('Each provider has id, name, and models', function() {",
+                  "    json.forEach(function(p) {",
+                  "        pm.expect(p).to.have.property('id');",
+                  "        pm.expect(p).to.have.property('name');",
+                  "        pm.expect(p).to.have.property('models');",
+                  "        pm.expect(p.models).to.be.an('array');",
+                  "    });",
+                  "});",
+                  "",
+                  "pm.test('Claude Code provider exists with models', function() {",
+                  "    var cc = json.find(function(p) { return p.id === 'claude_code'; });",
+                  "    pm.expect(cc).to.not.be.undefined;",
+                  "    pm.expect(cc.name).to.eql('Claude Code');",
+                  "    pm.expect(cc.models.length).to.be.at.least(1);",
+                  "    var modelIds = cc.models.map(function(m) { return m.id; });",
+                  "    pm.expect(modelIds).to.include('claude-sonnet-4-6');",
+                  "});",
+                  "",
+                  "pm.test('Each model has id and name', function() {",
+                  "    json.forEach(function(p) {",
+                  "        p.models.forEach(function(m) {",
+                  "            pm.expect(m).to.have.property('id');",
+                  "            pm.expect(m).to.have.property('name');",
+                  "            pm.expect(m.id.length).to.be.above(0);",
+                  "            pm.expect(m.name.length).to.be.above(0);",
+                  "        });",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
     {
       "name": "Health",
       "item": [
@@ -126,8 +187,8 @@
                   "    pm.expect(json.type).to.eql('agent');",
                   "});",
                   "",
-                  "pm.test('Agent status is creating', function() {",
-                  "    pm.expect(json.status).to.eql('creating');",
+                  "pm.test('Agent status is ready', function() {",
+                  "    pm.expect(json.status).to.eql('ready');",
                   "});",
                   "",
                   "pm.test('Agent has timestamps', function() {",
@@ -395,13 +456,22 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
+                  "// Create agent then immediately send a substantive update to put it in 'updating' state",
                   "pm.sendRequest({",
                   "    url: pm.collectionVariables.get('base_url') + '/api/agents',",
                   "    method: 'POST',",
                   "    header: { 'Content-Type': 'application/json' },",
-                  "    body: { mode: 'raw', raw: JSON.stringify({ name: 'Busy Agent', description: 'Still creating' }) }",
+                  "    body: { mode: 'raw', raw: JSON.stringify({ name: 'Busy Agent', description: 'Will be busy' }) }",
                   "}, function(err, res) {",
-                  "    pm.collectionVariables.set('busy_agent_id', res.json().id);",
+                  "    var agentId = res.json().id;",
+                  "    pm.collectionVariables.set('busy_agent_id', agentId);",
+                  "    // Trigger a substantive update to put the agent into 'updating' status",
+                  "    pm.sendRequest({",
+                  "        url: pm.collectionVariables.get('base_url') + '/api/agents/' + agentId,",
+                  "        method: 'PUT',",
+                  "        header: { 'Content-Type': 'application/json' },",
+                  "        body: { mode: 'raw', raw: JSON.stringify({ description: 'First update to trigger updating status' }) }",
+                  "    }, function() {});",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -422,7 +492,7 @@
                   "",
                   "pm.test('Error mentions status', function() {",
                   "    var json = pm.response.json();",
-                  "    pm.expect(json.error.message).to.include('creating');",
+                  "    pm.expect(json.error.message).to.include('updating');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -572,8 +642,8 @@
                   "",
                   "pm.test('Agent created with defaults', function() {",
                   "    pm.expect(json.type).to.eql('agent');",
-                  "    pm.expect(json.status).to.eql('creating');",
-                  "    pm.expect(json.provider).to.eql('anthropic');",
+                  "    pm.expect(json.status).to.eql('ready');",
+                  "    pm.expect(json.provider).to.eql('claude_code');",
                   "    pm.expect(json.computer_use).to.eql(false);",
                   "    pm.expect(json.samples).to.be.an('array').that.is.empty;",
                   "    pm.expect(json.steps).to.be.an('array').that.is.empty;",
@@ -643,15 +713,65 @@
                   "pm.collectionVariables.set('steps_agent_id', json.id);",
                   "pm.collectionVariables.set('steps_poll_count', '0');",
                   "",
-                  "pm.test('Agent has steps', function() {",
+                  "pm.test('Agent has steps as objects', function() {",
                   "    pm.expect(json.steps).to.be.an('array').with.lengthOf(3);",
-                  "    pm.expect(json.steps[0]).to.eql('Extract data from CSV');",
-                  "    pm.expect(json.steps[1]).to.eql('Clean and normalize data');",
-                  "    pm.expect(json.steps[2]).to.eql('Generate summary report');",
+                  "    pm.expect(json.steps[0].name).to.eql('Extract data from CSV');",
+                  "    pm.expect(json.steps[0].computer_use).to.eql(false);",
+                  "    pm.expect(json.steps[1].name).to.eql('Clean and normalize data');",
+                  "    pm.expect(json.steps[2].name).to.eql('Generate summary report');",
                   "});",
                   "",
-                  "pm.test('Status is creating', function() {",
-                  "    pm.expect(json.status).to.eql('creating');",
+                  "pm.test('Status is ready', function() {",
+                  "    pm.expect(json.status).to.eql('ready');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Create Agent - Per-Step Computer Use",
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/api/agents",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Competitor Spy\",\n  \"description\": \"Visit a competitor website, capture pricing, and produce a comparison report.\",\n  \"steps\": [\n    {\"name\": \"Open competitor website\", \"computer_use\": true},\n    {\"name\": \"Capture pricing details\", \"computer_use\": true},\n    {\"name\": \"Write comparison report\", \"computer_use\": false}\n  ]\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 201', function() {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "var json = pm.response.json();",
+                  "",
+                  "pm.test('Steps are objects with computer_use flags', function() {",
+                  "    pm.expect(json.steps).to.be.an('array').with.lengthOf(3);",
+                  "    pm.expect(json.steps[0].name).to.eql('Open competitor website');",
+                  "    pm.expect(json.steps[0].computer_use).to.eql(true);",
+                  "    pm.expect(json.steps[1].computer_use).to.eql(true);",
+                  "    pm.expect(json.steps[2].name).to.eql('Write comparison report');",
+                  "    pm.expect(json.steps[2].computer_use).to.eql(false);",
+                  "});",
+                  "",
+                  "pm.test('Agent-level computer_use derived from steps', function() {",
+                  "    pm.expect(json.computer_use).to.eql(true);",
+                  "});",
+                  "",
+                  "pm.test('Provider defaults to claude_code', function() {",
+                  "    pm.expect(json.provider).to.eql('claude_code');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -906,6 +1026,107 @@
                 "exec": [
                   "pm.test('Deleted agent returns 404', function() {",
                   "    pm.response.to.have.status(404);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Bulk Delete",
+      "item": [
+        {
+          "name": "Delete All Runs",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/runs"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Response has deleted count', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.have.property('deleted');",
+                  "    pm.expect(json.deleted).to.be.a('number');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Delete All Agents",
+          "request": {
+            "method": "DELETE",
+            "url": "{{base_url}}/api/agents"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Response has deleted count', function() {",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.have.property('deleted');",
+                  "    pm.expect(json.deleted).to.be.a('number');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Verify Agents Empty",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/agents"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('No agents remain', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.be.an('array').that.is.empty;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Verify Runs Empty",
+          "request": {
+            "method": "GET",
+            "url": "{{base_url}}/api/runs"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('No runs remain', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "    var json = pm.response.json();",
+                  "    pm.expect(json).to.be.an('array').that.is.empty;",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/api/engine/executor.py
+++ b/api/engine/executor.py
@@ -1,9 +1,13 @@
 """Agent executor -- routes execution to CLI providers or computer use."""
 
 import json
+from pathlib import Path
 from typing import Any, Callable, Coroutine
 
 from api.engine.providers import CLIAgentProvider, build_agent_prompt
+
+# Project root -- used as fallback workspace so CLI picks up .mcp.json
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
 
 
 EventCallback = Callable[[str, dict], Coroutine[Any, Any, None]]
@@ -30,13 +34,29 @@ class AgentExecutor:
         await callback("agent_started", {"agent_id": agent["id"], "name": agent["name"]})
 
         try:
-            if agent.get("computer_use"):
+            # CLI providers (claude_code, codex, etc.) handle computer use via
+            # MCP/plugins natively. Only route to computer_use_service for the
+            # direct anthropic provider, which needs the separate desktop engine.
+            use_cu_service = (
+                agent.get("computer_use")
+                and agent.get("provider") not in ("claude_code", "codex", "aider", "cline", "gemini")
+            )
+            if use_cu_service:
                 result = await self.computer_use_service.run_agent(agent, inputs, callback)
             else:
                 prompt = build_agent_prompt(agent, inputs)
+                # Always use project root as workspace: the prompt already
+                # references forge_path as a relative path from the root,
+                # and the root has .mcp.json (needed for computer_use tools).
+                workspace = _PROJECT_ROOT
+                # Agent runs can take a long time: multi-step workflows,
+                # forge-generated prompts, and computer use all add up.
+                # Computer use agents need even longer (MCP tool round-trips).
+                timeout = 1800 if agent.get("computer_use") else 900
                 raw_output = await self.provider.execute(
                     prompt=prompt,
-                    workspace=agent.get("forge_path") or None,
+                    workspace=workspace,
+                    timeout=timeout,
                 )
                 result = self._parse_output(raw_output, agent.get("output_schema", []))
 

--- a/api/engine/providers.py
+++ b/api/engine/providers.py
@@ -72,6 +72,9 @@ def load_provider_config(provider_key: str, overrides: dict | None = None) -> Pr
     config = {**providers[provider_key]}
     if overrides:
         config.update(overrides)
+    # Filter to only fields ProviderConfig accepts (ignore metadata like models)
+    valid_fields = {f.name for f in ProviderConfig.__dataclass_fields__.values()}
+    config = {k: v for k, v in config.items() if k in valid_fields}
     return ProviderConfig(**config)
 
 
@@ -224,6 +227,27 @@ def build_agent_prompt(agent: dict, inputs: dict) -> str:
         parts.append(f"You are an agent named '{agent['name']}'.")
         if agent.get("description"):
             parts.append(f"Your goal: {agent['description']}")
+
+    # Add per-step workflow instructions
+    steps = agent.get("steps", [])
+    if steps:
+        parts.append("\nWorkflow steps (execute in order):")
+        for i, step in enumerate(steps, 1):
+            step_name = step["name"] if isinstance(step, dict) else step
+            uses_cu = step.get("computer_use", False) if isinstance(step, dict) else False
+            mode = "DESKTOP" if uses_cu else "CLI"
+            parts.append(f"  {i}. [{mode}] {step_name}")
+        if any(
+            (s.get("computer_use", False) if isinstance(s, dict) else False)
+            for s in steps
+        ):
+            parts.append(
+                "\nSteps marked [DESKTOP] require desktop automation: use the "
+                "computer_use MCP tools (screenshot, click, type_text, key_press) "
+                "to interact with the screen. Open applications, navigate visually, "
+                "and capture information by reading screenshots. Do NOT use "
+                "web_fetch or curl for [DESKTOP] steps."
+            )
 
     if inputs:
         parts.append("\nInputs:")

--- a/api/main.py
+++ b/api/main.py
@@ -15,7 +15,7 @@ from api.engine.providers import CLIAgentProvider, load_provider_config
 from api.services.computer_use_service import ComputerUseService
 from api.services.agent_service import AgentService
 from api.services.execution_service import ExecutionService
-from api.routes import health, agents, projects, runs, computer_use, ws
+from api.routes import health, agents, projects, runs, computer_use, providers, ws
 
 
 def create_app(db: Optional[Database] = None) -> FastAPI:
@@ -77,6 +77,7 @@ def create_app(db: Optional[Database] = None) -> FastAPI:
     app.include_router(projects.router)
     app.include_router(runs.router)
     app.include_router(computer_use.router)
+    app.include_router(providers.router)
     app.include_router(ws.router)
 
     return app

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -1,9 +1,9 @@
 """Agent Pydantic models."""
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .common import AgentType
 
@@ -14,27 +14,64 @@ class SchemaField(BaseModel):
     required: bool = True
 
 
+class StepDefinition(BaseModel):
+    name: str
+    computer_use: bool = False
+
+
+def _normalize_steps(steps: list) -> list[StepDefinition]:
+    """Convert a list of strings or dicts to StepDefinition objects."""
+    result = []
+    for s in steps:
+        if isinstance(s, str):
+            result.append(StepDefinition(name=s, computer_use=False))
+        elif isinstance(s, dict):
+            result.append(StepDefinition(**s))
+        elif isinstance(s, StepDefinition):
+            result.append(s)
+        else:
+            result.append(StepDefinition(name=str(s), computer_use=False))
+    return result
+
+
 class AgentCreate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     description: str = Field(default="", max_length=10000)
-    steps: list[str] = []
+    steps: list[Union[str, StepDefinition]] = []
     samples: list[str] = []
     computer_use: bool = False
-    provider: str = "anthropic"
+    provider: str = "claude_code"
     model: str = "claude-sonnet-4-6"
+
+    @field_validator("steps", mode="before")
+    @classmethod
+    def normalize_steps(cls, v):
+        return _normalize_steps(v) if v else []
+
+    def model_post_init(self, __context: Any) -> None:
+        """Derive computer_use from steps if any step has computer_use=True."""
+        if self.steps and any(
+            s.computer_use for s in self.steps if isinstance(s, StepDefinition)
+        ):
+            object.__setattr__(self, "computer_use", True)
 
 
 class AgentUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=200)
     description: Optional[str] = Field(default=None, max_length=10000)
     status: Optional[str] = None
-    steps: Optional[list[str]] = None
+    steps: Optional[list[Union[str, StepDefinition]]] = None
     samples: Optional[list[str]] = None
     input_schema: Optional[list[SchemaField]] = None
     output_schema: Optional[list[SchemaField]] = None
     computer_use: Optional[bool] = None
     provider: Optional[str] = None
     model: Optional[str] = None
+
+    @field_validator("steps", mode="before")
+    @classmethod
+    def normalize_steps(cls, v):
+        return _normalize_steps(v) if v else v
 
 
 class Agent(BaseModel):
@@ -44,16 +81,21 @@ class Agent(BaseModel):
     type: AgentType
     status: str = "creating"
     forge_path: str = ""
-    steps: list[str] = []
+    steps: list[StepDefinition] = []
     samples: list[str] = []
     input_schema: list[SchemaField] = []
     output_schema: list[SchemaField] = []
     computer_use: bool = False
     forge_config: dict[str, Any] = {}
-    provider: str = "anthropic"
+    provider: str = "claude_code"
     model: str = "claude-sonnet-4-6"
     created_at: datetime
     updated_at: datetime
+
+    @field_validator("steps", mode="before")
+    @classmethod
+    def normalize_steps(cls, v):
+        return _normalize_steps(v) if v else []
 
 
 class AgentRunRequest(BaseModel):

--- a/api/persistence/database.py
+++ b/api/persistence/database.py
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS agents (
     output_schema TEXT DEFAULT '[]',
     computer_use INTEGER DEFAULT 0,
     forge_config TEXT DEFAULT '{}',
-    provider TEXT NOT NULL DEFAULT 'anthropic',
+    provider TEXT NOT NULL DEFAULT 'claude_code',
     model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL

--- a/api/persistence/repositories.py
+++ b/api/persistence/repositories.py
@@ -99,7 +99,7 @@ class AgentRepository:
         type: str = "agent",
         status: str = "creating",
         forge_path: str = "",
-        steps: list[str] | None = None,
+        steps: list | None = None,
         samples: list[str] | None = None,
         input_schema: list[dict] | None = None,
         output_schema: list[dict] | None = None,
@@ -178,6 +178,11 @@ class AgentRepository:
         )
         await self.db.conn.commit()
         return cursor.rowcount > 0
+
+    async def delete_all(self) -> int:
+        cursor = await self.db.conn.execute("DELETE FROM agents")
+        await self.db.conn.commit()
+        return cursor.rowcount
 
 
 class ProjectRepository:
@@ -397,3 +402,8 @@ class RunRepository:
                 "SELECT * FROM runs ORDER BY started_at DESC"
             )
         return [_row_to_run(row) for row in await cursor.fetchall()]
+
+    async def delete_all(self) -> int:
+        cursor = await self.db.conn.execute("DELETE FROM runs")
+        await self.db.conn.commit()
+        return cursor.rowcount

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -10,6 +10,9 @@ from api.models.agent import AgentCreate, AgentUpdate, AgentRunRequest
 
 router = APIRouter(prefix="/api/agents", tags=["agents"])
 
+# Resolve project root so forge_path cleanup works regardless of cwd
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
 
 def _not_found(agent_id: str):
     return JSONResponse(
@@ -21,10 +24,11 @@ def _not_found(agent_id: str):
 @router.post("", status_code=201)
 async def create_agent(body: AgentCreate, request: Request, background_tasks: BackgroundTasks):
     agent_service = request.app.state.agent_service
+    steps_dicts = [s.model_dump() if hasattr(s, "model_dump") else s for s in body.steps]
     agent = await agent_service.create_agent(
         name=body.name,
         description=body.description,
-        steps=body.steps,
+        steps=steps_dicts,
         samples=body.samples,
         computer_use=body.computer_use,
         provider=body.provider,
@@ -62,6 +66,8 @@ async def update_agent(
     agent_service = request.app.state.agent_service
 
     fields = body.model_dump(exclude_none=True)
+    if "steps" in fields:
+        fields["steps"] = [s.model_dump() if hasattr(s, "model_dump") else s for s in body.steps]
     if "input_schema" in fields:
         fields["input_schema"] = [s.model_dump() if hasattr(s, "model_dump") else s for s in fields["input_schema"]]
     if "output_schema" in fields:
@@ -96,6 +102,21 @@ async def update_agent(
     return agent
 
 
+@router.delete("", status_code=200)
+async def delete_all_agents(request: Request):
+    repo = request.app.state.agent_repo
+    # Clean up all forge output folders before deleting
+    agents = await repo.list_all()
+    for agent in agents:
+        forge_path = agent.get("forge_path", "")
+        if forge_path:
+            path = PROJECT_ROOT / forge_path
+            if path.exists() and path.is_dir():
+                shutil.rmtree(path)
+    count = await repo.delete_all()
+    return {"deleted": count}
+
+
 @router.delete("/{agent_id}", status_code=204)
 async def delete_agent(agent_id: str, request: Request):
     repo = request.app.state.agent_repo
@@ -105,7 +126,7 @@ async def delete_agent(agent_id: str, request: Request):
     # Clean up the output folder if it exists
     forge_path = agent.get("forge_path", "")
     if forge_path:
-        path = Path(forge_path)
+        path = PROJECT_ROOT / forge_path
         if path.exists() and path.is_dir():
             shutil.rmtree(path)
     await repo.delete(agent_id)

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -1,0 +1,21 @@
+"""Provider discovery routes."""
+
+from fastapi import APIRouter
+
+from api.engine.providers import _load_providers_yaml
+
+router = APIRouter(prefix="/api/providers", tags=["providers"])
+
+
+@router.get("")
+async def list_providers():
+    """Return available providers with their display names and model lists."""
+    raw = _load_providers_yaml()
+    result = []
+    for key, cfg in raw.items():
+        result.append({
+            "id": key,
+            "name": cfg.get("name", key),
+            "models": cfg.get("models", []),
+        })
+    return result

--- a/api/routes/runs.py
+++ b/api/routes/runs.py
@@ -29,6 +29,13 @@ async def start_project_run(project_id: str, body: RunCreate, request: Request):
     return {"run_id": run["id"], "status": run["status"]}
 
 
+@router.delete("/api/runs", status_code=200)
+async def delete_all_runs(request: Request):
+    run_repo = request.app.state.run_repo
+    count = await run_repo.delete_all()
+    return {"deleted": count}
+
+
 @router.get("/api/runs")
 async def list_runs(request: Request, status: str | None = None):
     run_repo = request.app.state.run_repo

--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -28,10 +28,10 @@ class AgentService:
         steps: list | None = None,
         samples: list | None = None,
         computer_use: bool = False,
-        provider: str = "anthropic",
+        provider: str = "claude_code",
         model: str = "claude-sonnet-4-6",
     ) -> dict:
-        """Create an agent record with status 'creating'."""
+        """Create an agent record with status 'creating' and trigger forge generation."""
         return await self.agent_repo.create(
             name=name,
             description=description,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -68,6 +68,14 @@ async def app(db):
     application.state.ws_manager = ConnectionManager()
 
     provider = AsyncMock(spec=CLIAgentProvider)
+    # Return valid forge JSON so background run_forge succeeds in tests
+    import json
+    provider.execute.return_value = json.dumps({
+        "forge_path": "output/test-agent/",
+        "forge_config": {"complexity": "simple", "steps": 1, "prompts": ["01_Agent.md"]},
+        "input_schema": [],
+        "output_schema": [],
+    })
     application.state.agent_service = AgentService(
         agent_repo=application.state.agent_repo,
         provider=provider,

--- a/api/tests/test_agents.py
+++ b/api/tests/test_agents.py
@@ -44,15 +44,66 @@ class TestAgentCreate:
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_create_agent_with_steps(self, client):
+    async def test_create_agent_with_step_objects(self, client):
+        """Steps sent as objects with per-step computer_use."""
         resp = await client.post("/api/agents", json={
             "name": "Multi Step",
             "description": "Do a multi-step task",
-            "steps": ["Research sources", "Synthesize findings", "Format report"],
+            "steps": [
+                {"name": "Research sources", "computer_use": False},
+                {"name": "Create PR in browser", "computer_use": True},
+            ],
         })
         assert resp.status_code == 201
         data = resp.json()
-        assert data["steps"] == ["Research sources", "Synthesize findings", "Format report"]
+        assert len(data["steps"]) == 2
+        assert data["steps"][0] == {"name": "Research sources", "computer_use": False}
+        assert data["steps"][1] == {"name": "Create PR in browser", "computer_use": True}
+
+    @pytest.mark.asyncio
+    async def test_create_agent_with_string_steps_normalized(self, client):
+        """Plain string steps are normalized to objects with computer_use=False."""
+        resp = await client.post("/api/agents", json={
+            "name": "String Steps",
+            "description": "Uses old format",
+            "steps": ["Research sources", "Format report"],
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["steps"] == [
+            {"name": "Research sources", "computer_use": False},
+            {"name": "Format report", "computer_use": False},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_agent_with_mixed_steps(self, client):
+        """Mix of string and object steps are all normalized."""
+        resp = await client.post("/api/agents", json={
+            "name": "Mixed Steps",
+            "description": "Mixed format",
+            "steps": [
+                "CLI step",
+                {"name": "Desktop step", "computer_use": True},
+            ],
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["steps"][0] == {"name": "CLI step", "computer_use": False}
+        assert data["steps"][1] == {"name": "Desktop step", "computer_use": True}
+
+    @pytest.mark.asyncio
+    async def test_create_agent_computer_use_derived_from_steps(self, client):
+        """Agent-level computer_use is True when any step has computer_use=True."""
+        resp = await client.post("/api/agents", json={
+            "name": "Derived CU",
+            "description": "Has desktop step",
+            "steps": [
+                {"name": "CLI step", "computer_use": False},
+                {"name": "Desktop step", "computer_use": True},
+            ],
+        })
+        assert resp.status_code == 201
+        assert resp.json()["computer_use"] is True
 
     @pytest.mark.asyncio
     async def test_create_agent_without_steps_defaults_empty(self, client):
@@ -107,9 +158,9 @@ class TestAgentUpdate:
         create = await client.post("/api/agents", json={"name": "S", "description": ""})
         agent_id = create.json()["id"]
         assert create.json()["status"] == "creating"
-        resp = await client.put(f"/api/agents/{agent_id}", json={"status": "ready"})
+        resp = await client.put(f"/api/agents/{agent_id}", json={"status": "error"})
         assert resp.status_code == 200
-        assert resp.json()["status"] == "ready"
+        assert resp.json()["status"] == "error"
 
     @pytest.mark.asyncio
     async def test_update_nonexistent_returns_404(self, client):
@@ -159,10 +210,12 @@ class TestAgentUpdateTriggersForge:
         assert resp.json()["error"]["code"] == "AGENT_BUSY"
 
     @pytest.mark.asyncio
-    async def test_cosmetic_update_allowed_during_creating(self, client):
+    async def test_cosmetic_update_allowed_during_creating(self, client, app):
         """Name-only update is allowed even when agent is creating."""
         create = await client.post("/api/agents", json={"name": "T", "description": "d"})
         agent_id = create.json()["id"]
+        # Simulate a creating state (e.g., during forge regeneration)
+        await app.state.agent_repo.update(agent_id, status="creating")
         resp = await client.put(f"/api/agents/{agent_id}", json={"name": "NewName"})
         assert resp.status_code == 200
         assert resp.json()["name"] == "NewName"
@@ -183,9 +236,15 @@ class TestAgentUpdateTriggersForge:
         create = await client.post("/api/agents", json={"name": "T", "description": "d"})
         agent_id = create.json()["id"]
         await app.state.agent_repo.update(agent_id, status="ready")
-        resp = await client.put(f"/api/agents/{agent_id}", json={"steps": ["Step 1", "Step 2"]})
+        resp = await client.put(f"/api/agents/{agent_id}", json={
+            "steps": [
+                {"name": "Step 1", "computer_use": False},
+                {"name": "Step 2", "computer_use": True},
+            ],
+        })
         assert resp.status_code == 200
         assert resp.json()["status"] == "updating"
+        assert resp.json()["steps"][1]["computer_use"] is True
 
 
 class TestAgentDelete:
@@ -227,6 +286,24 @@ class TestAgentDelete:
         resp = await client.delete(f"/api/agents/{agent_id}")
         assert resp.status_code == 204
 
+    @pytest.mark.asyncio
+    async def test_delete_all_agents(self, client):
+        """Bulk delete removes all agents."""
+        await client.post("/api/agents", json={"name": "A", "description": ""})
+        await client.post("/api/agents", json={"name": "B", "description": ""})
+        resp = await client.delete("/api/agents")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 2
+        list_resp = await client.get("/api/agents")
+        assert len(list_resp.json()) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_all_agents_empty(self, client):
+        """Bulk delete on empty table returns zero."""
+        resp = await client.delete("/api/agents")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 0
+
 
 class TestAgentRun:
 
@@ -236,7 +313,7 @@ class TestAgentRun:
             "name": "T", "description": "do something",
         })
         agent_id = create.json()["id"]
-        # Agent starts as "creating"; set to "ready" via repo before running
+        # Background forge sets status to ready, but ensure it explicitly
         await app.state.agent_repo.update(agent_id, status="ready")
         resp = await client.post(f"/api/agents/{agent_id}/run", json={
             "inputs": {"topic": "AI Safety"},
@@ -247,12 +324,13 @@ class TestAgentRun:
         assert data["status"] == "queued"
 
     @pytest.mark.asyncio
-    async def test_run_agent_not_ready_returns_409(self, client):
+    async def test_run_agent_not_ready_returns_409(self, client, app):
         create = await client.post("/api/agents", json={
             "name": "T", "description": "do something",
         })
         agent_id = create.json()["id"]
-        # Agent is still "creating", should return 409
+        # Set agent to "error" status so it's not ready
+        await app.state.agent_repo.update(agent_id, status="error")
         resp = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         assert resp.status_code == 409
         assert resp.json()["error"]["code"] == "AGENT_NOT_READY"
@@ -266,10 +344,73 @@ class TestAgentRun:
     async def test_list_agent_runs(self, client, app):
         create = await client.post("/api/agents", json={"name": "T", "description": ""})
         agent_id = create.json()["id"]
-        # Set to ready so runs can be created
         await app.state.agent_repo.update(agent_id, status="ready")
         await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
         resp = await client.get(f"/api/agents/{agent_id}/runs")
         assert resp.status_code == 200
         assert len(resp.json()) == 2
+
+    @pytest.mark.asyncio
+    async def test_delete_all_runs(self, client, app):
+        """Bulk delete removes all runs."""
+        create = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = create.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        resp = await client.delete("/api/runs")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 2
+        list_resp = await client.get("/api/runs")
+        assert len(list_resp.json()) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_all_runs_empty(self, client):
+        """Bulk delete on empty runs table returns zero."""
+        resp = await client.delete("/api/runs")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 0
+
+
+class TestProviders:
+
+    @pytest.mark.asyncio
+    async def test_list_providers(self, client):
+        resp = await client.get("/api/providers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    @pytest.mark.asyncio
+    async def test_providers_have_required_fields(self, client):
+        resp = await client.get("/api/providers")
+        data = resp.json()
+        for provider in data:
+            assert "id" in provider
+            assert "name" in provider
+            assert "models" in provider
+            assert isinstance(provider["models"], list)
+
+    @pytest.mark.asyncio
+    async def test_claude_code_provider_has_models(self, client):
+        resp = await client.get("/api/providers")
+        data = resp.json()
+        claude = next((p for p in data if p["id"] == "claude_code"), None)
+        assert claude is not None
+        assert claude["name"] == "Claude Code"
+        model_ids = [m["id"] for m in claude["models"]]
+        assert "claude-sonnet-4-6" in model_ids
+        assert "claude-opus-4-6" in model_ids
+
+    @pytest.mark.asyncio
+    async def test_each_model_has_id_and_name(self, client):
+        resp = await client.get("/api/providers")
+        data = resp.json()
+        for provider in data:
+            for model in provider["models"]:
+                assert "id" in model
+                assert "name" in model
+                assert len(model["id"]) > 0
+                assert len(model["name"]) > 0

--- a/api/tests/test_services.py
+++ b/api/tests/test_services.py
@@ -75,8 +75,10 @@ class TestProvidersYamlLoading:
     def test_yaml_providers_all_instantiate_as_provider_config(self):
         """Every provider in YAML can be deserialized into a ProviderConfig."""
         providers = _load_providers_yaml()
+        valid_fields = {f.name for f in ProviderConfig.__dataclass_fields__.values()}
         for key, prov in providers.items():
-            config = ProviderConfig(**prov)
+            filtered = {k: v for k, v in prov.items() if k in valid_fields}
+            config = ProviderConfig(**filtered)
             assert config.name, f"{key} has empty name"
             assert config.command, f"{key} has empty command"
             assert len(config.args) > 0, f"{key} has no args"
@@ -768,3 +770,203 @@ class TestExecutionService:
         assert data["node_id"] == n_gate["id"]
         assert n1["id"] in data["outputs_so_far"]
         assert data["outputs_so_far"][n1["id"]] == {"result": "done"}
+
+
+class TestAgentExecutor:
+    """Tests for AgentExecutor routing logic."""
+
+    @pytest.mark.asyncio
+    async def test_claude_code_agent_with_computer_use_routes_to_cli(self):
+        """claude_code agents should use CLI provider even when computer_use=True.
+
+        Claude Code handles computer use via MCP, so it does NOT need routing
+        to the computer_use_service.
+        """
+        from api.engine.executor import AgentExecutor
+
+        cli_provider = AsyncMock()
+        cli_provider.execute.return_value = '{"result": "pricing report"}'
+        cu_service = AsyncMock()
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-1",
+            "name": "competitor-spy",
+            "computer_use": True,
+            "provider": "claude_code",
+            "forge_path": "",
+            "description": "Spy on competitors",
+            "output_schema": [],
+            "steps": [
+                {"name": "Open website", "computer_use": True},
+                {"name": "Write report", "computer_use": False},
+            ],
+        }
+        result = await executor.execute(agent, {"task": "analyze pricing"}, callback)
+
+        # Should have called CLI provider, NOT computer_use_service
+        cli_provider.execute.assert_called_once()
+        cu_service.run_agent.assert_not_called()
+        assert result == {"result": "pricing report"}
+
+    @pytest.mark.asyncio
+    async def test_workspace_always_project_root_even_with_forge_path(self):
+        """Workspace must always be PROJECT_ROOT, never forge_path.
+
+        The prompt references forge_path as a relative path from project root
+        (e.g., 'Read output/abc/agentic.md'). If cwd were set to forge_path,
+        the agent would look for output/abc/output/abc/agentic.md (doubled path).
+        """
+        from api.engine.executor import AgentExecutor, _PROJECT_ROOT
+
+        cli_provider = AsyncMock()
+        cli_provider.execute.return_value = '{"result": "done"}'
+        cu_service = AsyncMock()
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-ws",
+            "name": "test-agent",
+            "computer_use": False,
+            "provider": "claude_code",
+            "forge_path": "output/some-agent-id",
+            "description": "Test agent",
+            "output_schema": [],
+        }
+        await executor.execute(agent, {"task": "test"}, callback)
+
+        call_kwargs = cli_provider.execute.call_args.kwargs
+        assert call_kwargs["workspace"] == _PROJECT_ROOT
+        # Must NOT be the forge_path
+        assert call_kwargs["workspace"] != "output/some-agent-id"
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_project_root_when_no_forge_path(self):
+        """Agents without forge_path should also get PROJECT_ROOT as workspace."""
+        from api.engine.executor import AgentExecutor, _PROJECT_ROOT
+
+        cli_provider = AsyncMock()
+        cli_provider.execute.return_value = '{"result": "done"}'
+        cu_service = AsyncMock()
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-no-fp",
+            "name": "test-agent",
+            "computer_use": False,
+            "provider": "claude_code",
+            "forge_path": "",
+            "description": "Agent without forge path",
+            "output_schema": [],
+        }
+        await executor.execute(agent, {}, callback)
+
+        call_kwargs = cli_provider.execute.call_args.kwargs
+        assert call_kwargs["workspace"] == _PROJECT_ROOT
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_forge_path_for_file_resolution(self):
+        """The prompt must include forge_path so Claude can find agentic.md from PROJECT_ROOT."""
+        from api.engine.executor import AgentExecutor
+
+        cli_provider = AsyncMock()
+        cli_provider.execute.return_value = '{"result": "done"}'
+        cu_service = AsyncMock()
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-fp",
+            "name": "test-agent",
+            "computer_use": False,
+            "provider": "claude_code",
+            "forge_path": "output/my-agent-uuid",
+            "description": "Test",
+            "output_schema": [],
+        }
+        await executor.execute(agent, {}, callback)
+
+        call_kwargs = cli_provider.execute.call_args.kwargs
+        prompt = call_kwargs["prompt"]
+        # Prompt should reference the forge_path so the file resolves from PROJECT_ROOT
+        assert "output/my-agent-uuid/agentic.md" in prompt
+
+    @pytest.mark.asyncio
+    async def test_timeout_900_for_cli_agents(self):
+        """CLI agents (no computer_use) should get 900s timeout."""
+        from api.engine.executor import AgentExecutor
+
+        cli_provider = AsyncMock()
+        cli_provider.execute.return_value = '{"result": "done"}'
+        cu_service = AsyncMock()
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-to",
+            "name": "cli-agent",
+            "computer_use": False,
+            "provider": "claude_code",
+            "forge_path": "output/test",
+            "description": "CLI only",
+            "output_schema": [],
+        }
+        await executor.execute(agent, {}, callback)
+
+        call_kwargs = cli_provider.execute.call_args.kwargs
+        assert call_kwargs["timeout"] == 900
+
+    @pytest.mark.asyncio
+    async def test_timeout_1800_for_computer_use_agents(self):
+        """Computer use agents routed via CLI should get 1800s timeout."""
+        from api.engine.executor import AgentExecutor
+
+        cli_provider = AsyncMock()
+        cli_provider.execute.return_value = '{"result": "done"}'
+        cu_service = AsyncMock()
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-cu-to",
+            "name": "cu-agent",
+            "computer_use": True,
+            "provider": "claude_code",  # CLI provider handles CU via MCP
+            "forge_path": "output/test",
+            "description": "Desktop agent",
+            "output_schema": [],
+        }
+        await executor.execute(agent, {}, callback)
+
+        call_kwargs = cli_provider.execute.call_args.kwargs
+        assert call_kwargs["timeout"] == 1800
+
+    @pytest.mark.asyncio
+    async def test_anthropic_agent_with_computer_use_routes_to_cu_service(self):
+        """anthropic provider agents with computer_use=True should use computer_use_service."""
+        from api.engine.executor import AgentExecutor
+
+        cli_provider = AsyncMock()
+        cu_service = AsyncMock()
+        cu_service.run_agent.return_value = {"success": True}
+        callback = AsyncMock()
+
+        executor = AgentExecutor(cli_provider, cu_service)
+        agent = {
+            "id": "test-2",
+            "name": "browser-agent",
+            "computer_use": True,
+            "provider": "anthropic",
+            "forge_path": "",
+            "description": "Browse the web",
+            "output_schema": [],
+        }
+        result = await executor.execute(agent, {}, callback)
+
+        # Should have called computer_use_service, NOT CLI provider
+        cu_service.run_agent.assert_called_once()
+        cli_provider.execute.assert_not_called()
+        assert result == {"success": True}

--- a/forge/api-generate.md
+++ b/forge/api-generate.md
@@ -30,19 +30,25 @@ Accept a JSON object with the following fields:
       "label": "Optional short label describing what this sample shows."
     }
   ],
-  "computer_use": false
+  "steps": [
+    {"name": "Research sources", "computer_use": false},
+    {"name": "Create pull request", "computer_use": true}
+  ],
+  "computer_use": true
 }
 ```
 
 **Required:** `name`, `description`
 
-**Optional:** `id` (string, when provided use `output/{id}/` as the output folder instead of `output/{name}/`), `samples` (array, may be empty or omitted), `computer_use` (boolean, defaults to false)
+**Optional:** `id` (string, when provided use `output/{id}/` as the output folder instead of `output/{name}/`), `samples` (array, may be empty or omitted), `computer_use` (boolean, defaults to false), `steps` (array of step objects or strings)
+
+**Steps format:** Steps can be plain strings (e.g. `"Research sources"`) or objects with per-step computer use (e.g. `{"name": "Create PR", "computer_use": true}`). When steps are objects, each step's `computer_use` flag indicates whether that specific step needs desktop automation (open apps, click, browse). Steps without `computer_use` or plain strings default to CLI-only.
 
 **Validation:**
 - If `name` is missing or empty, derive it from the description: take the first 4-5 significant words, lowercase, hyphens between words.
 - If `description` is missing or empty, write an error JSON to stdout and stop: `{"error": "description is required"}`.
 - `samples` items may be strings (treated as content with no label) or objects with `content` and optional `label` fields.
-- `computer_use` defaults to false if not provided.
+- `computer_use` at the agent level is true if any step has `computer_use: true`. Do not infer -- trust the caller's flags.
 
 ---
 
@@ -116,16 +122,16 @@ Analyze the description to determine:
 
 5. **Output schema.** What the agent produces. Infer from the description. Each output has a name and type.
 
-6. **Computer use.** Use the `computer_use` flag from the input. Do not infer from the description in API mode (the caller sets this explicitly).
+6. **Computer use.** Check each step's `computer_use` flag. Steps marked `computer_use: true` need desktop automation (browsers, GUI apps, clicking, typing on screen). Steps marked `computer_use: false` or plain string steps are CLI-only. Do not infer -- trust the caller's per-step flags.
 
 **Save in context:**
 ```
 complexity: simple | multi_step
-steps: [{number, name, description, agent_name or null}]
+steps: [{number, name, description, agent_name or null, computer_use: true|false}]
 agents: [{name, role, expertise}]
 input_schema: [{name, type, required}]
 output_schema: [{name, type}]
-computer_use: true | false
+computer_use: true | false (agent-level, true if any step has computer_use)
 ```
 
 ---
@@ -173,7 +179,7 @@ For each agent in the roster from Step 2:
    - Actual Input (placeholders matching what the orchestrator passes)
    - Expected Workflow (numbered list, starts with input validation)
 
-2. If `computer_use` is true, also generate a Computer Use Agent prompt based on `forge/Prompts/05_Computer_Use_Agent.md`. Adapt it to the specific desktop tasks described.
+2. For steps with `computer_use: true`, generate a Computer Use Agent prompt based on `forge/Prompts/05_Computer_Use_Agent.md`. Adapt it to the specific desktop tasks that step needs to perform. Only steps explicitly marked with `computer_use: true` get a Computer Use Agent prompt -- CLI steps do not.
 
 3. Calibrate prompts against quality samples if provided. For each sample:
    - Read the content and label.

--- a/forge/api-update.md
+++ b/forge/api-update.md
@@ -25,11 +25,20 @@ Accept a JSON object with the following fields:
   "original": {
     "name": "agent-name",
     "description": "Original description used when the agent was created.",
+    "steps": [
+      {"name": "Research sources", "computer_use": false},
+      {"name": "Create PR", "computer_use": true}
+    ],
     "samples": [],
-    "computer_use": false
+    "computer_use": true
   },
   "updated": {
     "description": "New description reflecting changed requirements.",
+    "steps": [
+      {"name": "Research sources", "computer_use": false},
+      {"name": "Write code", "computer_use": false},
+      {"name": "Create PR", "computer_use": true}
+    ],
     "samples": ["new sample"],
     "computer_use": true
   }
@@ -38,8 +47,10 @@ Accept a JSON object with the following fields:
 
 **Required:** `forge_path`, `original.name`, `updated` (at least one field inside it)
 
-**Optional fields inside `updated`:** Any subset of `description`, `samples`, `computer_use`.
+**Optional fields inside `updated`:** Any subset of `description`, `steps`, `samples`, `computer_use`.
 Only include the fields that changed. Fields absent from `updated` are treated as unchanged.
+
+**Steps format:** Steps are arrays of objects with `name` (string) and `computer_use` (boolean). Steps with `computer_use: true` need desktop automation. The agent-level `computer_use` is true if any step has `computer_use: true`.
 
 **Validation:**
 - If `forge_path` is missing or empty, write an error JSON to stdout and stop:
@@ -86,8 +97,8 @@ Read the JSON input provided after "update an existing agent from:".
 
 Extract:
 - `forge_path` (string, path to the existing agent folder)
-- `original` (object with `name`, `description`, `samples`, `computer_use`)
-- `updated` (object with any subset of `description`, `samples`, `computer_use`)
+- `original` (object with `name`, `description`, `steps`, `samples`, `computer_use`)
+- `updated` (object with any subset of `description`, `steps`, `samples`, `computer_use`)
 
 Run validation in this order:
 
@@ -120,6 +131,7 @@ For each field in `updated`, compare its value to the same field in `original`.
 
 **Comparison rules:**
 - `description`: strings differ if they are not identical.
+- `steps`: arrays differ if their length, any step name, or any step's `computer_use` flag differs.
 - `samples`: arrays differ if their length or any item content differs.
 - `computer_use`: booleans differ if one is true and the other is false.
 

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -7,6 +7,7 @@ export const agentsApi = {
   create: (body: AgentCreate) => api.post<Agent>('/agents', body),
   update: (id: string, body: AgentUpdate) => api.put<Agent>(`/agents/${id}`, body),
   delete: (id: string) => api.delete<void>(`/agents/${id}`),
+  deleteAll: () => api.delete<{ deleted: number }>('/agents'),
   run: (id: string, inputs: Record<string, unknown> = {}) =>
     api.post<RunStartResponse>(`/agents/${id}/run`, { inputs }),
   listRuns: (id: string) => api.get<import('../types').Run[]>(`/agents/${id}/runs`),

--- a/frontend/src/api/providers.ts
+++ b/frontend/src/api/providers.ts
@@ -1,0 +1,16 @@
+import { api } from './client';
+
+export interface ProviderModel {
+  id: string;
+  name: string;
+}
+
+export interface Provider {
+  id: string;
+  name: string;
+  models: ProviderModel[];
+}
+
+export const providersApi = {
+  list: () => api.get<Provider[]>('/providers'),
+};

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -7,4 +7,5 @@ export const runsApi = {
   get: (id: string) => api.get<Run>(`/runs/${id}`),
   cancel: (id: string) => api.post<Run>(`/runs/${id}/cancel`),
   approve: (id: string) => api.post<Run>(`/runs/${id}/approve`),
+  deleteAll: () => api.delete<{ deleted: number }>('/runs'),
 };

--- a/frontend/src/components/agents/AgentForm.tsx
+++ b/frontend/src/components/agents/AgentForm.tsx
@@ -4,23 +4,10 @@ import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { TextArea } from '../ui/TextArea';
 import { Select } from '../ui/Select';
-import { Toggle } from '../ui/Toggle';
 import { SchemaEditor } from './SchemaEditor';
 import { useCreateAgent, useUpdateAgent } from '../../hooks/useAgents';
+import { useProviders } from '../../hooks/useProviders';
 import type { Agent, SchemaField } from '../../types';
-
-const providerOptions = [
-  { value: 'claude_code', label: 'Claude Code' },
-  { value: 'anthropic', label: 'Anthropic' },
-];
-
-const modelOptions: Record<string, { value: string; label: string }[]> = {
-  claude_code: [{ value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' }],
-  anthropic: [
-    { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-    { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
-  ],
-};
 
 interface AgentFormProps {
   agent?: Agent;
@@ -30,14 +17,24 @@ export function AgentForm({ agent }: AgentFormProps) {
   const navigate = useNavigate();
   const createAgent = useCreateAgent();
   const updateAgent = useUpdateAgent();
+  const { data: providers } = useProviders();
+
+  const providerOptions = (providers ?? []).map((p) => ({ value: p.id, label: p.name }));
+  const modelOptions: Record<string, { value: string; label: string }[]> = {};
+  for (const p of providers ?? []) {
+    modelOptions[p.id] = p.models.map((m) => ({ value: m.id, label: m.name }));
+  }
 
   const [name, setName] = useState(agent?.name ?? '');
   const [description, setDescription] = useState(agent?.description ?? '');
-  const [steps, setSteps] = useState<string[]>(agent?.steps ?? []);
+  const [steps, setSteps] = useState<{ name: string; computer_use: boolean }[]>(
+    (agent?.steps ?? []).map((s: string | { name: string; computer_use: boolean }) =>
+      typeof s === 'string' ? { name: s, computer_use: false } : s
+    )
+  );
   const [stepInput, setStepInput] = useState('');
   const [provider, setProvider] = useState(agent?.provider ?? 'claude_code');
   const [model, setModel] = useState(agent?.model ?? 'claude-sonnet-4-6');
-  const [computerUse, setComputerUse] = useState(agent?.computer_use ?? false);
   const [inputSchema, setInputSchema] = useState<SchemaField[]>(agent?.input_schema ?? []);
   const [outputSchema, setOutputSchema] = useState<SchemaField[]>(agent?.output_schema ?? []);
 
@@ -47,14 +44,18 @@ export function AgentForm({ agent }: AgentFormProps) {
 
   const addStep = () => {
     const trimmed = stepInput.trim();
-    if (trimmed && !steps.includes(trimmed)) {
-      setSteps([...steps, trimmed]);
+    if (trimmed && !steps.some(s => s.name === trimmed)) {
+      setSteps([...steps, { name: trimmed, computer_use: false }]);
       setStepInput('');
     }
   };
 
   const removeStep = (index: number) => {
     setSteps(steps.filter((_, i) => i !== index));
+  };
+
+  const toggleStepComputerUse = (index: number) => {
+    setSteps(steps.map((s, i) => i === index ? { ...s, computer_use: !s.computer_use } : s));
   };
 
   const handleStepKeyDown = (e: React.KeyboardEvent) => {
@@ -64,6 +65,8 @@ export function AgentForm({ agent }: AgentFormProps) {
     }
   };
 
+  const hasComputerUse = steps.some(s => s.computer_use);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isEditing) {
@@ -71,7 +74,7 @@ export function AgentForm({ agent }: AgentFormProps) {
         id: agent.id,
         body: {
           name, description, steps, provider, model,
-          computer_use: computerUse,
+          computer_use: hasComputerUse,
           input_schema: inputSchema,
           output_schema: outputSchema,
         },
@@ -80,7 +83,7 @@ export function AgentForm({ agent }: AgentFormProps) {
     } else {
       await createAgent.mutateAsync({
         name, description, steps, provider, model,
-        computer_use: computerUse,
+        computer_use: hasComputerUse,
       });
       navigate('/agents');
     }
@@ -108,26 +111,63 @@ export function AgentForm({ agent }: AgentFormProps) {
       />
 
       {/* Steps Editor */}
-      <div className="space-y-2">
-        <label className="block text-sm font-medium text-text-secondary">Steps</label>
-        <div className="flex flex-wrap gap-2 min-h-[36px]">
-          {steps.map((step, i) => (
-            <span
-              key={i}
-              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-accent/10 text-accent text-sm"
-            >
-              {step}
-              <button
-                type="button"
-                onClick={() => removeStep(i)}
-                className="text-accent/60 hover:text-accent ml-0.5"
-                disabled={isBusy}
-              >
-                x
-              </button>
-            </span>
-          ))}
+      <div className="space-y-3">
+        <div>
+          <label className="block text-sm font-medium text-text-secondary">Steps</label>
+          <p className="text-xs text-text-muted mt-1">
+            Break your agent's work into ordered steps. Each step runs one after another.
+          </p>
         </div>
+        {steps.length > 0 && (
+          <div className="space-y-1.5">
+            {steps.map((step, i) => (
+              <div
+                key={i}
+                className="group flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg bg-bg-secondary border border-border"
+              >
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <span className="text-xs font-mono text-text-muted w-5 shrink-0">{i + 1}.</span>
+                  <span className="text-sm text-text-primary truncate">{step.name}</span>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => toggleStepComputerUse(i)}
+                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all ${
+                      step.computer_use
+                        ? 'bg-accent/15 text-accent border border-accent/40 shadow-sm shadow-accent/10'
+                        : 'bg-bg-tertiary text-text-muted border border-border/50 hover:border-border hover:text-text-secondary cursor-pointer'
+                    }`}
+                    disabled={isBusy}
+                    title={step.computer_use ? 'This step can take control of your computer: open apps, click, type, and navigate' : 'Click to let this step take control of your computer'}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+                      <rect x="1" y="2" width="14" height="9" rx="1.5"/>
+                      <line x1="5" y1="13.5" x2="11" y2="13.5"/>
+                      <line x1="8" y1="11" x2="8" y2="13.5"/>
+                      {step.computer_use && <circle cx="8" cy="6.5" r="1.5" fill="currentColor" stroke="none"/>}
+                    </svg>
+                    {step.computer_use ? 'Desktop' : 'CLI'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => removeStep(i)}
+                    className="text-text-muted hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100"
+                    disabled={isBusy}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
+            <p className="text-[11px] text-text-muted pt-1">
+              Click <span className="font-medium text-text-secondary">CLI</span> / <span className="font-medium text-text-secondary">Desktop</span> on each step to choose how it runs.
+              CLI uses the terminal. Desktop lets the agent take control of your computer.
+            </p>
+          </div>
+        )}
         <div className="flex gap-2">
           <input
             type="text"
@@ -163,7 +203,11 @@ export function AgentForm({ agent }: AgentFormProps) {
         />
       </div>
 
-      <Toggle label="Computer Use" checked={computerUse} onChange={setComputerUse} disabled={isBusy} />
+      {hasComputerUse && (
+        <div className="text-xs text-accent bg-accent/10 px-3 py-2 rounded-lg">
+          Computer use enabled -- {steps.filter(s => s.computer_use).length} of {steps.length} steps use it
+        </div>
+      )}
 
       {/* Schema editors only shown when editing an existing agent (schemas are auto-generated by forge) */}
       {isEditing && (

--- a/frontend/src/components/agents/__tests__/AgentForm.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentForm.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock react-router-dom
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+// Mock hooks
+vi.mock('../../../hooks/useAgents', () => ({
+  useCreateAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../../hooks/useProviders', () => ({
+  useProviders: () => ({
+    data: [
+      {
+        id: 'claude_code',
+        name: 'Claude Code',
+        models: [
+          { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
+          { id: 'claude-opus-4-6', name: 'Claude Opus 4.6' },
+          { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },
+        ],
+      },
+      {
+        id: 'codex',
+        name: 'OpenAI Codex CLI',
+        models: [
+          { id: 'o4-mini', name: 'o4-mini' },
+          { id: 'o3', name: 'o3' },
+        ],
+      },
+      {
+        id: 'aider',
+        name: 'Aider',
+        models: [
+          { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
+          { id: 'gpt-4.1', name: 'GPT-4.1' },
+        ],
+      },
+    ],
+  }),
+}));
+
+import { AgentForm } from '../AgentForm';
+
+describe('AgentForm - Model options', () => {
+  it('includes Claude models in claude_code model options', () => {
+    render(<AgentForm />);
+
+    // Default provider is claude_code
+    const modelSelect = screen.getByLabelText('Model');
+    const options = Array.from(modelSelect.querySelectorAll('option'));
+    const labels = options.map((o) => o.textContent);
+
+    expect(labels).toContain('Claude Sonnet 4.6');
+    expect(labels).toContain('Claude Opus 4.6');
+    expect(labels).toContain('Claude Haiku 4.5');
+  });
+
+  it('switches models when provider changes', async () => {
+    render(<AgentForm />);
+
+    // Switch to Codex provider
+    const providerSelect = screen.getByLabelText('Provider');
+    await userEvent.selectOptions(providerSelect, 'codex');
+
+    // Check model dropdown has Codex models
+    const modelSelect = screen.getByLabelText('Model');
+    const options = Array.from(modelSelect.querySelectorAll('option'));
+    const labels = options.map((o) => o.textContent);
+
+    expect(labels).toContain('o4-mini');
+    expect(labels).toContain('o3');
+    expect(labels).not.toContain('Claude Haiku 4.5');
+  });
+});
+
+describe('AgentForm - Per-step computer use', () => {
+  it('adds a step defaulting to CLI mode (computer_use=false)', async () => {
+    render(<AgentForm />);
+
+    const input = screen.getByPlaceholderText('Add a step and press Enter');
+    await userEvent.type(input, 'Research sources{enter}');
+
+    // Step should appear with CLI toggle button
+    expect(screen.getByText('Research sources')).toBeInTheDocument();
+    const toggleButtons = screen.getAllByRole('button').filter(b => b.textContent?.includes('CLI'));
+    expect(toggleButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('toggles a step from CLI to Desktop', async () => {
+    render(<AgentForm />);
+
+    const input = screen.getByPlaceholderText('Add a step and press Enter');
+    await userEvent.type(input, 'Create PR{enter}');
+
+    // Find the CLI toggle button (not the legend text)
+    const cliButton = screen.getAllByRole('button').find(b => b.textContent?.trim() === 'CLI');
+    expect(cliButton).toBeTruthy();
+
+    // Click to toggle to Desktop
+    await userEvent.click(cliButton!);
+    const desktopButton = screen.getAllByRole('button').find(b => b.textContent?.trim() === 'Desktop');
+    expect(desktopButton).toBeTruthy();
+  });
+
+  it('shows computer use banner when any step has Desktop enabled', async () => {
+    render(<AgentForm />);
+
+    const input = screen.getByPlaceholderText('Add a step and press Enter');
+    await userEvent.type(input, 'Browse web{enter}');
+
+    // No banner initially
+    expect(screen.queryByText(/Computer use enabled/)).not.toBeInTheDocument();
+
+    // Toggle to Desktop
+    const cliButton = screen.getAllByRole('button').find(b => b.textContent?.trim() === 'CLI');
+    await userEvent.click(cliButton!);
+
+    // Banner should appear
+    expect(screen.getByText(/Computer use enabled/)).toBeInTheDocument();
+  });
+
+  it('shows CLI/Desktop legend when steps exist', async () => {
+    render(<AgentForm />);
+
+    const input = screen.getByPlaceholderText('Add a step and press Enter');
+    await userEvent.type(input, 'Step one{enter}');
+
+    expect(screen.getByText(/terminal/)).toBeInTheDocument();
+    expect(screen.getByText(/take control/)).toBeInTheDocument();
+  });
+
+  it('loads existing agent with object steps correctly', () => {
+    const agent = {
+      id: 'test-1',
+      name: 'Test',
+      description: 'desc',
+      type: 'agent' as const,
+      status: 'ready' as const,
+      forge_path: '',
+      steps: [
+        { name: 'CLI step', computer_use: false },
+        { name: 'Desktop step', computer_use: true },
+      ],
+      samples: [],
+      input_schema: [],
+      output_schema: [],
+      computer_use: true,
+      forge_config: {},
+      provider: 'claude_code',
+      model: 'claude-sonnet-4-6',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+    };
+
+    render(<AgentForm agent={agent} />);
+
+    expect(screen.getByText('CLI step')).toBeInTheDocument();
+    expect(screen.getByText('Desktop step')).toBeInTheDocument();
+    // Toggle buttons: one should say CLI, one should say Desktop
+    const toggleButtons = screen.getAllByRole('button').filter(
+      b => b.textContent?.trim() === 'CLI' || b.textContent?.trim() === 'Desktop'
+    );
+    const cliButtons = toggleButtons.filter(b => b.textContent?.trim() === 'CLI');
+    const desktopButtons = toggleButtons.filter(b => b.textContent?.trim() === 'Desktop');
+    expect(cliButtons).toHaveLength(1);
+    expect(desktopButtons).toHaveLength(1);
+  });
+});

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { providersApi } from '../api/providers';
+
+export function useProviders() {
+  return useQuery({
+    queryKey: ['providers'],
+    queryFn: providersApi.list,
+    staleTime: 5 * 60 * 1000, // providers rarely change, cache 5 min
+  });
+}

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -89,12 +89,30 @@ export function AgentDetail() {
             <h2 className="font-heading text-lg font-semibold text-text-primary">Workflow Steps</h2>
           </div>
           <div className="flex flex-col gap-2">
-            {agent.steps.length > 0 ? agent.steps.map((step, i) => (
-              <div key={i} className="flex items-center gap-3 px-3.5 py-2.5 bg-hover-bg rounded-[10px] border border-border">
-                <span className="font-heading text-[13px] font-bold text-accent w-5 shrink-0">{i + 1}</span>
-                <span className="font-mono text-xs text-text-primary">{step}</span>
-              </div>
-            )) : (
+            {agent.steps.length > 0 ? agent.steps.map((step, i) => {
+              const stepObj = typeof step === 'string' ? { name: step, computer_use: false } : step;
+              return (
+                <div key={i} className="flex items-center justify-between gap-3 px-3.5 py-2.5 bg-hover-bg rounded-[10px] border border-border">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="font-heading text-[13px] font-bold text-accent w-5 shrink-0">{i + 1}</span>
+                    <span className="font-mono text-xs text-text-primary truncate">{stepObj.name}</span>
+                  </div>
+                  <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-medium shrink-0 ${
+                    stepObj.computer_use
+                      ? 'bg-accent/15 text-accent border border-accent/40'
+                      : 'bg-bg-tertiary text-text-muted border border-border/50'
+                  }`}>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+                      <rect x="1" y="2" width="14" height="9" rx="1.5"/>
+                      <line x1="5" y1="13.5" x2="11" y2="13.5"/>
+                      <line x1="8" y1="11" x2="8" y2="13.5"/>
+                      {stepObj.computer_use && <circle cx="8" cy="6.5" r="1.5" fill="currentColor" stroke="none"/>}
+                    </svg>
+                    {stepObj.computer_use ? 'Desktop' : 'CLI'}
+                  </span>
+                </div>
+              );
+            }) : (
               <p className="text-xs text-text-muted font-body">No steps defined.</p>
             )}
           </div>
@@ -139,7 +157,16 @@ export function AgentDetail() {
               </div>
             ))
           ) : (
-            <p className="text-xs text-text-muted mb-3 font-body">No inputs required. Click run to start.</p>
+            <div className="mb-3">
+              <label className="block font-body text-sm text-text-secondary mb-1.5">Task</label>
+              <textarea
+                value={inputs['task'] ?? ''}
+                onChange={(e) => setInputs({ ...inputs, task: e.target.value })}
+                className="w-full px-3.5 py-2.5 bg-bg-input border border-border rounded-[10px] text-sm text-text-primary placeholder:text-text-muted focus:border-accent transition-colors resize-y min-h-[80px]"
+                placeholder="Describe what the agent should do"
+                rows={3}
+              />
+            </div>
           )}
           <Button onClick={handleRun} disabled={runAgent.isPending}>
             {runAgent.isPending ? 'Starting...' : 'Start Run'}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { useTheme } from '../hooks/useTheme';
+import { useProviders } from '../hooks/useProviders';
+import { agentsApi } from '../api/agents';
+import { runsApi } from '../api/runs';
 import { PixelMoon, PixelSun, PixelGear, PixelClock } from '../components/ui/PixelIcon';
 
 const STORAGE_KEY = 'agent-forge-settings';
@@ -30,10 +34,10 @@ function loadSettings(): AppSettings {
   return defaults;
 }
 
-const providerOptions = ['claude_code', 'codex', 'aider'];
-
 export function Settings() {
   const { theme, toggle } = useTheme();
+  const { data: providers } = useProviders();
+  const providerOptions = (providers ?? []).map((p) => p.id);
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [saved, setSaved] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -55,16 +59,27 @@ export function Settings() {
     setSaved(true);
   };
 
-  const handleResetAgents = () => {
-    if (confirm('This will delete ALL agents. Are you sure?')) {
-      alert('Not implemented yet -- delete agents individually from the Agents page.');
+  const queryClient = useQueryClient();
+
+  const handleResetAgents = async () => {
+    if (!confirm('This will delete ALL agents and their generated files. Are you sure?')) return;
+    try {
+      const result = await agentsApi.deleteAll();
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
+      alert(`Deleted ${result.deleted} agent(s).`);
+    } catch (e) {
+      alert(`Failed to delete agents: ${e instanceof Error ? e.message : e}`);
     }
   };
 
-  const handleClearHistory = () => {
-    if (confirm('Clear local run history cache?')) {
-      localStorage.removeItem('agent-forge-run-cache');
-      alert('Local run cache cleared.');
+  const handleClearHistory = async () => {
+    if (!confirm('This will delete ALL run history from the database. Are you sure?')) return;
+    try {
+      const result = await runsApi.deleteAll();
+      queryClient.invalidateQueries({ queryKey: ['runs'] });
+      alert(`Deleted ${result.deleted} run(s).`);
+    } catch (e) {
+      alert(`Failed to clear runs: ${e instanceof Error ? e.message : e}`);
     }
   };
 

--- a/frontend/src/pages/__tests__/AgentDetail.test.tsx
+++ b/frontend/src/pages/__tests__/AgentDetail.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'agent-1' }),
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock hooks
+const mockRunAgent = { mutateAsync: vi.fn(), isPending: false };
+vi.mock('../../hooks/useAgents', () => ({
+  useAgent: () => ({
+    data: {
+      id: 'agent-1',
+      name: 'Test Agent',
+      description: 'A test agent',
+      status: 'ready',
+      type: 'agent',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      computer_use: true,
+      created_at: '2025-01-01T00:00:00Z',
+      steps: [
+        { name: 'Analyze code', computer_use: false },
+        { name: 'Write tests', computer_use: false },
+        { name: 'Create PR', computer_use: true },
+      ],
+      input_schema: [],
+      output_schema: [],
+    },
+    isLoading: false,
+  }),
+  useDeleteAgent: () => ({ mutateAsync: vi.fn() }),
+  useRunAgent: () => mockRunAgent,
+}));
+
+import { AgentDetail } from '../AgentDetail';
+
+describe('AgentDetail - Run Agent section', () => {
+  it('shows a task textarea when run form is opened and no input_schema exists', async () => {
+    render(<AgentDetail />);
+    const startBtn = screen.getByText('Start Run');
+    await userEvent.click(startBtn);
+
+    // Should show a task textarea, NOT "No inputs required"
+    expect(screen.getByPlaceholderText(/describe what.*agent should do/i)).toBeInTheDocument();
+    expect(screen.queryByText('No inputs required')).not.toBeInTheDocument();
+  });
+
+  it('task textarea updates the inputs for running', async () => {
+    render(<AgentDetail />);
+    await userEvent.click(screen.getByText('Start Run'));
+
+    const textarea = screen.getByPlaceholderText(/describe what.*agent should do/i);
+    await userEvent.type(textarea, 'Research AI safety');
+    expect(textarea).toHaveValue('Research AI safety');
+  });
+});
+
+describe('AgentDetail - Per-step computer use display', () => {
+  it('shows step names from object-shaped steps', () => {
+    render(<AgentDetail />);
+
+    expect(screen.getByText('Analyze code')).toBeInTheDocument();
+    expect(screen.getByText('Write tests')).toBeInTheDocument();
+    expect(screen.getByText('Create PR')).toBeInTheDocument();
+  });
+
+  it('shows CLI/Desktop badges per step', () => {
+    render(<AgentDetail />);
+
+    // 2 CLI steps + 1 Desktop step
+    const cliBadges = screen.getAllByText('CLI');
+    const desktopBadges = screen.getAllByText('Desktop');
+    expect(cliBadges).toHaveLength(2);
+    expect(desktopBadges).toHaveLength(1);
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,11 @@ export interface SchemaField {
   required: boolean;
 }
 
+export interface StepDefinition {
+  name: string;
+  computer_use: boolean;
+}
+
 export type AgentStatus = 'creating' | 'updating' | 'ready' | 'error';
 
 export interface Agent {
@@ -13,7 +18,7 @@ export interface Agent {
   type: 'agent' | 'approval' | 'input' | 'output';
   status: AgentStatus;
   forge_path: string;
-  steps: string[];
+  steps: StepDefinition[];
   samples: string[];
   input_schema: SchemaField[];
   output_schema: SchemaField[];
@@ -28,7 +33,7 @@ export interface Agent {
 export interface AgentCreate {
   name: string;
   description?: string;
-  steps?: string[];
+  steps?: StepDefinition[];
   samples?: string[];
   computer_use?: boolean;
   provider?: string;
@@ -39,7 +44,7 @@ export interface AgentUpdate {
   name?: string;
   description?: string;
   status?: string;
-  steps?: string[];
+  steps?: StepDefinition[];
   samples?: string[];
   input_schema?: SchemaField[];
   output_schema?: SchemaField[];

--- a/providers.yaml
+++ b/providers.yaml
@@ -11,7 +11,11 @@ providers:
     command: claude
     args: ["-p", "{{prompt}}", "--dangerously-skip-permissions", "--output-format", "json"]
     available_check: ["claude", "--version"]
-    timeout: 300
+    timeout: 900
+    models:
+      - { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
+      - { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
+      - { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" }
 
   codex:
     name: "OpenAI Codex CLI"
@@ -19,6 +23,10 @@ providers:
     args: ["exec", "{{prompt}}", "--full-auto", "--json"]
     available_check: ["codex", "--version"]
     timeout: 300
+    models:
+      - { id: "o4-mini", name: "o4-mini" }
+      - { id: "o3", name: "o3" }
+      - { id: "gpt-4.1", name: "GPT-4.1" }
 
   aider:
     name: "Aider"
@@ -26,6 +34,12 @@ providers:
     args: ["--message", "{{prompt}}", "--yes-always"]
     available_check: ["aider", "--version"]
     timeout: 300
+    models:
+      - { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
+      - { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
+      - { id: "gpt-4.1", name: "GPT-4.1" }
+      - { id: "o4-mini", name: "o4-mini" }
+      - { id: "deepseek/deepseek-chat", name: "DeepSeek V3" }
 
   cline:
     name: "Cline CLI"
@@ -33,6 +47,10 @@ providers:
     args: ["{{prompt}}", "-y", "--json"]
     available_check: ["cline", "--version"]
     timeout: 300
+    models:
+      - { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
+      - { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
+      - { id: "gpt-4.1", name: "GPT-4.1" }
 
   gemini:
     name: "Gemini CLI"
@@ -40,3 +58,6 @@ providers:
     args: ["{{prompt}}", "--output-format", "json"]
     available_check: ["gemini", "--version"]
     timeout: 300
+    models:
+      - { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" }
+      - { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" }


### PR DESCRIPTION
## Summary

- **Per-step computer use**: Steps can be marked CLI or Desktop individually. UI shows toggle per step, executor routes Desktop steps to computer use
- **Fix forge generation**: `create_agent` now sets status='creating' and triggers `run_forge` as background task (was incorrectly setting 'ready' immediately)
- **Fix workspace bug**: Executor always uses PROJECT_ROOT as cwd (was using forge_path, causing doubled paths when resolving agentic.md)
- **Fix run timeouts**: Increase timeout from 300s to 900s for CLI agents, 1800s for computer use agents
- **Fix delete cleanup**: Delete routes use PROJECT_ROOT/forge_path to correctly remove output folders
- **Add providers endpoint**: Dynamic provider/model selection in Settings UI
- **163 passing backend tests** (6 new for workspace/timeout fixes)

## Test plan

- [x] All 163 backend tests pass
- [x] Created agent via UI, verified forge generates workflow (status: creating -> ready)
- [x] Ran brand-name-scout agent successfully (1m 25s, completed)
- [x] Verified delete cleans up output folders
- [x] Verified per-step Desktop/CLI toggle works in agent creation form