### PR TITLE
fix: frontend fails to start due to npx version mismatch (#74)

### DIFF
--- a/cli/commands/service.py
+++ b/cli/commands/service.py
@@ -163,17 +163,20 @@ def _find_node() -> str | None:
     return None
 
 
-def _find_npx() -> str | None:
+def _find_npm() -> str | None:
+    """Find npm executable. Used to launch frontend via 'npm run dev'."""
+    found = shutil.which("npm")
+    if found:
+        return found
     node = _find_node()
     if not node:
         return None
     node_dir = Path(node).parent
-    # On Windows, npx is a .cmd batch file, not a bare script
-    for name in ("npx.cmd", "npx.exe", "npx"):
+    for name in ("npm.cmd", "npm.exe", "npm"):
         candidate = node_dir / name
         if candidate.exists():
             return str(candidate)
-    return shutil.which("npx")
+    return None
 
 
 def _get_api_python() -> str:
@@ -254,18 +257,18 @@ def start(api_port, frontend_port):
         print_warning(f"API failed to start. Check {FORGE_HOME / 'api.log'}")
         raise SystemExit(1)
 
-    # Start frontend via npx vite
+    # Start frontend via npm run dev (not npx -- npx resolution varies across Node versions)
     frontend_dir = FORGE_REPO / "frontend"
-    npx = _find_npx()
-    if not npx:
-        print_warning("npx not found. Frontend will not start.")
+    npm = _find_npm()
+    if not npm:
+        print_warning("npm not found. Frontend will not start.")
         print_success(f"API is running at http://localhost:{api_port}")
         return
 
     print_info("Starting frontend...")
     fe_log = open(FORGE_HOME / "frontend.log", "w")
     fe_proc = subprocess.Popen(
-        [npx, "vite"], cwd=str(frontend_dir),
+        [npm, "run", "dev"], cwd=str(frontend_dir),
         env=env, stdout=fe_log, stderr=subprocess.STDOUT,
         **_session_kwargs(),
     )

--- a/cli/tests/test_service.py
+++ b/cli/tests/test_service.py
@@ -90,23 +90,24 @@ class TestFindNode:
         assert _find_node() is None
 
 
-class TestFindNpx:
-    """Issue #74: npx on Windows is npx.cmd, not a bare script."""
+class TestFindNpm:
+    """Frontend must launch via npm (not npx) for consistent behavior across Node versions."""
 
-    def test_finds_npx_cmd_on_windows(self, monkeypatch, tmp_path):
-        """On Windows, _find_npx should return npx.cmd if it exists."""
-        from cli.commands.service import _find_npx
+    def test_finds_npm_on_path(self, monkeypatch):
+        from cli.commands.service import _find_npm
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None)
+        assert _find_npm() == "/usr/bin/npm"
 
-        # Simulate Windows: node.exe exists, npx does not, but npx.cmd does
+    def test_finds_npm_cmd_on_windows(self, monkeypatch, tmp_path):
+        from cli.commands.service import _find_npm
         node_dir = tmp_path / "nodejs"
         node_dir.mkdir()
         (node_dir / "node.exe").write_text("")
-        (node_dir / "npx.cmd").write_text("")
-
+        (node_dir / "npm.cmd").write_text("")
         monkeypatch.setattr("shutil.which", lambda cmd: str(node_dir / "node.exe") if cmd == "node" else None)
-        result = _find_npx()
+        result = _find_npm()
         assert result is not None
-        assert result.endswith("npx.cmd")
+        assert "npm" in result
 
 
 class TestSessionKwargs:


### PR DESCRIPTION
## Summary

`forge start` launched the frontend via `npx vite`, but `npx` behavior varies across Node versions. On Node v24, npx downloaded a fresh vite v8.0.3 instead of using the locally installed v7.3.1, causing config failures (plugins not found).

Replaced `npx vite` with `npm run dev` which always uses the local `node_modules/.bin/vite` regardless of Node version or OS.

## Changes

- Replaced `_find_npx()` with `_find_npm()` in `cli/commands/service.py`
- Frontend launch changed from `[npx, "vite"]` to `[npm, "run", "dev"]`
- Updated tests

## Test plan

- [x] 18 service tests pass
- [x] WSL integration: `forge start` launches frontend on port 3000 via `npm run dev`

Closes #74