### PR TITLE
fix: frontend not detected on Windows 11 due to IPv6 (#74)

### DIFF
--- a/cli/commands/service.py
+++ b/cli/commands/service.py
@@ -94,9 +94,15 @@ def _kill_tree(pid: int):
 
 def _port_in_use(port: int) -> bool:
     import socket
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(1)
-        return s.connect_ex(("127.0.0.1", port)) == 0
+    # Check both IPv4 and IPv6 loopback -- Vite on Windows 11 often binds
+    # to ::1 only, so checking just 127.0.0.1 would miss it.
+    for addr in ("127.0.0.1", "::1"):
+        family = socket.AF_INET6 if ":" in addr else socket.AF_INET
+        with socket.socket(family, socket.SOCK_STREAM) as s:
+            s.settimeout(1)
+            if s.connect_ex((addr, port)) == 0:
+                return True
+    return False
 
 
 def _kill_port(port: int):
@@ -123,7 +129,9 @@ def _wait_for_api(port: int, timeout: int = _API_STARTUP_TIMEOUT) -> bool:
 def _wait_for_frontend(port: int, timeout: int = 10) -> bool:
     for _ in range(timeout):
         try:
-            req = urllib.request.Request(f"http://127.0.0.1:{port}")
+            # Use "localhost" instead of "127.0.0.1" so the OS resolves to
+            # whichever loopback address Vite actually bound (IPv4 or IPv6).
+            req = urllib.request.Request(f"http://localhost:{port}")
             urllib.request.urlopen(req, timeout=2)
             return True
         except Exception:

--- a/cli/tests/test_port_check.py
+++ b/cli/tests/test_port_check.py
@@ -17,6 +17,27 @@ class TestPortInUse:
         from cli.commands.service import _port_in_use
         assert _port_in_use(59998) is False
 
+    def test_detects_ipv4_listener(self):
+        """Port bound on 127.0.0.1 should be detected."""
+        import socket
+        from cli.commands.service import _port_in_use
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 59997))
+            s.listen(1)
+            assert _port_in_use(59997) is True
+
+    def test_detects_ipv6_listener(self):
+        """Port bound on ::1 (IPv6) should be detected -- Vite on Windows 11."""
+        import socket
+        from cli.commands.service import _port_in_use
+        try:
+            with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+                s.bind(("::1", 59996))
+                s.listen(1)
+                assert _port_in_use(59996) is True
+        except OSError:
+            pytest.skip("IPv6 not available")
+
 
 class TestKillPort:
     def test_kill_port_calls_fuser(self, monkeypatch):


### PR DESCRIPTION
## Summary

`forge start` reported "Frontend failed to start" on Windows 11 even though Vite was running fine. Debugged on-device by another Claude Code instance.

**Root cause**: Vite 7 on Windows 11 binds to `::1` (IPv6 loopback) but both `_port_in_use` and `_wait_for_frontend` only checked `127.0.0.1` (IPv4). The health check always timed out.

## Fix

- `_port_in_use`: checks both `127.0.0.1` and `::1`
- `_wait_for_frontend`: uses `localhost` which resolves to whichever loopback the OS prefers

## Test plan

- [x] `test_detects_ipv4_listener` -- port on 127.0.0.1 detected
- [x] `test_detects_ipv6_listener` -- port on ::1 detected
- [x] 25 service + port tests pass
- [x] WSL integration: forge start/stop works
- [x] Verified on Windows 11 by separate Claude Code instance

Closes #74