### PR TITLE
fix: auto-find free port when default is busy (#84)

### DIFF
--- a/cli/commands/service.py
+++ b/cli/commands/service.py
@@ -105,6 +105,15 @@ def _port_in_use(port: int) -> bool:
     return False
 
 
+def _find_free_port(default: int, max_attempts: int = 20) -> int | None:
+    """Find a free port starting from *default*, incrementing on conflict."""
+    for offset in range(max_attempts):
+        candidate = default + offset
+        if not _port_in_use(candidate):
+            return candidate
+    return None
+
+
 def _kill_port(port: int):
     if sys.platform == "win32":
         subprocess.run(["powershell", "-Command",
@@ -237,9 +246,22 @@ def start(api_port, frontend_port):
         print_warning("vadgr is already running. Use 'vadgr stop' first.")
         raise SystemExit(1)
 
+    # Find free ports, auto-incrementing if default is busy
     if _port_in_use(api_port):
-        print_warning(f"Port {api_port} is already in use. Stop the existing process first.")
-        raise SystemExit(1)
+        original = api_port
+        api_port = _find_free_port(api_port)
+        if api_port is None:
+            print_warning(f"No free port found starting from {original}.")
+            raise SystemExit(1)
+        print_info(f"Port {original} busy, using {api_port}")
+
+    if _port_in_use(frontend_port):
+        original = frontend_port
+        frontend_port = _find_free_port(frontend_port)
+        if frontend_port is None:
+            print_warning(f"No free port found starting from {original}.")
+            raise SystemExit(1)
+        print_info(f"Port {original} busy, using {frontend_port}")
 
     env = _build_env(api_port, frontend_port)
 
@@ -439,6 +461,14 @@ def api_only(port):
     if _read_pid("api"):
         print_warning("API is already running. Use 'vadgr stop' first.")
         raise SystemExit(1)
+
+    if _port_in_use(port):
+        original = port
+        port = _find_free_port(port)
+        if port is None:
+            print_warning(f"No free port found starting from {original}.")
+            raise SystemExit(1)
+        print_info(f"Port {original} busy, using {port}")
 
     env = _build_env(port, 3000)
     print_info(f"Starting API server (port {port})...")

--- a/cli/tests/test_port_check.py
+++ b/cli/tests/test_port_check.py
@@ -48,15 +48,38 @@ class TestKillPort:
         assert len(calls) > 0
 
 
+class TestFindFreePort:
+    def test_returns_default_when_free(self):
+        from cli.commands.service import _find_free_port
+        # Port 59990 should be free
+        assert _find_free_port(59990) == 59990
+
+    def test_increments_when_busy(self, monkeypatch):
+        from cli.commands.service import _find_free_port
+        busy = {8000, 8001, 8002}
+        monkeypatch.setattr("cli.commands.service._port_in_use", lambda p: p in busy)
+        assert _find_free_port(8000) == 8003
+
+    def test_returns_none_after_max_attempts(self, monkeypatch):
+        from cli.commands.service import _find_free_port
+        monkeypatch.setattr("cli.commands.service._port_in_use", lambda p: True)
+        assert _find_free_port(8000, max_attempts=5) is None
+
+
 class TestStartPortCheck:
-    def test_start_fails_if_api_port_busy(self, runner, tmp_forge, monkeypatch):
+    def test_start_uses_next_free_port_when_busy(self, runner, tmp_forge, monkeypatch):
+        """Issue #84: start should find a free port instead of blocking."""
         from cli.commands.service import start
         from click.testing import CliRunner
-        monkeypatch.setattr("cli.commands.service._port_in_use", lambda p: p == 8000)
+        busy = {8000}
+        monkeypatch.setattr("cli.commands.service._port_in_use", lambda p: p in busy)
+        monkeypatch.setattr("cli.commands.service._wait_for_api", lambda p, **kw: True)
+        monkeypatch.setattr("cli.commands.service._find_npm", lambda: None)
+        monkeypatch.setattr("subprocess.Popen", mock.MagicMock(return_value=mock.MagicMock(poll=lambda: None, pid=123)))
         runner = CliRunner()
         result = runner.invoke(start)
-        assert result.exit_code != 0
-        assert "already in use" in result.output.lower() or result.exit_code != 0
+        assert result.exit_code == 0
+        assert "8001" in result.output
 
 
 class TestStopWithStalePort:


### PR DESCRIPTION
## Summary

`vadgr start` blocked with "Port 8000 is already in use" when the default port was busy. Now it auto-increments to the next free port.

## Changes

- Added `_find_free_port(default, max_attempts=20)` helper that scans from the default port upward
- `start` command: auto-finds free ports for both API and frontend, prints which port it picked
- `api` command: same auto-fallback behavior
- User sees: `[vadgr] Port 8000 busy, using 8001`

## Test plan

- [x] `test_returns_default_when_free` -- returns default port if free
- [x] `test_increments_when_busy` -- finds next free port
- [x] `test_returns_none_after_max_attempts` -- gives up after max tries
- [x] `test_start_uses_next_free_port_when_busy` -- start command picks new port
- [x] 28 tests pass
- [x] Integration: blocked port 8000, started on 8001 automatically
- [x] Integration: blocked both 8000 and 3000, started on 8001 and 3001

Closes #84