### PR TITLE
fix: registry pack missing input/output schemas

### DIFF
--- a/registry/packer.py
+++ b/registry/packer.py
@@ -83,10 +83,22 @@ def build_manifest(folder: Path, overrides: Optional[dict] = None) -> Manifest:
         with open(manifest_path) as f:
             existing = json.load(f)
 
+    # Pick up input/output schemas from schema.json (written by the API)
+    schema_path = folder / "schema.json"
+    if schema_path.exists():
+        try:
+            with open(schema_path) as f:
+                schema_data = json.load(f)
+            for key in ("input_schema", "output_schema", "samples"):
+                if schema_data.get(key) and not existing.get(key):
+                    existing[key] = schema_data[key]
+        except (json.JSONDecodeError, OSError):
+            pass
+
     steps = _detect_steps(folder)
 
     auto = {
-        "manifest_version": 1,
+        "manifest_version": 2,
         "name": _detect_name(folder),
         "computer_use": _detect_computer_use(steps),
         "steps": [s.model_dump() for s in steps],

--- a/registry/tests/test_packer.py
+++ b/registry/tests/test_packer.py
@@ -112,6 +112,24 @@ class TestBuildManifest:
         m = build_manifest(sample_agent_folder, overrides={"name": "override-name"})
         assert m.name == "override-name"
 
+    def test_reads_schema_json(self, sample_agent_folder):
+        """build_manifest should include input/output schemas from schema.json."""
+        schema = {
+            "input_schema": [
+                {"name": "cv_file", "type": "file", "required": True}
+            ],
+            "output_schema": [
+                {"name": "report", "type": "file"}
+            ],
+            "samples": ["example input"],
+        }
+        (sample_agent_folder / "schema.json").write_text(json.dumps(schema))
+        m = build_manifest(sample_agent_folder)
+        assert len(m.input_schema) == 1
+        assert m.input_schema[0]["name"] == "cv_file"
+        assert len(m.output_schema) == 1
+        assert m.samples == ["example input"]
+
 
 class TestCollectFiles:
 


### PR DESCRIPTION
## Summary

Pulled agents started running without asking for inputs because the packed manifest had empty `input_schema`. The API writes schemas to `schema.json` but `build_manifest` only read from `agent-forge.json`, missing the schema data.

Now `build_manifest` reads `schema.json` and includes `input_schema`, `output_schema`, and `samples` in the manifest when the manifest itself has empty values for those fields.

Also updated the sample registry .agnt with schemas included.

## Test plan

- [x] `test_reads_schema_json` -- schemas picked up from schema.json
- [x] 150 registry tests pass
- [x] Integration: repacked linkedin agent, pulled it, `forge agents get` shows inputs (cv_file, linkedin_url)