### PR TITLE
fix: WSL2 backend available when bridge daemon reachable

### DIFF
--- a/computer_use/platform/wsl2.py
+++ b/computer_use/platform/wsl2.py
@@ -1080,6 +1080,12 @@ class WSL2Backend(PlatformBackend):
         return self._executor
 
     def is_available(self) -> bool:
+        # Bridge daemon (native Windows TCP server) is the primary path --
+        # it doesn't need powershell.exe on PATH at all.
+        if self._probe_bridge():
+            return True
+        # Fallback: PowerShell subprocess (needs powershell.exe on PATH).
+        # On WSL2 with appendWindowsPath=false, shutil.which won't find it.
         return shutil.which("powershell.exe") is not None
 
     def get_foreground_window(self):

--- a/computer_use/tests/test_wsl2.py
+++ b/computer_use/tests/test_wsl2.py
@@ -604,13 +604,21 @@ class TestWSL2ActionExecutor:
 
 class TestWSL2Backend:
     @patch("shutil.which", return_value="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
-    def test_is_available_true(self, _which):
+    def test_is_available_true_powershell(self, _which):
         backend = WSL2Backend()
         assert backend.is_available() is True
-        _which.assert_called_with("powershell.exe")
 
+    @patch.object(WSL2Backend, "_probe_bridge", return_value=True)
     @patch("shutil.which", return_value=None)
-    def test_is_available_false(self, _which):
+    def test_is_available_true_bridge_daemon(self, _which, _bridge):
+        """Available when bridge daemon is reachable even without powershell on PATH."""
+        backend = WSL2Backend()
+        assert backend.is_available() is True
+
+    @patch.object(WSL2Backend, "_probe_bridge", return_value=False)
+    @patch("shutil.which", return_value=None)
+    def test_is_available_false(self, _which, _bridge):
+        """Not available when neither powershell nor bridge daemon are reachable."""
         backend = WSL2Backend()
         assert backend.is_available() is False
 


### PR DESCRIPTION
is_available() only checked shutil.which("powershell.exe"), which fails on WSL2 with appendWindowsPath=false in /etc/wsl.conf or when binfmt WSLInterop isn't registered (sandboxed environments, MCP child processes). The bridge daemon is the primary screenshot path and runs natively on Windows over TCP -- it doesn't need powershell on PATH.

Now is_available() checks the bridge daemon first via _probe_bridge(). If reachable, returns True without requiring powershell.exe.