### PR TITLE
fix: computer use toggle resets to disabled after navigating away

### DIFF
--- a/frontend/src/hooks/useComputerUse.ts
+++ b/frontend/src/hooks/useComputerUse.ts
@@ -1,0 +1,50 @@
+/**
+ * Module-scoped state for computer use toggle operations.
+ *
+ * The enable/disable PUT can take 30-60s (venv creation + pip install).
+ * If the user navigates away and back, the Settings component remounts
+ * and re-fetches status from the backend — which still returns the old
+ * state because the PUT hasn't completed. This makes the toggle "reset".
+ *
+ * This module keeps the in-flight promise outside React component
+ * lifecycle so remounts can pick it up instead of re-fetching stale state.
+ */
+
+import { api } from '../api/client';
+
+interface CuStatus {
+  enabled: boolean;
+  cache_enabled: boolean;
+}
+
+let inflight: {
+  promise: Promise<CuStatus>;
+  activating: boolean;
+} | null = null;
+
+export function getInflight() {
+  return inflight;
+}
+
+export function resetInflight() {
+  inflight = null;
+}
+
+export async function toggleComputerUse(
+  enabled: boolean,
+  cacheEnabled: boolean,
+): Promise<CuStatus> {
+  const promise = api.put<CuStatus>('/settings/computer-use', {
+    enabled,
+    cache_enabled: cacheEnabled,
+  });
+
+  inflight = { promise, activating: enabled };
+
+  try {
+    const result = await promise;
+    return result;
+  } finally {
+    inflight = null;
+  }
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import { agentsApi } from '../api/agents';
 import { runsApi } from '../api/runs';
 import { api } from '../api/client';
 import { PixelMoon, PixelSun, PixelGear, PixelClock } from '../components/ui/PixelIcon';
+import { getInflight, toggleComputerUse as toggleCu } from '../hooks/useComputerUse';
 
 const STORAGE_KEY = 'agent-forge-settings';
 
@@ -50,14 +51,30 @@ export function Settings() {
   const [cuActivating, setCuActivating] = useState(false); // true = enabling, false = disabling
   const [cuError, setCuError] = useState<string | null>(null);
 
-  // Load computer use status from API on mount
+  // Load computer use status from API on mount, or pick up in-flight operation
   useEffect(() => {
-    api.get<{ enabled: boolean; cache_enabled: boolean }>('/settings/computer-use')
-      .then((data) => {
-        setCuEnabled(data.enabled);
-        setCuCacheEnabled(data.cache_enabled);
-      })
-      .catch(() => {});
+    const pending = getInflight();
+    if (pending) {
+      // An enable/disable is still running from before navigation — await it
+      setCuLoading(true);
+      setCuActivating(pending.activating);
+      pending.promise
+        .then((result) => {
+          setCuEnabled(result.enabled);
+          setCuCacheEnabled(result.cache_enabled);
+        })
+        .catch((e) => {
+          setCuError(e instanceof Error ? e.message : 'Failed to update computer use');
+        })
+        .finally(() => setCuLoading(false));
+    } else {
+      api.get<{ enabled: boolean; cache_enabled: boolean }>('/settings/computer-use')
+        .then((data) => {
+          setCuEnabled(data.enabled);
+          setCuCacheEnabled(data.cache_enabled);
+        })
+        .catch(() => {});
+    }
   }, []);
 
   const toggleComputerUse = async (enabled: boolean) => {
@@ -65,10 +82,7 @@ export function Settings() {
     setCuActivating(enabled);
     setCuError(null);
     try {
-      const result = await api.put<{ enabled: boolean; cache_enabled: boolean }>(
-        '/settings/computer-use',
-        { enabled, cache_enabled: cuCacheEnabled },
-      );
+      const result = await toggleCu(enabled, cuCacheEnabled);
       setCuEnabled(result.enabled);
       setCuCacheEnabled(result.cache_enabled);
     } catch (e) {

--- a/frontend/src/pages/__tests__/Settings.test.tsx
+++ b/frontend/src/pages/__tests__/Settings.test.tsx
@@ -33,6 +33,19 @@ vi.mock('../../api/client', () => ({
   },
 }));
 
+// Mock useComputerUse — delegate toggleComputerUse to mockPut so existing tests work,
+// but track inflight state for navigation tests.
+let mockInflight: { promise: Promise<unknown>; activating: boolean } | null = null;
+vi.mock('../../hooks/useComputerUse', () => ({
+  getInflight: () => mockInflight,
+  resetInflight: () => { mockInflight = null; },
+  toggleComputerUse: (enabled: boolean, cacheEnabled: boolean) => {
+    const promise = mockPut('/settings/computer-use', { enabled, cache_enabled: cacheEnabled });
+    mockInflight = { promise, activating: enabled };
+    return promise.finally(() => { mockInflight = null; });
+  },
+}));
+
 import { Settings } from '../Settings';
 
 describe('Settings - Computer Use Toggle', () => {
@@ -132,5 +145,59 @@ describe('Settings - Computer Use Toggle', () => {
     });
     const pingEl = document.querySelector('.animate-ping');
     expect(pingEl).toBeNull();
+  });
+});
+
+describe('Settings - Computer Use Toggle survives navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ enabled: false, cache_enabled: true });
+    mockInflight = null;
+  });
+
+  it('remount shows Activating while PUT is still in flight', async () => {
+    let resolvePut: (v: unknown) => void;
+    mockPut.mockReturnValue(new Promise((r) => { resolvePut = r; }));
+
+    // Mount, toggle ON
+    const { unmount } = render(<Settings />);
+    await waitFor(() => expect(screen.getByText('Disabled')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: /computer use toggle/i }));
+    await waitFor(() => expect(screen.getByText('Activating...')).toBeTruthy());
+
+    // Simulate navigation: unmount and remount
+    unmount();
+    render(<Settings />);
+
+    // Should still show Activating, NOT Disabled
+    await waitFor(() => {
+      expect(screen.getByText('Activating...')).toBeTruthy();
+    });
+
+    // Resolve the PUT
+    resolvePut!({ enabled: true, cache_enabled: true });
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeTruthy();
+    });
+  });
+
+  it('remount shows Active after in-flight PUT resolves', async () => {
+    // PUT resolves immediately
+    mockPut.mockResolvedValue({ enabled: true, cache_enabled: true });
+
+    const { unmount } = render(<Settings />);
+    await waitFor(() => expect(screen.getByText('Disabled')).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: /computer use toggle/i }));
+    await waitFor(() => expect(screen.getByText('Active')).toBeTruthy());
+
+    // Navigate away and back
+    unmount();
+    // Now GET returns the updated state
+    mockGet.mockResolvedValue({ enabled: true, cache_enabled: true });
+    render(<Settings />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
  ## Summary

  - Fix visual bug where the computer use toggle in Settings resets to "Disabled" when the user navigates away
  and comes back while activation is in progress
  - Add `useComputerUse.ts` hook with a module-scoped singleton that holds the in-flight PUT promise, surviving
  React component unmount/remount cycles
  - On remount, Settings checks for a pending operation first and shows "Activating..." instead of re-fetching
  stale state from the backend

  ## Root cause

  Enabling computer use takes 30-60s (venv creation + pip install). If the user navigates away mid-operation,
  the component unmounts. On remount, `useEffect` fires a GET that returns `enabled: false` (backend still
  busy), resetting the toggle. The user has to re-toggle, but the second time works instantly because the venv
  was already created by the first attempt.

  ## Test plan

  - [x] New test: `remount shows Activating while PUT is still in flight`
  - [x] New test: `remount shows Active after in-flight PUT resolves`
  - [x] 8/8 Settings tests pass (no regressions)
  - [x] 102/102 all frontend tests pass