### PR TITLE
fix: use taskkill /T to kill entire process tree on forge stop

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -232,7 +232,8 @@ function Stop-Forge {
             if ($procId) {
                 $proc = Get-Process -Id $procId -ErrorAction SilentlyContinue
                 if ($proc) {
-                    Stop-Process -Id $procId -Force
+                    # taskkill /T kills the entire process tree (e.g. npm.cmd -> node.exe)
+                    & taskkill /PID $procId /T /F 2>$null | Out-Null
                     Info "Stopped $service (PID $procId)"
                     $stopped = $true
                 }


### PR DESCRIPTION
Stop-Process only kills the parent (npm.cmd), leaving child node.exe running. taskkill /T kills the full tree so Vite actually stops.