### PR TITLE
fix: kill zombie daemon processes and prefer active user's Python (#66)

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -195,15 +195,43 @@ def _probe_daemon() -> str:
         return "stopped"
 
 
+def _get_windows_userprofile() -> str | None:
+    """Get the active Windows user's profile directory as a WSL path."""
+    try:
+        result = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-Command", "$env:USERPROFILE"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            wsl_path = subprocess.run(
+                ["wslpath", "-u", result.stdout.strip()],
+                capture_output=True, text=True,
+            ).stdout.strip()
+            return wsl_path
+    except Exception:
+        pass
+    return None
+
+
 def _find_windows_python() -> str | None:
-    common_paths = [
-        "/mnt/c/Users/*/AppData/Local/Programs/Python/Python3*/python.exe",
-    ]
+    """Find a Python install on the active Windows user's account."""
     import glob
-    for pattern in common_paths:
-        matches = sorted(glob.glob(pattern), reverse=True)
+
+    # First try the active Windows user's Python install
+    profile = _get_windows_userprofile()
+    if profile:
+        user_pattern = f"{profile}/AppData/Local/Programs/Python/Python3*/python.exe"
+        matches = sorted(glob.glob(user_pattern), reverse=True)
         if matches:
             return matches[0].replace("/mnt/c/", "C:\\").replace("/", "\\")
+
+    # Fallback: any user's Python (multi-user machines)
+    all_users_pattern = "/mnt/c/Users/*/AppData/Local/Programs/Python/Python3*/python.exe"
+    matches = sorted(glob.glob(all_users_pattern), reverse=True)
+    if matches:
+        return matches[0].replace("/mnt/c/", "C:\\").replace("/", "\\")
+
+    # Last resort: ask PowerShell
     try:
         result = subprocess.run(
             ["powershell.exe", "-NoProfile", "-Command", "(Get-Command python).Source"],
@@ -218,25 +246,7 @@ def _find_windows_python() -> str | None:
 
 def _deploy_and_launch_daemon(win_python: str) -> None:
     bridge_dir = str(PROJECT_ROOT / "computer_use" / "bridge")
-    deploy_dir = None
-    try:
-        result = subprocess.run(
-            ["wslpath", "-u", os.path.expanduser("~").replace("/home/", "/mnt/c/Users/")],
-            capture_output=True, text=True,
-        )
-        # Try getting Windows USERPROFILE
-        result = subprocess.run(
-            ["powershell.exe", "-NoProfile", "-Command", "$env:USERPROFILE"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            win_profile = result.stdout.strip()
-            deploy_dir = subprocess.run(
-                ["wslpath", "-u", win_profile],
-                capture_output=True, text=True,
-            ).stdout.strip()
-    except Exception:
-        pass
+    deploy_dir = _get_windows_userprofile()
 
     if not deploy_dir:
         return
@@ -303,12 +313,24 @@ def _stop_daemon():
     if not _is_wsl2():
         return
     try:
+        # Kill by port (catches healthy daemons)
         subprocess.run(
             [
                 "powershell.exe", "-NoProfile", "-Command",
                 f"Get-NetTCPConnection -LocalPort {_DAEMON_PORT} -State Listen "
                 f"-ErrorAction SilentlyContinue | "
                 f"ForEach-Object {{ Stop-Process -Id $_.OwningProcess -Force }}",
+            ],
+            capture_output=True, timeout=10,
+        )
+        # Also kill any pythonw.exe running daemon.py (catches zombies that
+        # crashed before binding to the port)
+        subprocess.run(
+            [
+                "powershell.exe", "-NoProfile", "-Command",
+                'Get-CimInstance Win32_Process -Filter "Name=\'pythonw.exe\'" '
+                "| Where-Object { $_.CommandLine -like '*daemon.py*' } "
+                "| ForEach-Object { Stop-Process -Id $_.ProcessId -Force }",
             ],
             capture_output=True, timeout=10,
         )

--- a/api/tests/test_daemon.py
+++ b/api/tests/test_daemon.py
@@ -53,9 +53,11 @@ class TestStopDaemon:
         with patch("api.services.computer_use_setup._is_wsl2", return_value=True), \
              patch("subprocess.run") as m:
             _stop_daemon()
-            assert m.called
-            cmd = str(m.call_args)
-            assert "19542" in cmd
+            assert m.call_count == 2
+            # First call kills by port
+            assert "19542" in str(m.call_args_list[0])
+            # Second call kills zombie pythonw.exe daemon.py processes
+            assert "daemon.py" in str(m.call_args_list[1])
 
     def test_noop_on_non_wsl2(self):
         from api.services.computer_use_setup import _stop_daemon


### PR DESCRIPTION
## Summary

Follow-up to #69. On multi-user Windows machines, two issues caused the daemon to appear degraded:

1. `_stop_daemon` only killed processes by port. If a daemon crashed before binding (zombie pythonw.exe), it was never cleaned up, blocking new daemon launches.

2. `_find_windows_python` globbed all users' Python installs and could pick the wrong user's Python (e.g. Python 3.9 from another account instead of Python 3.12 from the active user).

## Changes

- `_stop_daemon` now also kills `pythonw.exe daemon.py` processes by name
- `_find_windows_python` checks active user's Python first via `$env:USERPROFILE`
- Extracted `_get_windows_userprofile` helper shared by find and deploy

## Test plan

- [x] 14 daemon tests pass
- [x] Integration: disable -> enable -> status shows Daemon: running

Closes #66