### PR TITLE
fix: show error details on pull API import failure (#63)

### DIFF
--- a/cli/commands/registry.py
+++ b/cli/commands/registry.py
@@ -234,12 +234,13 @@ def _import_to_api(ctx, name: str, archive_path):
             print_success(f"{agent_name} is ready (ID: {agent_id[:8]})")
         else:
             print_warning(f"{agent_name} finished with status: {result.get('status')}")
-    except Exception:
+    except Exception as exc:
         print_warning(
-            f"Agent files installed but API registration failed.\n"
+            f"Agent files installed but API registration failed: {exc}\n"
             f"  Is the API running? Start it with: forge start\n"
             f"  Then import manually with: forge agents import {archive_path}"
         )
         return
-    finally:
-        Path(archive_path).unlink(missing_ok=True)
+
+    # Only clean up the archive on success; on failure it stays for manual import
+    Path(archive_path).unlink(missing_ok=True)

--- a/cli/tests/test_registry_cmd.py
+++ b/cli/tests/test_registry_cmd.py
@@ -120,6 +120,37 @@ class TestRegistryPullApiSync:
             # Should warn that API registration failed
             assert "API registration failed" in result.output
 
+    def test_pull_api_failure_shows_reason(self, runner):
+        """Error message should include the actual failure reason for debugging."""
+        from cli.commands.registry import registry_group
+
+        with mock.patch("cli.commands.registry.registry_client") as m_reg, \
+             mock.patch("cli.commands.agents._upload_agnt") as m_upload:
+            m_reg.pull.return_value = "/home/user/.forge/agents/test-agent"
+            m_upload.side_effect = Exception("Import failed: 422 Unprocessable Entity")
+
+            result = runner.invoke(registry_group, ["pull", "test-agent"])
+
+            assert result.exit_code == 0
+            # Should show the actual error so users can debug
+            assert "422" in result.output or "Import failed" in result.output
+
+    def test_pull_api_failure_preserves_archive(self, runner, tmp_path):
+        """When API import fails, the .agnt archive should be kept for manual import."""
+        from cli.commands.registry import _import_to_api
+        from pathlib import Path
+
+        archive = tmp_path / "test-agent.agnt"
+        archive.write_bytes(b"fake archive")
+
+        with mock.patch("cli.commands.agents._upload_agnt") as m_upload:
+            m_upload.side_effect = Exception("Connection refused")
+            ctx = mock.MagicMock()
+            _import_to_api(ctx, "test-agent", archive)
+
+        # Archive should still exist so user can manually import
+        assert archive.exists(), "Archive was deleted but user needs it for manual import"
+
 
 class TestRegistryAgents:
     def test_list_installed(self, runner):


### PR DESCRIPTION
## Summary

- `_import_to_api` was swallowing exceptions with a bare `except Exception`, so users saw a generic "API registration failed" message with no clue what went wrong
- The `.agnt` archive was deleted in a `finally` block even on failure, making the suggested `forge agents import` workaround impossible since the file no longer existed
- Now the actual error message is included in the warning output
- Archive is only deleted on success; on failure it stays on disk for manual import

## Test plan

- [x] `test_pull_api_failure_shows_reason` -- error details appear in output
- [x] `test_pull_api_failure_preserves_archive` -- .agnt file kept on failure
- [x] All existing registry and CLI tests pass (162 passed)

Closes #63