### PR TITLE
fix: TOML backslash escape error in Codex MCP config on Windows

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -54,14 +54,18 @@ def _gemini_settings_content(cache_enabled: bool = True) -> dict:
 
 
 def _codex_config_content(cache_enabled: bool = True) -> str:
-    """Build .codex/config.toml content with MCP server configuration."""
+    """Build .codex/config.toml content with MCP server configuration.
+
+    Uses TOML literal strings (single quotes) for ``cwd`` so that Windows
+    backslashes are treated as literal characters, not escape sequences.
+    """
     python = _python_command()
     cwd = str(PROJECT_ROOT)
     lines = [
         '[mcp_servers.computer-use]',
         f'command = "{python}"',
         'args = ["-m", "computer_use.mcp_server", "--transport", "stdio"]',
-        f'cwd = "{cwd}"',
+        f"cwd = '{cwd}'",
         '',
         '[mcp_servers.computer-use.env]',
         'AGENT_FORGE_DEBUG = "1"',

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -343,6 +343,19 @@ class TestMultiProviderMcpConfig:
             # Should have args as array
             assert 'args = [' in content
 
+    def test_codex_config_backslashes_safe_on_windows(self, tmp_path):
+        """cwd with Windows backslashes must use TOML literal strings (single quotes)."""
+        # Simulate a Windows-style path with backslashes
+        fake_root = Path("C:\\Users\\TestUser\\.forge\\Agent-Forge")
+        with self._patch_all(tmp_path):
+            with patch.object(cu_setup, "PROJECT_ROOT", fake_root):
+                cu_setup.enable_computer_use()
+                content = (tmp_path / ".codex" / "config.toml").read_text()
+                # cwd must use single quotes so backslashes are literal, not TOML escapes
+                assert "cwd = 'C:\\Users\\TestUser\\.forge\\Agent-Forge'" in content
+                # Must NOT use double quotes with unescaped backslashes
+                assert 'cwd = "C:\\' not in content
+
     def test_disable_removes_all_config_files(self, tmp_path):
         """Disabling computer use removes .mcp.json, .gemini/settings.json, and .codex/config.toml."""
         mcp_path = tmp_path / ".mcp.json"


### PR DESCRIPTION
## Summary

  - Fix `[WinError]` TOML parse error when Codex CLI reads `.codex/config.toml` on Windows
  - Windows paths like `C:\Users\...` contain `\U`, `\S`, `\.` which TOML double-quoted strings interpret as
  escape sequences
  - Switch `cwd` value from double quotes to TOML literal strings (single quotes) where backslashes are literal
  characters
  - Linux paths have no backslashes so behavior is unchanged

  ## Root cause

  ```toml
  # Before (broken on Windows):
  cwd = "C:\Users\Santigo\.forge\Agent-Forge"
  #          \U = invalid unicode escape → TOML parse error

  # After (works everywhere):
  cwd = 'C:\Users\Santigo\.forge\Agent-Forge'
  #     single quotes = literal string, no escaping
  ```

  Test plan

  - New test: test_codex_config_backslashes_safe_on_windows verifies single quotes with Windows paths
  - 34/34 settings tests pass (no regressions)
  - Manual: reinstall on Windows and run agent with Codex provider