### PR TITLE
feat: experimental settings with computer use toggle

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -21,6 +21,7 @@ from api.services.artifact_service import ArtifactService
 from api.services.execution_service import ExecutionService
 from api.services.log_writer import LogWriter
 from api.routes import health, agents, projects, runs, computer_use, providers, ws
+from api.routes import settings as settings_routes
 
 
 def create_app(db: Optional[Database] = None) -> FastAPI:
@@ -125,6 +126,7 @@ def create_app(db: Optional[Database] = None) -> FastAPI:
     app.include_router(runs.router)
     app.include_router(computer_use.router)
     app.include_router(providers.router)
+    app.include_router(settings_routes.router)
     app.include_router(ws.router)
 
     return app

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -208,6 +208,19 @@ async def run_agent(agent_id: str, body: AgentRunRequest, request: Request, back
             content={"error": {"code": "AGENT_NOT_READY", "message": f"Agent is '{agent['status']}', must be 'ready' to run", "details": {}}},
         )
 
+    # Block run if agent needs computer use but it's disabled
+    if agent.get("computer_use"):
+        from api.services.computer_use_setup import get_status as cu_status
+        if not cu_status()["enabled"]:
+            return JSONResponse(
+                status_code=409,
+                content={"error": {
+                    "code": "COMPUTER_USE_DISABLED",
+                    "message": "This agent has desktop steps but computer use is disabled. Enable it in Settings to run this agent.",
+                    "details": {},
+                }},
+            )
+
     run_provider = body.provider or agent["provider"]
     run_model = body.model or agent["model"]
 

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -1,0 +1,32 @@
+"""Settings routes for experimental features."""
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from api.services.computer_use_setup import (
+    get_status,
+    enable_computer_use,
+    disable_computer_use,
+    update_cache_setting,
+)
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+class ComputerUseUpdate(BaseModel):
+    enabled: bool
+    cache_enabled: bool = True
+
+
+@router.get("/computer-use")
+async def get_computer_use_status():
+    return get_status()
+
+
+@router.put("/computer-use")
+async def update_computer_use(body: ComputerUseUpdate):
+    if body.enabled:
+        result = enable_computer_use(cache_enabled=body.cache_enabled)
+    else:
+        result = disable_computer_use()
+    return result

--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -1,0 +1,115 @@
+"""Service for managing computer use setup: venv, .mcp.json, cache toggle."""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+MCP_JSON_PATH = PROJECT_ROOT / ".mcp.json"
+CU_VENV_DIR = PROJECT_ROOT / "computer_use" / ".venv"
+CU_REQUIREMENTS = PROJECT_ROOT / "computer_use" / "requirements.txt"
+
+
+def _python_command() -> str:
+    """Return the correct python command for the current platform."""
+    if sys.platform == "win32":
+        return "python"
+    return "python3"
+
+
+def _mcp_json_content(cache_enabled: bool = True) -> dict:
+    """Build .mcp.json content with platform-correct values."""
+    env = {"AGENT_FORGE_DEBUG": "1"}
+    if not cache_enabled:
+        env["AGENT_FORGE_CACHE_ENABLED"] = "0"
+    return {
+        "mcpServers": {
+            "computer-use": {
+                "command": _python_command(),
+                "args": ["-m", "computer_use.mcp_server", "--transport", "stdio"],
+                "cwd": str(PROJECT_ROOT),
+                "env": env,
+            }
+        }
+    }
+
+
+def get_status() -> dict:
+    """Check current computer use status."""
+    mcp_exists = MCP_JSON_PATH.exists()
+    venv_exists = CU_VENV_DIR.exists()
+
+    enabled = False
+    cache_enabled = True
+
+    if mcp_exists:
+        try:
+            data = json.loads(MCP_JSON_PATH.read_text())
+            cu_server = data.get("mcpServers", {}).get("computer-use")
+            enabled = cu_server is not None
+            if cu_server:
+                env = cu_server.get("env", {})
+                cache_enabled = env.get("AGENT_FORGE_CACHE_ENABLED", "1") != "0"
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return {
+        "enabled": enabled,
+        "cache_enabled": cache_enabled,
+        "venv_ready": venv_exists,
+    }
+
+
+def enable_computer_use(cache_enabled: bool = True) -> dict:
+    """Set up computer use: create venv if needed, write .mcp.json."""
+    # Create venv and install deps if needed
+    if not CU_VENV_DIR.exists():
+        logger.info("Creating computer_use venv...")
+        python = _python_command()
+        subprocess.run(
+            [python, "-m", "venv", str(CU_VENV_DIR)],
+            check=True, capture_output=True,
+        )
+
+    # Install/update deps
+    if CU_REQUIREMENTS.exists():
+        if sys.platform == "win32":
+            pip = str(CU_VENV_DIR / "Scripts" / "pip")
+        else:
+            pip = str(CU_VENV_DIR / "bin" / "pip")
+        logger.info("Installing computer_use dependencies...")
+        subprocess.run(
+            [pip, "install", "-q", "-r", str(CU_REQUIREMENTS)],
+            check=True, capture_output=True,
+        )
+
+    # Write .mcp.json
+    content = _mcp_json_content(cache_enabled=cache_enabled)
+    MCP_JSON_PATH.write_text(json.dumps(content, indent=2) + "\n")
+    logger.info("Wrote .mcp.json (cache_enabled=%s)", cache_enabled)
+
+    return get_status()
+
+
+def disable_computer_use() -> dict:
+    """Remove .mcp.json to disable computer use. Keeps venv for re-enable."""
+    if MCP_JSON_PATH.exists():
+        MCP_JSON_PATH.unlink()
+        logger.info("Removed .mcp.json")
+    return get_status()
+
+
+def update_cache_setting(cache_enabled: bool) -> dict:
+    """Update cache setting in .mcp.json without touching venv."""
+    if not MCP_JSON_PATH.exists():
+        return get_status()
+
+    content = _mcp_json_content(cache_enabled=cache_enabled)
+    MCP_JSON_PATH.write_text(json.dumps(content, indent=2) + "\n")
+    logger.info("Updated cache_enabled=%s in .mcp.json", cache_enabled)
+    return get_status()

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -1,0 +1,255 @@
+"""Tests for settings endpoints (computer use toggle)."""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+import api.services.computer_use_setup as cu_setup
+
+
+class TestComputerUseSetupService:
+    """Tests for the computer_use_setup service functions."""
+
+    def test_get_status_no_mcp_json(self, tmp_path):
+        """When .mcp.json doesn't exist, computer use is disabled."""
+        with patch.object(cu_setup, "MCP_JSON_PATH", tmp_path / ".mcp.json"):
+            status = cu_setup.get_status()
+            assert status["enabled"] is False
+            assert status["cache_enabled"] is True
+
+    def test_enable_creates_mcp_json(self, tmp_path):
+        """Enabling computer use creates .mcp.json."""
+        mcp_path = tmp_path / ".mcp.json"
+        venv_path = tmp_path / "computer_use" / ".venv"
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "CU_VENV_DIR", venv_path),
+            patch.object(cu_setup, "CU_REQUIREMENTS", tmp_path / "nonexistent.txt"),
+            patch("subprocess.run"),
+        ):
+            result = cu_setup.enable_computer_use(cache_enabled=True)
+            assert mcp_path.exists()
+            data = json.loads(mcp_path.read_text())
+            assert "computer-use" in data["mcpServers"]
+            assert result["enabled"] is True
+
+    def test_enable_with_cache_disabled(self, tmp_path):
+        """Enabling with cache_enabled=False sets env var in .mcp.json."""
+        mcp_path = tmp_path / ".mcp.json"
+        venv_path = tmp_path / "computer_use" / ".venv"
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "CU_VENV_DIR", venv_path),
+            patch.object(cu_setup, "CU_REQUIREMENTS", tmp_path / "nonexistent.txt"),
+            patch("subprocess.run"),
+        ):
+            cu_setup.enable_computer_use(cache_enabled=False)
+            data = json.loads(mcp_path.read_text())
+            env = data["mcpServers"]["computer-use"]["env"]
+            assert env["AGENT_FORGE_CACHE_ENABLED"] == "0"
+
+    def test_disable_removes_mcp_json(self, tmp_path):
+        """Disabling computer use removes .mcp.json."""
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text('{"mcpServers": {"computer-use": {}}}')
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            result = cu_setup.disable_computer_use()
+            assert not mcp_path.exists()
+            assert result["enabled"] is False
+
+    def test_update_cache_setting(self, tmp_path):
+        """Toggling cache updates env var in .mcp.json."""
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text('{"mcpServers": {"computer-use": {"env": {}}}}')
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "PROJECT_ROOT", tmp_path),
+        ):
+            cu_setup.update_cache_setting(cache_enabled=False)
+            data = json.loads(mcp_path.read_text())
+            assert data["mcpServers"]["computer-use"]["env"]["AGENT_FORGE_CACHE_ENABLED"] == "0"
+
+    def test_get_status_reads_cache_disabled(self, tmp_path):
+        """get_status reads cache_enabled=False from .mcp.json env."""
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text(json.dumps({
+            "mcpServers": {
+                "computer-use": {
+                    "env": {"AGENT_FORGE_CACHE_ENABLED": "0"}
+                }
+            }
+        }))
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            status = cu_setup.get_status()
+            assert status["enabled"] is True
+            assert status["cache_enabled"] is False
+
+    def test_get_status_malformed_json(self, tmp_path):
+        """Malformed .mcp.json is treated as disabled."""
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text("{invalid json!!!")
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            status = cu_setup.get_status()
+            assert status["enabled"] is False
+
+    def test_get_status_venv_ready(self, tmp_path):
+        """venv_ready reflects whether venv directory exists."""
+        mcp_path = tmp_path / ".mcp.json"
+        venv_path = tmp_path / "cu_venv"
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "CU_VENV_DIR", venv_path),
+        ):
+            assert cu_setup.get_status()["venv_ready"] is False
+            venv_path.mkdir()
+            assert cu_setup.get_status()["venv_ready"] is True
+
+    def test_enable_skips_venv_creation_when_exists(self, tmp_path):
+        """Re-enabling reuses existing venv, does not recreate it."""
+        mcp_path = tmp_path / ".mcp.json"
+        venv_path = tmp_path / "cu_venv"
+        venv_path.mkdir()  # venv already exists
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "CU_VENV_DIR", venv_path),
+            patch.object(cu_setup, "CU_REQUIREMENTS", tmp_path / "nonexistent.txt"),
+            patch("subprocess.run") as mock_run,
+        ):
+            cu_setup.enable_computer_use()
+            # subprocess.run should NOT be called for venv creation
+            # (no -m venv call since venv exists)
+            for call_args in mock_run.call_args_list:
+                assert "venv" not in str(call_args)
+
+    def test_enable_installs_deps_when_requirements_exist(self, tmp_path):
+        """When requirements.txt exists, pip install is called."""
+        mcp_path = tmp_path / ".mcp.json"
+        venv_path = tmp_path / "cu_venv"
+        venv_path.mkdir()
+        reqs_path = tmp_path / "requirements.txt"
+        reqs_path.write_text("some-package==1.0\n")
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "CU_VENV_DIR", venv_path),
+            patch.object(cu_setup, "CU_REQUIREMENTS", reqs_path),
+            patch("subprocess.run") as mock_run,
+        ):
+            cu_setup.enable_computer_use()
+            # pip install should have been called
+            assert mock_run.called
+            pip_call = mock_run.call_args_list[0]
+            assert "pip" in str(pip_call)
+
+    def test_update_cache_noop_when_no_mcp_json(self, tmp_path):
+        """update_cache_setting is a no-op when .mcp.json doesn't exist."""
+        mcp_path = tmp_path / ".mcp.json"
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            result = cu_setup.update_cache_setting(cache_enabled=False)
+            assert result["enabled"] is False
+            assert not mcp_path.exists()
+
+    def test_disable_noop_when_already_disabled(self, tmp_path):
+        """Disabling when already disabled is a no-op."""
+        mcp_path = tmp_path / ".mcp.json"  # doesn't exist
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            result = cu_setup.disable_computer_use()
+            assert result["enabled"] is False
+
+    def test_mcp_json_uses_python_on_windows(self, tmp_path):
+        """On Windows, .mcp.json uses 'python' not 'python3'."""
+        with patch.object(cu_setup, "sys") as mock_sys:
+            mock_sys.platform = "win32"
+            assert cu_setup._python_command() == "python"
+
+    def test_mcp_json_uses_python3_on_unix(self, tmp_path):
+        """On non-Windows, .mcp.json uses 'python3'."""
+        with patch.object(cu_setup, "sys") as mock_sys:
+            mock_sys.platform = "linux"
+            assert cu_setup._python_command() == "python3"
+
+
+class TestComputerUseSettingsEndpoints:
+    """Tests for GET/PUT /api/settings/computer-use."""
+
+    @pytest.mark.asyncio
+    async def test_get_computer_use_status(self, client):
+        """GET returns current computer use status."""
+        resp = await client.get("/api/settings/computer-use")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "enabled" in data
+        assert "cache_enabled" in data
+
+    @pytest.mark.asyncio
+    async def test_put_enable_computer_use(self, client, tmp_path):
+        """PUT with enabled=true creates .mcp.json."""
+        mcp_path = tmp_path / ".mcp.json"
+        with (
+            patch.object(cu_setup, "MCP_JSON_PATH", mcp_path),
+            patch.object(cu_setup, "CU_VENV_DIR", tmp_path / "cu_venv"),
+            patch.object(cu_setup, "CU_REQUIREMENTS", tmp_path / "nonexistent.txt"),
+            patch("subprocess.run"),
+        ):
+            resp = await client.put("/api/settings/computer-use", json={
+                "enabled": True, "cache_enabled": True,
+            })
+            assert resp.status_code == 200
+            assert resp.json()["enabled"] is True
+            assert mcp_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_put_disable_computer_use(self, client, tmp_path):
+        """PUT with enabled=false removes .mcp.json."""
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text('{"mcpServers": {"computer-use": {}}}')
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            resp = await client.put("/api/settings/computer-use", json={
+                "enabled": False,
+            })
+            assert resp.status_code == 200
+            assert resp.json()["enabled"] is False
+            assert not mcp_path.exists()
+
+
+class TestRunBlockedWhenComputerUseDisabled:
+    """Tests that agents with computer_use=true can't run when disabled."""
+
+    @pytest.mark.asyncio
+    async def test_run_blocked_when_cu_disabled(self, client, app, tmp_path):
+        """Running an agent with computer_use=true returns 409 when disabled."""
+        agent = await app.state.agent_repo.create(
+            name="CU Agent", description="needs desktop",
+            computer_use=True, status="ready",
+        )
+        mcp_path = tmp_path / ".mcp.json"  # doesn't exist = disabled
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            resp = await client.post(f"/api/agents/{agent['id']}/run", json={})
+            assert resp.status_code == 409
+            assert resp.json()["error"]["code"] == "COMPUTER_USE_DISABLED"
+
+    @pytest.mark.asyncio
+    async def test_run_allowed_when_cu_enabled(self, client, app, tmp_path):
+        """Running an agent with computer_use=true succeeds when enabled."""
+        agent = await app.state.agent_repo.create(
+            name="CU Agent", description="needs desktop",
+            computer_use=True, status="ready",
+            forge_path="output/test/",
+        )
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text('{"mcpServers": {"computer-use": {}}}')
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            resp = await client.post(f"/api/agents/{agent['id']}/run", json={})
+            assert resp.status_code == 202
+
+    @pytest.mark.asyncio
+    async def test_run_allowed_for_cli_agent_when_cu_disabled(self, client, app, tmp_path):
+        """Running a CLI-only agent works even when computer use is disabled."""
+        agent = await app.state.agent_repo.create(
+            name="CLI Agent", description="no desktop",
+            computer_use=False, status="ready",
+        )
+        mcp_path = tmp_path / ".mcp.json"  # doesn't exist = disabled
+        with patch.object(cu_setup, "MCP_JSON_PATH", mcp_path):
+            resp = await client.post(f"/api/agents/{agent['id']}/run", json={})
+            assert resp.status_code == 202

--- a/computer_use/core/engine.py
+++ b/computer_use/core/engine.py
@@ -126,6 +126,7 @@ class ComputerUseEngine:
         self,
         config_path: Optional[str] = None,
         provider: Optional[str] = None,
+        cache_enabled: bool = True,
     ):
         self._config = self._load_config(config_path)
         self._platform = detect_platform()
@@ -152,12 +153,16 @@ class ComputerUseEngine:
         self._screen_w: int = 0
         self._screen_h: int = 0
 
-        # Muscle memory cache (cross-platform).
-        db_path = _default_cache_path()
-        self._cache = MuscleMemoryCache(db_path)
+        # Muscle memory cache (cross-platform, can be disabled).
+        if cache_enabled:
+            db_path = _default_cache_path()
+            self._cache: Optional[MuscleMemoryCache] = MuscleMemoryCache(db_path)
+            logger.info("Muscle memory cache: %s", db_path)
+        else:
+            self._cache = None
+            logger.info("Muscle memory cache: disabled")
         self._last_hint: str = ""
         self._last_app: str = ""
-        logger.info("Muscle memory cache: %s", db_path)
 
         # Foreground window cache (TTL-based).
         self._fg_window: Optional[ForegroundWindow] = None
@@ -291,6 +296,8 @@ class ComputerUseEngine:
 
     def _cache_lookup(self, ctx: _CacheContext) -> int:
         """Look up in muscle memory. Returns hit_count (0 on miss)."""
+        if self._cache is None:
+            return 0
         entry = self._cache.lookup(
             ctx.app_name, ctx.hint, ctx.cache_x, ctx.cache_y
         )
@@ -298,6 +305,8 @@ class ComputerUseEngine:
 
     def _cache_record(self, ctx: _CacheContext) -> None:
         """Record a successful interaction in muscle memory."""
+        if self._cache is None:
+            return
         self._cache.record_hit(
             ctx.app_name, ctx.hint, ctx.cache_x, ctx.cache_y,
             prev_hint=self._last_hint,
@@ -512,6 +521,12 @@ class ComputerUseEngine:
             # Step 2: strict cache lookup under current app
             # lookup_for_nav falls back to hint-only search across all apps
             # when exact app+hint misses (handles wsl2 app name mismatch).
+            if self._cache is None:
+                return {
+                    "completed": completed, "total": len(hints),
+                    "last_hint": last_hint, "stopped": True,
+                    "reason": "cache disabled, navigation unavailable",
+                }
             entry = self._cache.lookup_for_nav(current_app, hint)
             if entry is None:
                 return {
@@ -610,7 +625,7 @@ class ComputerUseEngine:
                 target_app = self._platform.value
 
         # Try path finding if we know where we are
-        if current_hint:
+        if current_hint and self._cache is not None:
             path = self._cache.find_path(target_app, current_hint, target_hint)
             if path and len(path) > 1:
                 # path is list of (app, hint) tuples; skip first (current pos).
@@ -636,6 +651,11 @@ class ComputerUseEngine:
         Returns dict with completed/total/stopped/reason (same format as
         navigate_chain). Increments use_count on successful completion.
         """
+        if self._cache is None:
+            return {
+                "completed": 0, "total": 0, "last_hint": "",
+                "stopped": True, "reason": "cache disabled, templates unavailable",
+            }
         result_tpl = self._cache.get_template(name)
         if result_tpl is None:
             return {
@@ -682,7 +702,8 @@ class ComputerUseEngine:
                 time.sleep(step.wait_ms / 1000.0)
             completed += 1
 
-        self._cache.increment_template_use(name)
+        if self._cache is not None:
+            self._cache.increment_template_use(name)
         return {
             "completed": completed, "total": len(steps),
             "last_hint": "", "stopped": False, "reason": "",

--- a/computer_use/mcp_server.py
+++ b/computer_use/mcp_server.py
@@ -94,7 +94,8 @@ def _get_engine():
     global _engine, _MAX_WIDTH
     if _engine is None:
         from computer_use.core.engine import ComputerUseEngine
-        _engine = ComputerUseEngine()
+        cache_enabled = os.environ.get("AGENT_FORGE_CACHE_ENABLED", "1") != "0"
+        _engine = ComputerUseEngine(cache_enabled=cache_enabled)
         logger.info("Engine initialized (platform=%s)", _engine.get_platform().value)
         if _MAX_WIDTH == 0:
             w, _ = _engine.get_screen_size()
@@ -395,6 +396,8 @@ def create_template(name: str, app_name: str, steps: list) -> str:
     Example step: {"action": "key_press", "text": "ctrl+s", "wait_ms": 200}
     """
     engine = _get_engine()
+    if engine._cache is None:
+        return "Error: cache is disabled, templates unavailable"
     step_dicts = [dict(s) if not isinstance(s, dict) else s for s in steps]
     try:
         tid = engine._cache.create_template(name, app_name, step_dicts)
@@ -433,6 +436,8 @@ def list_templates(app_name: str = "") -> str:
     Returns a summary of each template with name, app, use count, and step count.
     """
     engine = _get_engine()
+    if engine._cache is None:
+        return "No templates (cache is disabled)."
     templates = engine._cache.list_templates(app_name=app_name or None)
     if not templates:
         return "No templates found."
@@ -449,6 +454,8 @@ def list_templates(app_name: str = "") -> str:
 def delete_template(name: str) -> str:
     """Delete an action template by name."""
     engine = _get_engine()
+    if engine._cache is None:
+        return "Error: cache is disabled, templates unavailable"
     if engine._cache.delete_template(name):
         return f"Template '{name}' deleted."
     return f"Template '{name}' not found."

--- a/computer_use/tests/test_engine.py
+++ b/computer_use/tests/test_engine.py
@@ -1681,3 +1681,91 @@ class TestTemplateExecution:
         assert result["stopped"] is True
         assert result["completed"] == 0
         assert "error" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# TestCacheDisabled -- engine with cache_enabled=False
+# ---------------------------------------------------------------------------
+
+class TestCacheDisabled:
+    """Tests that engine works correctly when cache_enabled=False."""
+
+    def _make_engine_no_cache(self, mock_backend):
+        backend, capture, executor = mock_backend
+        backend.get_foreground_window.return_value = None
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+        ):
+            engine = ComputerUseEngine(cache_enabled=False)
+        return engine, capture, executor
+
+    def test_cache_is_none(self, mock_backend):
+        """cache_enabled=False sets _cache to None."""
+        engine, _, _ = self._make_engine_no_cache(mock_backend)
+        assert engine._cache is None
+
+    def test_cache_lookup_returns_zero(self, mock_backend):
+        """_cache_lookup returns 0 (miss) when cache is disabled."""
+        engine, _, _ = self._make_engine_no_cache(mock_backend)
+        ctx = _CacheContext(app_name="test", hint="btn", cache_x=50, cache_y=50, layer=1)
+        assert engine._cache_lookup(ctx) == 0
+
+    def test_cache_record_is_noop(self, mock_backend):
+        """_cache_record does not raise when cache is disabled."""
+        engine, _, _ = self._make_engine_no_cache(mock_backend)
+        ctx = _CacheContext(app_name="test", hint="btn", cache_x=50, cache_y=50, layer=1)
+        engine._cache_record(ctx)  # should not raise
+
+    def test_navigate_chain_stops_immediately(self, mock_backend):
+        """navigate_chain returns stopped=True when cache is disabled."""
+        engine, _, _ = self._make_engine_no_cache(mock_backend)
+        result = engine.navigate_chain("app.exe", ["menu", "file", "save"])
+        assert result["stopped"] is True
+        assert result["completed"] == 0
+        assert "cache disabled" in result["reason"]
+
+    def test_execute_template_stops_immediately(self, mock_backend):
+        """execute_template returns stopped=True when cache is disabled."""
+        engine, _, _ = self._make_engine_no_cache(mock_backend)
+        result = engine.execute_template("some-template")
+        assert result["stopped"] is True
+        assert result["completed"] == 0
+        assert "cache disabled" in result["reason"]
+
+    def test_navigate_to_skips_path_finding(self, mock_backend):
+        """navigate_to falls back to direct click when cache is None."""
+        engine, _, _ = self._make_engine_no_cache(mock_backend)
+        # With cache disabled, navigate_to should still work but skip
+        # BFS path finding and go straight to navigate_chain (which will
+        # also stop due to cache being disabled)
+        result = engine.navigate_to("target_btn", current_hint="current_btn")
+        assert result["stopped"] is True
+        assert "cache disabled" in result["reason"]
+
+    def test_screenshot_still_works(self, mock_backend):
+        """Core operations like screenshot still work without cache."""
+        engine, capture, _ = self._make_engine_no_cache(mock_backend)
+        screen = engine.screenshot()
+        assert screen.width == 1920
+        capture.capture_full.assert_called_once()
+
+    def test_click_still_works(self, mock_backend):
+        """Click still works without cache (hit_count=0 since no cache)."""
+        engine, _, executor = self._make_engine_no_cache(mock_backend)
+        engine.click(100, 200)
+        executor.click.assert_called_once_with(100, 200, hit_count=0)
+
+    def test_cache_enabled_true_creates_cache(self, mock_backend):
+        """Default (cache_enabled=True) creates a real cache object."""
+        backend, _, _ = mock_backend
+        backend.get_foreground_window.return_value = None
+        with (
+            patch("computer_use.core.engine.detect_platform", return_value=Platform.WSL2),
+            patch("computer_use.core.engine.get_backend", return_value=backend),
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            engine = ComputerUseEngine(cache_enabled=True)
+        assert engine._cache is not None

--- a/computer_use/tests/test_mcp_server.py
+++ b/computer_use/tests/test_mcp_server.py
@@ -523,6 +523,95 @@ class TestTemplateTools:
         assert "3/3" in result
 
 
+class TestCacheDisabledGuards:
+    """Tests for MCP tool behavior when engine cache is disabled."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_cache(self, mock_engine):
+        """Set engine._cache to None to simulate cache_enabled=False."""
+        mock_engine._cache = None
+        yield
+
+    def test_create_template_returns_error(self):
+        import computer_use.mcp_server as mod
+        result = mod.create_template("test", "app.exe", [{"action": "wait"}])
+        assert "cache is disabled" in result
+
+    def test_list_templates_returns_empty(self):
+        import computer_use.mcp_server as mod
+        result = mod.list_templates()
+        assert "cache is disabled" in result
+
+    def test_delete_template_returns_error(self):
+        import computer_use.mcp_server as mod
+        result = mod.delete_template("test")
+        assert "cache is disabled" in result
+
+
+class TestGetEngineEnvVar:
+    """Tests that _get_engine reads AGENT_FORGE_CACHE_ENABLED env var."""
+
+    def test_cache_disabled_via_env(self):
+        import computer_use.mcp_server as mod
+        mod._engine = None  # force re-init
+
+        with (
+            patch.dict("os.environ", {"AGENT_FORGE_CACHE_ENABLED": "0"}),
+            patch("computer_use.core.engine.detect_platform") as mock_detect,
+            patch("computer_use.core.engine.get_backend") as mock_get_backend,
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            mock_detect.return_value = Platform.WSL2
+            backend = MagicMock()
+            backend.is_available.return_value = True
+            backend.get_accessibility_info.return_value = {"available": True, "api_name": "Mock", "notes": ""}
+            capture = MagicMock()
+            capture.get_screen_size.return_value = (1920, 1080)
+            capture.get_scale_factor.return_value = 1.0
+            backend.get_screen_capture.return_value = capture
+            backend.get_action_executor.return_value = MagicMock()
+            backend.get_foreground_window.return_value = None
+            mock_get_backend.return_value = backend
+
+            engine = mod._get_engine()
+            assert engine._cache is None
+
+        mod._engine = None  # clean up
+
+    def test_cache_enabled_by_default(self):
+        import computer_use.mcp_server as mod
+        mod._engine = None
+
+        with (
+            patch.dict("os.environ", {}, clear=False),
+            patch("computer_use.core.engine.detect_platform") as mock_detect,
+            patch("computer_use.core.engine.get_backend") as mock_get_backend,
+            patch("computer_use.core.engine.yaml"),
+            patch("computer_use.core.engine._default_cache_path", return_value=":memory:"),
+        ):
+            # Remove the env var if it exists
+            import os
+            os.environ.pop("AGENT_FORGE_CACHE_ENABLED", None)
+
+            mock_detect.return_value = Platform.WSL2
+            backend = MagicMock()
+            backend.is_available.return_value = True
+            backend.get_accessibility_info.return_value = {"available": True, "api_name": "Mock", "notes": ""}
+            capture = MagicMock()
+            capture.get_screen_size.return_value = (1920, 1080)
+            capture.get_scale_factor.return_value = 1.0
+            backend.get_screen_capture.return_value = capture
+            backend.get_action_executor.return_value = MagicMock()
+            backend.get_foreground_window.return_value = None
+            mock_get_backend.return_value = backend
+
+            engine = mod._get_engine()
+            assert engine._cache is not None
+
+        mod._engine = None
+
+
 class TestEngineSingleton:
     def test_lazy_init(self):
         import computer_use.mcp_server as mod

--- a/frontend/src/components/agents/AgentForm.tsx
+++ b/frontend/src/components/agents/AgentForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import type { ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../ui/Button';
@@ -8,6 +8,7 @@ import { Select } from '../ui/Select';
 import { SchemaEditor } from './SchemaEditor';
 import { useCreateAgent, useUpdateAgent, useImportAgentPackage } from '../../hooks/useAgents';
 import { useProviders } from '../../hooks/useProviders';
+import { api } from '../../api/client';
 import { BUSY_STATUSES } from '../../types';
 import type { Agent, SchemaField } from '../../types';
 
@@ -63,6 +64,14 @@ export function AgentForm({ agent }: AgentFormProps) {
       event.target.value = '';
     }
   };
+
+  // Check if computer use is enabled globally
+  const [cuEnabled, setCuEnabled] = useState(true);
+  useEffect(() => {
+    api.get<{ enabled: boolean }>('/settings/computer-use')
+      .then((data) => setCuEnabled(data.enabled))
+      .catch(() => {});
+  }, []);
 
   const isEditing = !!agent;
   const isBusy = agent?.status !== undefined && BUSY_STATUSES.has(agent.status);
@@ -246,14 +255,14 @@ export function AgentForm({ agent }: AgentFormProps) {
                 <div className="flex items-center gap-2 shrink-0">
                   <button
                     type="button"
-                    onClick={() => toggleStepComputerUse(i)}
+                    onClick={() => cuEnabled && toggleStepComputerUse(i)}
                     className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all ${
                       step.computer_use
                         ? 'bg-accent/15 text-accent border border-accent/40 shadow-sm shadow-accent/10'
                         : 'bg-bg-tertiary text-text-muted border border-border/50 hover:border-border hover:text-text-secondary cursor-pointer'
-                    }`}
-                    disabled={isBusy}
-                    title={step.computer_use ? 'This step can take control of your computer: open apps, click, type, and navigate' : 'Click to let this step take control of your computer'}
+                    } ${!cuEnabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    disabled={isBusy || !cuEnabled}
+                    title={!cuEnabled ? 'Enable computer use in Settings to use desktop steps' : step.computer_use ? 'This step can take control of your computer: open apps, click, type, and navigate' : 'Click to let this step take control of your computer'}
                   >
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
                       <rect x="1" y="2" width="14" height="9" rx="1.5"/>

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useAgent, useDeleteAgent, useExportAgentPackage, useRunAgent, useUploadAgentArtifact } from '../hooks/useAgents';
 import { useProviders } from '../hooks/useProviders';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
 import { StatusBadge, ProviderBadge } from '../components/ui/Badge';
 import { PixelBack, PixelGear, PixelPlay, PixelStep } from '../components/ui/PixelIcon';
+import { api } from '../api/client';
 import { BUSY_STATUSES } from '../types';
 import type { ArtifactDescriptor, SchemaField } from '../types';
 
@@ -150,6 +151,16 @@ export function AgentDetail() {
 
   const isReady = agent.status === 'ready';
   const isBusy = BUSY_STATUSES.has(agent.status);
+  const [cuEnabled, setCuEnabled] = useState(true);
+  const needsCu = agent.computer_use;
+  const cuBlocked = needsCu && !cuEnabled;
+
+  useEffect(() => {
+    api.get<{ enabled: boolean }>('/settings/computer-use')
+      .then((data) => setCuEnabled(data.enabled))
+      .catch(() => {});
+  }, []);
+
   const providerOptions = providers ?? [];
   const modelOptions = providerOptions.find((provider) => provider.id === runProvider)?.models ?? [];
 
@@ -218,11 +229,20 @@ export function AgentDetail() {
           </Button>
           <Button variant="secondary" size="sm" onClick={() => navigate(`/agents/${agent.id}/edit`)} disabled={isBusy}>Edit</Button>
           <Button variant="danger" size="sm" onClick={handleDelete}>Delete</Button>
-          <Button size="sm" onClick={handleRun} disabled={runAgent.isPending || uploadArtifact.isPending || !isReady}>
+          <Button size="sm" onClick={handleRun} disabled={runAgent.isPending || uploadArtifact.isPending || !isReady || cuBlocked}>
             <PixelPlay size={12} color="var(--color-bg-primary)" /> {isBusy ? 'Generating...' : uploadArtifact.isPending ? 'Uploading...' : 'Start Run'}
           </Button>
         </div>
       </div>
+
+      {cuBlocked && (
+        <Card className="p-4 border-warning/30 bg-warning/5 mb-6">
+          <p className="text-sm text-warning font-body">
+            This agent has desktop steps but computer use is disabled.{' '}
+            <Link to="/settings" className="underline font-medium">Enable it in Settings</Link> to run this agent.
+          </p>
+        </Card>
+      )}
 
       {isBusy && (
         <Card className="p-4 border-info/30 bg-info/5 mb-6">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '../hooks/useTheme';
 import { useProviders } from '../hooks/useProviders';
 import { agentsApi } from '../api/agents';
 import { runsApi } from '../api/runs';
+import { api } from '../api/client';
 import { PixelMoon, PixelSun, PixelGear, PixelClock } from '../components/ui/PixelIcon';
 
 const STORAGE_KEY = 'agent-forge-settings';
@@ -14,6 +15,7 @@ interface AppSettings {
   defaultProvider: string;
   defaultModel: string;
   computerUse: boolean;
+  cacheEnabled: boolean;
   autoRefreshInterval: string;
   maxConcurrentRuns: number;
 }
@@ -22,6 +24,7 @@ const defaults: AppSettings = {
   defaultProvider: 'claude_code',
   defaultModel: 'claude-sonnet-4-6',
   computerUse: false,
+  cacheEnabled: true,
   autoRefreshInterval: '5',
   maxConcurrentRuns: 3,
 };
@@ -41,6 +44,44 @@ export function Settings() {
   const [settings, setSettings] = useState<AppSettings>(loadSettings);
   const [saved, setSaved] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
+  const [cuEnabled, setCuEnabled] = useState(false);
+  const [cuCacheEnabled, setCuCacheEnabled] = useState(true);
+  const [cuLoading, setCuLoading] = useState(false);
+
+  // Load computer use status from API on mount
+  useEffect(() => {
+    api.get<{ enabled: boolean; cache_enabled: boolean }>('/settings/computer-use')
+      .then((data) => {
+        setCuEnabled(data.enabled);
+        setCuCacheEnabled(data.cache_enabled);
+      })
+      .catch(() => {});
+  }, []);
+
+  const toggleComputerUse = async (enabled: boolean) => {
+    setCuLoading(true);
+    try {
+      const result = await api.put<{ enabled: boolean; cache_enabled: boolean }>(
+        '/settings/computer-use',
+        { enabled, cache_enabled: cuCacheEnabled },
+      );
+      setCuEnabled(result.enabled);
+      setCuCacheEnabled(result.cache_enabled);
+    } catch { /* ignore */ }
+    setCuLoading(false);
+  };
+
+  const toggleCuCache = async (cacheEnabled: boolean) => {
+    setCuLoading(true);
+    try {
+      const result = await api.put<{ enabled: boolean; cache_enabled: boolean }>(
+        '/settings/computer-use',
+        { enabled: cuEnabled, cache_enabled: cacheEnabled },
+      );
+      setCuCacheEnabled(result.cache_enabled);
+    } catch { /* ignore */ }
+    setCuLoading(false);
+  };
 
   useEffect(() => {
     if (saved) {
@@ -156,6 +197,62 @@ export function Settings() {
               <span
                 className="absolute top-[3px] w-5 h-5 rounded-full bg-white shadow-[0_1px_4px_rgba(0,0,0,0.2)] transition-all"
                 style={{ left: autoRefresh ? 25 : 3 }}
+              />
+            </button>
+          </div>
+        </Card>
+
+        {/* Experimental */}
+        <Card className="px-7 py-6 border-accent/20">
+          <div className="flex items-center gap-2.5 mb-1">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--color-accent)" strokeWidth="1.3">
+              <path d="M6 2v4.5L3 12.5a1 1 0 001 1.5h8a1 1 0 001-1.5L10 6.5V2" strokeLinecap="round" strokeLinejoin="round"/>
+              <line x1="4.5" y1="2" x2="11.5" y2="2" strokeLinecap="round"/>
+              <circle cx="7.5" cy="10" r="0.8" fill="var(--color-accent)" stroke="none"/>
+              <circle cx="10" cy="11.5" r="0.6" fill="var(--color-accent)" stroke="none"/>
+            </svg>
+            <h2 className="font-heading text-lg font-semibold text-text-primary">Experimental</h2>
+          </div>
+          <p className="font-body text-xs text-text-muted font-light ml-[26px] mb-5">Features in development. May not work on all platforms.</p>
+
+          {/* Computer Use Toggle */}
+          <div className="flex items-center justify-between py-3 border-b border-border/50">
+            <div className="flex-1">
+              <span className="text-sm text-text-secondary font-body">Computer use</span>
+              <p className="text-xs text-text-muted font-light mt-0.5">
+                Allows agents to control your desktop: open apps, click, type, and navigate.
+              </p>
+            </div>
+            <button
+              onClick={() => toggleComputerUse(!cuEnabled)}
+              disabled={cuLoading}
+              className="w-12 h-[26px] rounded-full border-none cursor-pointer relative transition-colors shrink-0 ml-4 disabled:opacity-50"
+              style={{ background: cuEnabled ? 'var(--color-success)' : 'var(--color-border)' }}
+            >
+              <span
+                className="absolute top-[3px] w-5 h-5 rounded-full bg-white shadow-[0_1px_4px_rgba(0,0,0,0.2)] transition-all"
+                style={{ left: cuEnabled ? 25 : 3 }}
+              />
+            </button>
+          </div>
+
+          {/* Computer Use Cache Toggle */}
+          <div className={`flex items-center justify-between py-3 mt-1 ${!cuEnabled ? 'opacity-40' : ''}`}>
+            <div className="flex-1">
+              <span className="text-sm text-text-secondary font-body">Computer use cache</span>
+              <p className="text-xs text-text-muted font-light mt-0.5">
+                Remembers where UI elements are for faster, more precise interactions.
+              </p>
+            </div>
+            <button
+              onClick={() => cuEnabled && toggleCuCache(!cuCacheEnabled)}
+              disabled={!cuEnabled || cuLoading}
+              className="w-12 h-[26px] rounded-full border-none cursor-pointer relative transition-colors shrink-0 ml-4 disabled:cursor-not-allowed"
+              style={{ background: cuEnabled && cuCacheEnabled ? 'var(--color-success)' : 'var(--color-border)' }}
+            >
+              <span
+                className="absolute top-[3px] w-5 h-5 rounded-full bg-white shadow-[0_1px_4px_rgba(0,0,0,0.2)] transition-all"
+                style={{ left: cuEnabled && cuCacheEnabled ? 25 : 3 }}
               />
             </button>
           </div>


### PR DESCRIPTION
### Summary

  - Add Experimental section in Settings with toggles to enable/disable computer use and its muscle memory cache
  - Block agents with desktop steps from running when computer use is disabled (HTTP 409 with clear message)
  - Auto-setup computer_use venv and .mcp.json when enabling, clean up .mcp.json when disabling
  - Lock CLI/Desktop toggle in agent form and show warning banner on agent detail when computer use is off

  ### Changes

  **Backend**
  - `api/routes/settings.py` -- GET/PUT `/api/settings/computer-use`
  - `api/services/computer_use_setup.py` -- venv creation, .mcp.json management, cache toggle
  - `api/routes/agents.py` -- run guard returns 409 COMPUTER_USE_DISABLED
  - `api/main.py` -- register settings router
  - `computer_use/core/engine.py` -- `cache_enabled` parameter, None-safe cache access
  - `computer_use/mcp_server.py` -- read AGENT_FORGE_CACHE_ENABLED env var, cache-disabled guards on template tools

  **Frontend**
  - `Settings.tsx` -- Experimental card with computer use and cache toggles
  - `AgentForm.tsx` -- disable desktop toggle when CU is off globally
  - `AgentDetail.tsx` -- warning banner + block run button when CU is off

  **Tests**
  - 20 service/endpoint tests (`test_settings.py`)
  - 9 engine cache-disabled tests (`test_engine.py`)
  - 5 MCP server cache-disabled tests (`test_mcp_server.py`)
  - E2E verified on WSL and Windows via API

  ### Test plan

  - [x] Unit tests pass (34 new tests across 3 files)
  - [x] E2E: disable CU, try run CU agent, get 409
  - [x] E2E: enable CU, run CU agent, get 202
  - [x] E2E: toggle cache off/on, verify .mcp.json env var
  - [x] E2E: CLI agents run regardless of CU setting
  - [x] E2E: .mcp.json readable from Windows via WSL path
  - [x] Frontend: toggle works, form locks, warning banner shows