### PR TITLE
fix: set process-scoped execution policy in PowerShell installer

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -3,6 +3,10 @@
 
 $ErrorActionPreference = "Stop"
 
+# Allow child .ps1 shims (npm.ps1, npx.ps1, etc.) to run inside this process.
+# Without this, `irm ... | iex` works but spawning npm fails under Restricted policy.
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+
 $FORGE_HOME = "$env:USERPROFILE\.forge"
 $FORGE_BIN = "$FORGE_HOME\bin"
 $FORGE_REPO = "$FORGE_HOME\Agent-Forge"


### PR DESCRIPTION
irm ... | iex runs the script inline, but npm.ps1/npx.ps1 shims are separate script files blocked by the default Restricted policy. Bypass for the current process only so child shims can execute.