### PR TITLE
feat: add universal execution directive to all agent prompts

### DIFF
--- a/api/engine/providers.py
+++ b/api/engine/providers.py
@@ -536,6 +536,15 @@ class CLIAgentProvider:
                 await kill_process_tree(proc)
 
 
+_EXECUTION_DIRECTIVE = (
+    "Execute this step immediately. DO NOT summarize what you read. DO NOT ask "
+    "for confirmation. DO NOT say \"I can do this if you want\". Read the step "
+    "file, perform every action it describes, and write all required output "
+    "files before finishing. If a step requires computer use tools, use them "
+    "-- do not describe what you would do, actually do it."
+)
+
+
 def build_agent_prompt(agent: dict, inputs: dict, run_id: str = "") -> str:
     """Build the prompt to send to the CLI provider.
 
@@ -610,6 +619,7 @@ def build_agent_prompt(agent: dict, inputs: dict, run_id: str = "") -> str:
             )
         parts.append("No explanation, no markdown -- just the JSON.")
 
+    parts.append(f"\n{_EXECUTION_DIRECTIVE}")
     return "\n".join(parts)
 
 
@@ -725,6 +735,7 @@ def build_step_prompt(
             )
         parts.append("No explanation, no markdown -- just the JSON.")
 
+    parts.append(f"\n{_EXECUTION_DIRECTIVE}")
     return "\n".join(parts)
 
 

--- a/api/tests/test_executor.py
+++ b/api/tests/test_executor.py
@@ -512,6 +512,31 @@ class TestBuildStepPrompt:
         assert "output/agent_outputs/" in prompt
         assert "step_01_agent_output.md" in prompt
 
+    def test_step_prompt_has_execution_directive(self):
+        """Every step prompt ends with the universal execution directive."""
+        agent = {
+            "forge_path": "output/test/",
+            "name": "test",
+            "steps": [{"name": "Analyze", "computer_use": False}],
+            "output_schema": [],
+        }
+        prompt = build_step_prompt(agent, {}, step_number=1, step=agent["steps"][0])
+        assert "DO NOT summarize" in prompt
+        assert "DO NOT ask for confirmation" in prompt
+        assert "Execute this step immediately" in prompt
+
+    def test_execution_directive_is_last_section(self):
+        """The execution directive should be at the end of the prompt."""
+        agent = {
+            "forge_path": "output/test/",
+            "name": "test",
+            "steps": [{"name": "Analyze", "computer_use": False}],
+            "output_schema": [],
+        }
+        prompt = build_step_prompt(agent, {"topic": "AI"}, step_number=1, step=agent["steps"][0])
+        # The directive should be in the last lines
+        assert prompt.strip().endswith("actually do it.")
+
     def test_new_format_references_correct_step(self, tmp_path):
         """Step file reference matches step number and kebab name."""
         forge_path = "output/test-agent"

--- a/api/tests/test_services.py
+++ b/api/tests/test_services.py
@@ -223,6 +223,20 @@ class TestBuildAgentPrompt:
         prompt = build_agent_prompt(agent, {})
         assert "Your goal:" not in prompt
 
+    def test_prompt_has_execution_directive(self):
+        """Every agent prompt ends with the universal execution directive."""
+        agent = {"name": "T", "description": "test", "forge_path": "output/t/"}
+        prompt = build_agent_prompt(agent, {})
+        assert "DO NOT summarize" in prompt
+        assert "DO NOT ask for confirmation" in prompt
+        assert "Execute this step immediately" in prompt
+
+    def test_execution_directive_present_without_forge_path(self):
+        """Execution directive is appended even for agents without forge_path."""
+        agent = {"name": "T", "description": "test", "forge_path": ""}
+        prompt = build_agent_prompt(agent, {})
+        assert "Execute this step immediately" in prompt
+
 
 class TestCLIAgentProvider:
 


### PR DESCRIPTION
  ## Summary

  - Append a universal execution directive to every prompt sent to CLI providers
  - Tells agents to execute immediately, not summarize, not ask for confirmation
  - Fixes Codex/GPT treating step prompts as informational in `exec` mode — reading agentic.md and saying "I can
   do this if you want" instead of actually executing

  ## The directive

  Execute this step immediately. DO NOT summarize what you read. DO NOT ask
  for confirmation. DO NOT say "I can do this if you want". Read the step
  file, perform every action it describes, and write all required output
  files before finishing. If a step requires computer use tools, use them
  -- do not describe what you would do, actually do it.

  ## Why

  Claude Code follows "read and execute" literally. Codex/GPT in `exec` mode interprets the same prompt as a
  planning/conversation task, reads the context, and reports back instead of acting. The directive makes the
  expected behavior explicit for all providers.

  ## Test plan

  - [x] `test_prompt_has_execution_directive` — agent prompt contains the directive
  - [x] `test_execution_directive_present_without_forge_path` — works for non-forge agents too
  - [x] `test_step_prompt_has_execution_directive` — step prompt contains the directive
  - [x] `test_execution_directive_is_last_section` — directive is always at the end
  - [x] 143/143 tests pass across services + executor (no regressions)