### PR TITLE
fix: MCP config missing type field breaks Claude Code connection

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -60,6 +60,7 @@ def _mcp_json_content(cache_enabled: bool = True) -> dict:
     return {
         "mcpServers": {
             "computer-use": {
+                "type": "stdio",
                 "command": _cu_venv_python(),
                 "args": ["-m", "computer_use.mcp_server", "--transport", "stdio"],
                 "cwd": str(PROJECT_ROOT),

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -279,6 +279,12 @@ class TestComputerUseSetupService:
             result = cu_setup.disable_computer_use()
             assert result["enabled"] is False
 
+    def test_mcp_json_includes_type_stdio(self):
+        """Claude Code requires 'type': 'stdio' in MCP server config."""
+        content = cu_setup._mcp_json_content()
+        server = content["mcpServers"]["computer-use"]
+        assert server.get("type") == "stdio"
+
     def test_mcp_json_uses_python_on_windows(self, tmp_path):
         """On Windows, .mcp.json uses 'python' not 'python3'."""
         with patch("api.utils.platform.sys") as mock_sys:


### PR DESCRIPTION
## Summary

The computer-use MCP server has been failing to connect in Claude Code for ~2 weeks. The server itself works perfectly when run manually, but Claude Code shows "Failed to connect".

## Root cause

Our `.mcp.json` config (written by `vadgr computer-use enable`) was missing the `"type": "stdio"` field. Recent Claude Code versions require this field to know which transport to use. Without it, the connection fails silently.

**Before:**
```json
{ "command": "python", "args": [...], "cwd": "...", "env": {...} }
```

**After:**
```json
{ "type": "stdio", "command": "python", "args": [...], "cwd": "...", "env": {...} }
```

## Fix

Added `"type": "stdio"` to `_mcp_json_content()` in `api/services/computer_use_setup.py`.

Users need to re-run `vadgr computer-use enable` (or `vadgr computer-use disable && vadgr computer-use enable`) to regenerate the config, then restart Claude Code.

## Test plan

- [x] `test_mcp_json_includes_type_stdio` passes
- [x] Integration: disable -> enable -> verified .mcp.json contains `"type": "stdio"`
- [ ] Manual: `/exit` Claude Code, reopen, check `/mcp` shows computer-use connected