### PR TITLE
fix: run git pull in child scope to suppress stderr termination

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -80,7 +80,7 @@ function InstallNode {
 function SetupRepo {
     if (Test-Path "$FORGE_REPO\.git") {
         Info "Agent Forge repo already exists, pulling latest..."
-        $pullOut = & git -C $FORGE_REPO pull --ff-only origin master 2>&1
+        & { $ErrorActionPreference = 'SilentlyContinue'; git -C $FORGE_REPO pull --ff-only origin master 2>$null }
         if ($LASTEXITCODE -ne 0) { Warn "Could not pull latest (offline?)" }
     } else {
         Info "Cloning Agent Forge..."


### PR DESCRIPTION
ErrorActionPreference=Stop makes PowerShell treat any native stderr as a terminating error, regardless of 2> or 2>&1 redirections. Run git in a child scriptblock with SilentlyContinue to isolate it.