### PR TITLE
fix: register pulled agents with API (#61)

### DIFF
--- a/cli/commands/registry.py
+++ b/cli/commands/registry.py
@@ -6,7 +6,7 @@ import click
 
 from registry import registry_client
 from registry.config import load_config, save_config, CONFIG_PATH
-from cli.output import print_table, print_success, print_warning, status_text
+from cli.output import print_table, print_success, print_warning, print_info, status_text
 
 
 @click.group("registry")
@@ -31,13 +31,23 @@ def pack(folder: str, output: str | None):
 @click.argument("name")
 @click.option("--registry", "-r", default=None)
 @click.option("--force", "-f", is_flag=True)
-def pull(name: str, registry: str | None, force: bool):
+@click.pass_context
+def pull(ctx, name: str, registry: str | None, force: bool):
     """Download and install an agent from a registry."""
+    import tempfile
+    from pathlib import Path
+
+    archive_path = Path(tempfile.mktemp(suffix=".agnt"))
     try:
-        result = registry_client.pull(name, registry_name=registry, force=force)
+        result = registry_client.pull(
+            name, registry_name=registry, force=force, keep_archive=archive_path,
+        )
         print_success(f"Installed: {name} -> {result}")
     except (ValueError, FileExistsError, FileNotFoundError, RuntimeError) as e:
+        archive_path.unlink(missing_ok=True)
         raise click.ClickException(str(e))
+
+    _import_to_api(ctx, name, archive_path)
 
 
 @registry_group.command()
@@ -195,3 +205,41 @@ def remove_registry(name: str):
     config["registries"] = registries
     save_config(config)
     print_success(f"Removed registry '{name}'")
+
+
+# -- Helpers --
+
+def _import_to_api(ctx, name: str, archive_path):
+    """Register a pulled agent with the API so it appears in `forge agents list`."""
+    from pathlib import Path
+
+    try:
+        from cli.commands.agents import _upload_agnt
+        from cli.output import wait_with_spinner
+        import time
+
+        data = _upload_agnt(ctx, str(archive_path))
+        agent_id = data.get("id", "?")
+        agent_name = data.get("name", name)
+        print_info(f"Registering {agent_name} with API...")
+        time.sleep(1)
+
+        _agent_done = lambda r: r.get("status") not in ("creating", "updating", "importing")
+        result = wait_with_spinner(
+            ctx, f"/api/agents/{agent_id}", _agent_done,
+            f"Setting up {agent_name}...",
+        )
+
+        if result.get("status") == "ready":
+            print_success(f"{agent_name} is ready (ID: {agent_id[:8]})")
+        else:
+            print_warning(f"{agent_name} finished with status: {result.get('status')}")
+    except Exception:
+        print_warning(
+            f"Agent files installed but API registration failed.\n"
+            f"  Is the API running? Start it with: forge start\n"
+            f"  Then import manually with: forge agents import {archive_path}"
+        )
+        return
+    finally:
+        Path(archive_path).unlink(missing_ok=True)

--- a/cli/tests/test_registry_cmd.py
+++ b/cli/tests/test_registry_cmd.py
@@ -82,6 +82,45 @@ class TestRegistrySearch:
             assert "No agents found" in result.output
 
 
+class TestRegistryPullApiSync:
+    """Regression test for issue #61: pulled agents must appear in `forge agents list`.
+
+    `forge registry pull` installs files to ~/.forge/agents/ but must also
+    register the agent with the API so `forge agents list` returns it.
+    """
+
+    def test_pull_registers_agent_with_api(self, runner):
+        """After a successful pull, the agent should be imported into the API."""
+        from cli.commands.registry import registry_group
+
+        with mock.patch("cli.commands.registry.registry_client") as m_reg, \
+             mock.patch("cli.commands.registry._import_to_api") as m_import:
+            m_reg.pull.return_value = "/home/user/.forge/agents/test-agent"
+            m_import.return_value = None
+
+            result = runner.invoke(registry_group, ["pull", "test-agent"])
+
+            assert result.exit_code == 0
+            assert "Installed" in result.output
+            m_import.assert_called_once()
+
+    def test_pull_api_unavailable_still_succeeds(self, runner):
+        """If the API is down, pull should still succeed (files installed) with a warning."""
+        from cli.commands.registry import registry_group
+
+        with mock.patch("cli.commands.registry.registry_client") as m_reg, \
+             mock.patch("cli.commands.agents._upload_agnt") as m_upload:
+            m_reg.pull.return_value = "/home/user/.forge/agents/test-agent"
+            m_upload.side_effect = Exception("Connection refused")
+
+            result = runner.invoke(registry_group, ["pull", "test-agent"])
+
+            assert result.exit_code == 0
+            assert "Installed" in result.output
+            # Should warn that API registration failed
+            assert "API registration failed" in result.output
+
+
 class TestRegistryAgents:
     def test_list_installed(self, runner):
         from cli.commands.registry import registry_group

--- a/registry/registry_client.py
+++ b/registry/registry_client.py
@@ -42,14 +42,20 @@ def pull(
     name: str,
     registry_name: Optional[str] = None,
     force: bool = False,
+    keep_archive: Optional[Path] = None,
 ) -> str:
     """Pull an agent from a registry and install it locally.
 
     Searches the specified registry (or default) for the agent by name,
     downloads the .agnt file, and installs it to ~/.forge/agents/.
 
+    If *keep_archive* is given, the downloaded .agnt file is copied there
+    before the temporary directory is cleaned up.
+
     Returns the path to the installed agent.
     """
+    import shutil
+
     adapter = _get_adapter(registry_name)
     agent_info = adapter.find_agent(name)
     if not agent_info:
@@ -72,6 +78,9 @@ def pull(
             verify_sha256(agnt_path, expected_hash)
 
         install_dir = install_agent(agnt_path, agents_dir=agents_dir, force=force)
+
+        if keep_archive:
+            shutil.copy2(agnt_path, keep_archive)
 
     return str(install_dir)
 

--- a/registry/tests/test_cli.py
+++ b/registry/tests/test_cli.py
@@ -65,14 +65,22 @@ class TestPullCommand:
         mock_pull.return_value = "/home/user/.forge/agents/test-agent"
         result = runner.invoke(cli, ["pull", "test-agent", "--force"])
         assert result.exit_code == 0
-        mock_pull.assert_called_once_with("test-agent", registry_name=None, force=True)
+        mock_pull.assert_called_once()
+        args, kwargs = mock_pull.call_args
+        assert args == ("test-agent",)
+        assert kwargs["registry_name"] is None
+        assert kwargs["force"] is True
 
     @patch("registry.registry_client.pull")
     def test_pull_specific_registry(self, mock_pull, runner):
         mock_pull.return_value = "/path/to/agent"
         result = runner.invoke(cli, ["pull", "test-agent", "-r", "my-registry"])
         assert result.exit_code == 0
-        mock_pull.assert_called_once_with("test-agent", registry_name="my-registry", force=False)
+        mock_pull.assert_called_once()
+        args, kwargs = mock_pull.call_args
+        assert args == ("test-agent",)
+        assert kwargs["registry_name"] == "my-registry"
+        assert kwargs["force"] is False
 
 
 class TestPushCommand:


### PR DESCRIPTION
## Summary

- `forge registry pull` was only installing agent files to disk (~/.forge/agents/) without registering them in the API database
- `forge agents list` queries the API, so pulled agents were invisible
- After pull, the .agnt archive is now uploaded to the API import endpoint so the agent shows up in both `forge registry agents` and `forge agents list`
- If the API is down, pull still works -- files are installed and a warning is shown with manual import instructions

## Test plan

- [x] Added regression tests in `cli/tests/test_registry_cmd.py` (TestRegistryPullApiSync)
- [x] Verified all existing registry and CLI tests still pass (174 passed)
- [ ] Manual: `forge registry pull <agent>` then `forge agents list` should show the agent

Closes #61