### PR TITLE
fix: terminal corrupted after forge start (#74)

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -279,6 +279,7 @@ def _deploy_and_launch_daemon(win_python: str) -> None:
                 f'-WorkingDirectory "{win_dir}" '
                 f'-WindowStyle Hidden',
             ],
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/cli/commands/service.py
+++ b/cli/commands/service.py
@@ -195,9 +195,14 @@ def _build_env(api_port: int, frontend_port: int) -> dict:
 
 
 def _session_kwargs() -> dict:
+    """Kwargs for Popen to fully detach background processes from the terminal.
+
+    Without stdin=DEVNULL, child processes inherit the terminal stdin and
+    compete with the shell for input, corrupting typing and copy/paste.
+    """
     if sys.platform == "win32":
-        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
-    return {"start_new_session": True}
+        return {"stdin": subprocess.DEVNULL, "creationflags": 0x08000000}  # CREATE_NO_WINDOW
+    return {"stdin": subprocess.DEVNULL, "start_new_session": True}
 
 
 def _file_hash(path: Path) -> str | None:

--- a/cli/tests/test_service.py
+++ b/cli/tests/test_service.py
@@ -109,6 +109,17 @@ class TestFindNpx:
         assert result.endswith("npx.cmd")
 
 
+class TestSessionKwargs:
+    """Issue #74: background processes must not inherit terminal stdin."""
+
+    def test_includes_devnull_stdin(self):
+        """_session_kwargs must include stdin=DEVNULL to prevent terminal corruption."""
+        import subprocess
+        from cli.commands.service import _session_kwargs
+        kwargs = _session_kwargs()
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+
+
 class TestDetectFrontendPort:
     def test_parses_vite_log(self, tmp_path):
         from cli.commands.service import _detect_frontend_port

--- a/computer_use/platform/wsl2.py
+++ b/computer_use/platform/wsl2.py
@@ -1017,6 +1017,7 @@ class WSL2Backend(PlatformBackend):
                     f'-WorkingDirectory "{win_dir}" '
                     f'-WindowStyle Minimized',
                 ],
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )


### PR DESCRIPTION
## Summary

After `forge start`, the terminal becomes unusable on both Windows and WSL2: typing drops keystrokes, backspace shows `^H`, copy/paste breaks.

**Root cause**: `subprocess.Popen` for background processes (uvicorn, vite) did not redirect stdin. By default, child processes inherit the parent terminal stdin. After forge exits, both the shell AND the background process read from the same stdin, causing input to split randomly between them.

## Fix

- Added `stdin=subprocess.DEVNULL` to all background Popen calls:
  - `cli/commands/service.py`: API, frontend, and api-only launches (3 calls)
  - `api/services/computer_use_setup.py`: daemon launcher
  - `computer_use/platform/wsl2.py`: daemon auto-launcher
- On Windows, changed `CREATE_NEW_PROCESS_GROUP` to `CREATE_NO_WINDOW` to fully detach from the console

## Verification

- [x] `TestSessionKwargs::test_includes_devnull_stdin` passes
- [x] 17 service tests pass
- [x] WSL2: `forge start` -> API stdin is `/dev/null` (confirmed via `/proc/{pid}/fd/0`)
- [x] Windows: `forge start` -> process starts without terminal corruption

Closes #74