### PR TITLE
Fix WSL2 platform detection for Codex MCP spawning

### DIFF
--- a/computer_use/platform/detect.py
+++ b/computer_use/platform/detect.py
@@ -28,16 +28,16 @@ def detect_platform() -> Platform:
     2. Check sys.platform for native OS
     """
     if sys.platform == "linux":
-        # WSL2 detection: WSL2 IS Linux, but needs Windows-routed backends
-        wsl_distro = os.environ.get("WSL_DISTRO_NAME")
-        if wsl_distro:
-            try:
-                with open("/proc/version", "r") as f:
-                    if "microsoft" in f.read().lower():
-                        return Platform.WSL2
-            except OSError:
-                pass
-            # Trust WSL_DISTRO_NAME even without /proc/version
+        # WSL2 detection: WSL2 IS Linux, but needs Windows-routed backends.
+        # Check /proc/version first (works even if env vars are stripped),
+        # then fall back to WSL_DISTRO_NAME env var.
+        try:
+            with open("/proc/version", "r") as f:
+                if "microsoft" in f.read().lower():
+                    return Platform.WSL2
+        except OSError:
+            pass
+        if os.environ.get("WSL_DISTRO_NAME"):
             return Platform.WSL2
         return Platform.LINUX
 

--- a/computer_use/tests/test_detect.py
+++ b/computer_use/tests/test_detect.py
@@ -32,13 +32,31 @@ class TestDetectPlatform:
         ):
             assert detect_platform() == Platform.WSL2
 
-    def test_native_linux(self):
-        """Native Linux: no WSL_DISTRO_NAME env."""
+    def test_wsl2_proc_version_only(self):
+        """WSL2 detection: no WSL_DISTRO_NAME but /proc/version has microsoft."""
         env = os.environ.copy()
         env.pop("WSL_DISTRO_NAME", None)
         with (
             patch.dict(os.environ, env, clear=True),
             patch("sys.platform", "linux"),
+            patch(
+                "builtins.open",
+                mock_open(read_data="Linux version 5.15 microsoft-standard-WSL2"),
+            ),
+        ):
+            assert detect_platform() == Platform.WSL2
+
+    def test_native_linux(self):
+        """Native Linux: no WSL_DISTRO_NAME, /proc/version without microsoft."""
+        env = os.environ.copy()
+        env.pop("WSL_DISTRO_NAME", None)
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.platform", "linux"),
+            patch(
+                "builtins.open",
+                mock_open(read_data="Linux version 6.1.0-generic"),
+            ),
         ):
             assert detect_platform() == Platform.LINUX
 

--- a/computer_use/tests/test_detect_platform.py
+++ b/computer_use/tests/test_detect_platform.py
@@ -29,12 +29,30 @@ class TestDetectPlatform:
         ):
             assert detect_platform() == Platform.WSL2
 
+    def test_wsl2_detected_via_proc_version_without_env(self):
+        """WSL2 detected via /proc/version even without WSL_DISTRO_NAME."""
+        env = os.environ.copy()
+        env.pop("WSL_DISTRO_NAME", None)
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.platform", "linux"),
+            patch(
+                "builtins.open",
+                mock_open(read_data="Linux 5.15.90.1-microsoft-standard-WSL2"),
+            ),
+        ):
+            assert detect_platform() == Platform.WSL2
+
     def test_plain_linux_without_wsl_env(self):
         env = os.environ.copy()
         env.pop("WSL_DISTRO_NAME", None)
         with (
             patch.dict(os.environ, env, clear=True),
             patch("sys.platform", "linux"),
+            patch(
+                "builtins.open",
+                mock_open(read_data="Linux version 6.1.0-generic"),
+            ),
         ):
             assert detect_platform() == Platform.LINUX
 


### PR DESCRIPTION
## Summary

- Reorder WSL2 detection in `detect_platform()` to check `/proc/version` **before** the `WSL_DISTRO_NAME` env var
- This fixes MCP server platform detection when spawned by tools (like Codex) that don't pass environment variables through to subprocesses
- `/proc/version` always contains "microsoft" on WSL2 regardless of env vars, making it the more reliable primary check
- Added tests for the "proc/version only, no env var" scenario in both test files

## Test plan

- [x] All 21 platform detection unit tests pass
- [x] Verified fix works in Codex: `computer_use.screenshot({})` succeeds after restart