### PR TITLE
  fix: MCP server fails to start - configs use system Python instead of venv

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from api.utils.platform import python_command, venv_pip
+from api.utils.platform import python_command, venv_pip, venv_python
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,17 @@ def _python_command() -> str:
     return python_command()
 
 
+def _cu_venv_python() -> str:
+    """Return the full path to the Python inside the computer_use venv.
+
+    CLI tools (Codex, Gemini) start MCP servers independently -- they
+    don't inherit our PATH, so bare ``python`` resolves to the system
+    Python which lacks the MCP dependencies.  Using the full venv path
+    works on both Windows (Scripts/python) and Linux (bin/python).
+    """
+    return str(venv_python(CU_VENV_DIR))
+
+
 def _mcp_json_content(cache_enabled: bool = True) -> dict:
     """Build .mcp.json content with platform-correct values."""
     env = {"AGENT_FORGE_DEBUG": "1"}
@@ -39,7 +50,7 @@ def _mcp_json_content(cache_enabled: bool = True) -> dict:
     return {
         "mcpServers": {
             "computer-use": {
-                "command": _python_command(),
+                "command": _cu_venv_python(),
                 "args": ["-m", "computer_use.mcp_server", "--transport", "stdio"],
                 "cwd": str(PROJECT_ROOT),
                 "env": env,
@@ -59,11 +70,11 @@ def _codex_config_content(cache_enabled: bool = True) -> str:
     Uses TOML literal strings (single quotes) for ``cwd`` so that Windows
     backslashes are treated as literal characters, not escape sequences.
     """
-    python = _python_command()
+    python = _cu_venv_python()
     cwd = str(PROJECT_ROOT)
     lines = [
         '[mcp_servers.computer-use]',
-        f'command = "{python}"',
+        f"command = '{python}'",
         'args = ["-m", "computer_use.mcp_server", "--transport", "stdio"]',
         f"cwd = '{cwd}'",
         '',

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -304,7 +304,7 @@ class TestMultiProviderMcpConfig:
             data = json.loads(gemini_path.read_text())
             assert "computer-use" in data["mcpServers"]
             server = data["mcpServers"]["computer-use"]
-            assert server["command"] == cu_setup._python_command()
+            assert "python" in server["command"]  # full venv path contains 'python'
             assert "-m" in server["args"]
             assert "computer_use.mcp_server" in server["args"]
 
@@ -338,8 +338,9 @@ class TestMultiProviderMcpConfig:
             content = (tmp_path / ".codex" / "config.toml").read_text()
             # Should have the server table
             assert "[mcp_servers.computer-use]" in content
-            # Should have command
-            assert f'command = "{cu_setup._python_command()}"' in content
+            # Should have command with venv python path
+            assert "command = '" in content
+            assert "python" in content
             # Should have args as array
             assert 'args = [' in content
 
@@ -405,6 +406,47 @@ class TestMultiProviderMcpConfig:
             cu_setup.enable_computer_use(cache_enabled=False)
             content = (tmp_path / ".codex" / "config.toml").read_text()
             assert 'AGENT_FORGE_CACHE_ENABLED = "0"' in content
+
+    def test_all_configs_use_venv_python_not_bare_command(self, tmp_path):
+        """All MCP configs must use the full venv Python path, not bare python/python3."""
+        from api.utils.platform import venv_python
+        with self._patch_all(tmp_path):
+            cu_setup.enable_computer_use()
+            expected_python = str(venv_python(tmp_path / "cu_venv"))
+
+            # .mcp.json
+            mcp_data = json.loads((tmp_path / ".mcp.json").read_text())
+            assert mcp_data["mcpServers"]["computer-use"]["command"] == expected_python
+
+            # .gemini/settings.json
+            gemini_data = json.loads((tmp_path / ".gemini" / "settings.json").read_text())
+            assert gemini_data["mcpServers"]["computer-use"]["command"] == expected_python
+
+            # .codex/config.toml
+            codex_content = (tmp_path / ".codex" / "config.toml").read_text()
+            assert expected_python in codex_content
+
+    @patch("api.utils.platform.sys")
+    def test_venv_python_path_correct_on_linux(self, mock_sys, tmp_path):
+        """On Linux, configs use the venv bin/python path."""
+        mock_sys.platform = "linux"
+        with self._patch_all(tmp_path):
+            cu_setup.enable_computer_use()
+            mcp_data = json.loads((tmp_path / ".mcp.json").read_text())
+            command = mcp_data["mcpServers"]["computer-use"]["command"]
+            # Should contain bin/python, not Scripts/python
+            assert "bin" in command.replace("\\", "/")
+            assert "Scripts" not in command
+
+    @patch("api.utils.platform.sys")
+    def test_venv_python_path_correct_on_windows(self, mock_sys, tmp_path):
+        """On Windows, configs use the venv Scripts/python path."""
+        mock_sys.platform = "win32"
+        with self._patch_all(tmp_path):
+            cu_setup.enable_computer_use()
+            mcp_data = json.loads((tmp_path / ".mcp.json").read_text())
+            command = mcp_data["mcpServers"]["computer-use"]["command"]
+            assert "Scripts" in command
 
     def test_disable_tolerates_missing_gemini_and_codex(self, tmp_path):
         """Disable works even if only .mcp.json exists (Gemini/Codex never written)."""


### PR DESCRIPTION
  ## Summary

  - MCP configs (`.mcp.json`, `.gemini/settings.json`, `.codex/config.toml`) used bare `python`/`python3` as the
   command, which resolves to the system Python that lacks MCP dependencies
  - Replace with the full path to `computer_use/.venv/Scripts/python` (Windows) or
  `computer_use/.venv/bin/python` (Linux) using the existing `venv_python()` utility
  - Also use TOML literal strings for the Codex command path (backslash safety)

  ## Root cause

  Codex and Gemini start MCP servers independently by reading their config files. Unlike Claude Code (where we
  control the subprocess PATH), these tools don't inherit our venv PATH manipulation. The system Python can't
  import `computer_use.mcp_server` because `yaml`, `fastmcp`, etc. aren't installed there.

  ## Test plan

  - [x] New test: `test_all_configs_use_venv_python_not_bare_command` — verifies all 3 configs use venv path
  - [x] New test: `test_venv_python_path_correct_on_linux` — mocks Linux, verifies `bin/python`
  - [x] New test: `test_venv_python_path_correct_on_windows` — mocks Windows, verifies `Scripts/python`
  - [x] 37/37 settings tests pass (no regressions)
  - [ ] Manual: reinstall, enable computer use, run agent with Codex — verify MCP tools available