### PR TITLE
feat: persistent memory system for forge agents

### DIFF
--- a/forge/Prompts/02_Workflow_Architect.md
+++ b/forge/Prompts/02_Workflow_Architect.md
@@ -245,6 +245,7 @@ Steps: 12
 - Map each step to its agent (or mark as "direct" if no agent needed)
 - Identify which patterns from the patterns library apply
 - If the workflow involves desktop automation, read `forge/patterns/10-computer-use.md` and include a Computer Use Agent
+- If the workflow benefits from remembering context across runs (same repo, same user profile, repeated tasks), read `forge/patterns/11-persistent-memory.md` and include memory operations in relevant steps
 - Present the architecture for user review before finalizing
 
 **Never:**

--- a/forge/docs/memory-roadmap.md
+++ b/forge/docs/memory-roadmap.md
@@ -1,0 +1,144 @@
+# Memory System Roadmap
+
+## Phase 1: Markdown files (current)
+
+File-based persistent memory at `FORGE_HOME/memory/{agent}/{key}.md`.
+
+- Markdown + YAML frontmatter format
+- CLI-agnostic (works with Claude Code, Codex, Gemini)
+- Human readable and editable
+- Max 30 lines per file (token cost control)
+- Overwrite strategy (no unbounded growth)
+- Includes CUA element hints for spatial cache consistency
+
+### Interface
+
+```python
+from forge.scripts.src.memory import read_memory, write_memory, list_memories, clear_memory, repo_key
+
+content = read_memory("agent-name")
+write_memory("agent-name", content="- learned fact")
+write_memory("agent-name", key=repo_key("/path/to/repo"), content="- stack: FastAPI")
+write_memory("agent-name", key="cua-hints", content="# App\n- button: \"save button\"")
+memories = list_memories("agent-name")
+clear_memory("agent-name")
+```
+
+### Limitations
+
+- No search (must know exact key)
+- Linear scan of files
+- No semantic matching
+- Max ~30 lines per file
+
+---
+
+## Phase 2: SQLite
+
+Replace `.md` file read/write with SQLite queries. Same `memory.py` interface, different backend.
+
+### Storage
+
+Single file: `FORGE_HOME/memory.db`
+
+### Schema
+
+```sql
+CREATE TABLE memories (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_name  TEXT NOT NULL,
+    key         TEXT NOT NULL DEFAULT 'global',
+    content     TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    UNIQUE(agent_name, key)
+);
+
+CREATE INDEX idx_memories_agent ON memories(agent_name);
+```
+
+### Why
+
+- Full text search via SQLite FTS5: `SELECT * FROM memories WHERE content MATCH 'pytest'`
+- Handles hundreds of memories without file system overhead
+- Still zero external dependencies (sqlite3 is built into Python)
+- Still local, no network calls, no external services
+- Single file backup (`memory.db`)
+
+### Migration
+
+```python
+# Read all .md files, insert into SQLite, remove .md files
+for agent_dir in MEMORY_DIR.iterdir():
+    for md_file in agent_dir.glob("*.md"):
+        meta, body = _parse_frontmatter(md_file.read_text())
+        db.execute("INSERT INTO memories ...", (meta["agent"], meta["key"], body, meta["updated"]))
+        md_file.unlink()
+```
+
+### When to upgrade
+
+When any of these become true:
+- An agent has 50+ memory files
+- Users request search across memories ("what did I learn about React projects?")
+- Memory management becomes a pain (too many files in `FORGE_HOME/memory/`)
+
+---
+
+## Phase 3: sqlite-vec (vector search)
+
+Add local embeddings for semantic similarity search. Still SQLite, still local, still free.
+
+### Dependencies
+
+- `sqlite-vec`: SQLite extension for vector operations
+- `sentence-transformers` with `all-MiniLM-L6-v2` model (~80MB, runs on CPU)
+
+### Schema addition
+
+```sql
+CREATE VIRTUAL TABLE memory_vectors USING vec0(
+    memory_id INTEGER,
+    embedding FLOAT[384]
+);
+```
+
+### New interface method
+
+```python
+def search_memory(agent_name: str, query: str, top_k: int = 5) -> list[dict]:
+    """Semantic search across memories. Returns top_k most relevant."""
+    embedding = model.encode(query)
+    results = db.execute("""
+        SELECT m.*, v.distance
+        FROM memory_vectors v
+        JOIN memories m ON m.id = v.memory_id
+        WHERE m.agent_name = ?
+        ORDER BY v.distance
+        LIMIT ?
+    """, (agent_name, top_k))
+    return results
+```
+
+### Why
+
+- "Find memories relevant to this task" without exact key matching
+- Agents get smarter with every run
+- Cross-pollination: lessons from one context help with similar contexts
+- Still fully local, no API calls, no external services, no charges
+
+### When to upgrade
+
+When any of these become true:
+- An agent accumulates 50+ memories and needs to recall relevant ones
+- Simple key-based lookup isn't finding the right memories
+- Users want "smart recall" where the agent automatically knows what's relevant
+
+---
+
+## Design principles (all phases)
+
+1. **Same interface** -- `read_memory`, `write_memory`, `list_memories`, `clear_memory` never change. Backend swaps transparently.
+2. **Local only** -- no external services, no API keys, no charges. Everything on the user's machine.
+3. **CLI-agnostic** -- works identically with Claude Code, Codex, Gemini, or any future provider.
+4. **Human editable** -- users can always inspect and modify memories (even in SQLite via CLI tools).
+5. **Token-conscious** -- memories are compact, selectively loaded, never dumped wholesale into context.

--- a/forge/patterns/11-persistent-memory.md
+++ b/forge/patterns/11-persistent-memory.md
@@ -1,0 +1,84 @@
+# Pattern 11: Persistent Memory
+
+Agents can remember facts, preferences, and context across runs using persistent memory files stored at `FORGE_HOME/memory/`.
+
+## When to use
+
+- The agent works with the same context repeatedly (e.g., same repo, same user profile)
+- Re-analyzing the context each run wastes time and tokens
+- The agent benefits from learning across runs (getting faster, more accurate)
+- Computer use steps benefit from consistent element hints for spatial cache
+
+## How it works
+
+Memory files are markdown with YAML frontmatter stored at `FORGE_HOME/memory/{agent-name}/{key}.md`. Any CLI provider (Claude Code, Codex, Gemini) can read markdown naturally.
+
+### File format
+
+```markdown
+---
+agent: my-agent
+key: global
+updated: 2026-04-05T12:00:00Z
+---
+
+- User prefers dark theme
+- Default output format: PDF
+```
+
+### Directory structure
+
+```
+FORGE_HOME/memory/
+  my-agent/
+    global.md          -- agent-wide knowledge (default key)
+    custom-key.md      -- optional scoped memory
+```
+
+### Usage in steps
+
+```python
+from forge.scripts.src.memory import read_memory, write_memory
+
+# Read at the start of a step
+previous = read_memory("my-agent")
+
+# Write at the end of a step
+write_memory("my-agent", content="- learned: user prefers pytest over unittest")
+```
+
+### Per-repo memory
+
+Agents that work across multiple repos can scope memory by repo path:
+
+```python
+from forge.scripts.src.memory import read_memory, write_memory, repo_key
+
+key = repo_key("/home/user/my-project")  # -> "repo-home-user-my-project"
+context = read_memory("software-engineer", key=key)
+write_memory("software-engineer", key=key, content="- Stack: FastAPI + React")
+```
+
+## CUA element hints
+
+Agents that use computer use can store standardized element hints so the spatial cache gets consistent keys across runs. This makes repeated clicks faster via the muscle memory system.
+
+```python
+write_memory("my-agent", key="cua-hints", content="""
+# VS Code
+- run tests: "run tests button"
+- terminal: "terminal panel"
+
+# Chrome
+- address bar: "url bar"
+""")
+```
+
+Steps that use computer use should read `cua-hints` and use the exact strings as `element_hint` in click/navigate calls.
+
+## Constraints
+
+- Max 30 lines per memory file (keeps token cost low)
+- Memory is overwritten each run, not appended (prevents unbounded growth)
+- Memory is per-agent, not shared between agents
+- Human-editable: users can open and modify memory files directly

--- a/forge/scripts/src/memory.py
+++ b/forge/scripts/src/memory.py
@@ -1,0 +1,117 @@
+"""Persistent memory for forge agents.
+
+Stores markdown files with YAML frontmatter at ~/.forge/memory/{agent}/{key}.md.
+CLI-agnostic: works with Claude Code, Codex, Gemini, or any provider.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+MEMORY_DIR = Path.home() / ".forge" / "memory"
+
+
+def _frontmatter(agent: str, key: str) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f"---\nagent: {agent}\nkey: {key}\nupdated: {now}\n---\n\n"
+
+
+def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Split a file into frontmatter dict and body string."""
+    match = re.match(r"^---\n(.*?)\n---\n*(.*)", text, re.DOTALL)
+    if not match:
+        return {}, text
+    meta = {}
+    for line in match.group(1).splitlines():
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip()
+    return meta, match.group(2)
+
+
+def write_memory(
+    agent_name: str,
+    key: str = "global",
+    *,
+    content: str,
+    max_lines: int = 30,
+) -> Path:
+    """Write a memory file with auto-generated frontmatter.
+
+    Overwrites existing content. Truncates body to max_lines.
+    Returns the path to the written file.
+    """
+    agent_dir = MEMORY_DIR / agent_name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / f"{key}.md"
+
+    lines = content.strip().splitlines()
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+
+    body = "\n".join(lines) + "\n"
+    path.write_text(_frontmatter(agent_name, key) + body)
+    return path
+
+
+def read_memory(agent_name: str, key: str = "global") -> Optional[str]:
+    """Read memory content (without frontmatter). Returns None if not found."""
+    path = MEMORY_DIR / agent_name / f"{key}.md"
+    if not path.exists():
+        return None
+    text = path.read_text()
+    _, body = _parse_frontmatter(text)
+    return body.strip() or None
+
+
+def list_memories(agent_name: str) -> list[dict]:
+    """List all memory keys for an agent with their frontmatter metadata."""
+    agent_dir = MEMORY_DIR / agent_name
+    if not agent_dir.exists():
+        return []
+    result = []
+    for f in sorted(agent_dir.glob("*.md")):
+        text = f.read_text()
+        meta, _ = _parse_frontmatter(text)
+        if not meta:
+            meta = {"agent": agent_name, "key": f.stem}
+        result.append(meta)
+    return result
+
+
+def clear_memory(agent_name: str, key: Optional[str] = None) -> int:
+    """Clear one key or all memories for an agent. Returns count of files deleted."""
+    agent_dir = MEMORY_DIR / agent_name
+    if not agent_dir.exists():
+        return 0
+    if key:
+        path = agent_dir / f"{key}.md"
+        if path.exists():
+            path.unlink()
+            return 1
+        return 0
+    # Clear all
+    count = 0
+    for f in agent_dir.glob("*.md"):
+        f.unlink()
+        count += 1
+    # Remove empty dir
+    if not any(agent_dir.iterdir()):
+        agent_dir.rmdir()
+    return count
+
+
+def repo_key(repo_path: str) -> str:
+    """Convert a repo path to a safe memory key.
+
+    '/home/user/my-app' -> 'repo--home-user-my-app'
+    'C:\\Users\\me\\project' -> 'repo-c-users-me-project'
+    """
+    clean = repo_path.replace("\\", "/").replace("~", "").lower()
+    clean = re.sub(r"[^a-z0-9/\-]", "", clean)
+    clean = clean.strip("/").replace("/", "-")
+    return f"repo-{clean}"

--- a/forge/scripts/tests/test_memory.py
+++ b/forge/scripts/tests/test_memory.py
@@ -1,0 +1,152 @@
+"""Tests for forge persistent memory utility."""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from forge.scripts.src.memory import (
+    read_memory,
+    write_memory,
+    list_memories,
+    clear_memory,
+    repo_key,
+    MEMORY_DIR,
+)
+
+
+@pytest.fixture
+def memory_dir(tmp_path, monkeypatch):
+    """Use a temp directory instead of ~/.forge/memory/."""
+    mem = tmp_path / "memory"
+    monkeypatch.setattr("forge.scripts.src.memory.MEMORY_DIR", mem)
+    return mem
+
+
+class TestWriteMemory:
+
+    def test_creates_file_with_frontmatter(self, memory_dir):
+        path = write_memory("test-agent", content="- fact one\n- fact two")
+        assert path.exists()
+        text = path.read_text()
+        assert "---" in text
+        assert "agent: test-agent" in text
+        assert "key: global" in text
+        assert "- fact one" in text
+
+    def test_creates_agent_directory(self, memory_dir):
+        write_memory("new-agent", content="hello")
+        assert (memory_dir / "new-agent").is_dir()
+
+    def test_custom_key(self, memory_dir):
+        write_memory("my-agent", key="repo-myapp", content="stack: python")
+        path = memory_dir / "my-agent" / "repo-myapp.md"
+        assert path.exists()
+        assert "key: repo-myapp" in path.read_text()
+
+    def test_overwrites_existing(self, memory_dir):
+        write_memory("agent", content="old stuff")
+        write_memory("agent", content="new stuff")
+        text = (memory_dir / "agent" / "global.md").read_text()
+        assert "new stuff" in text
+        assert "old stuff" not in text
+
+    def test_max_lines_truncates(self, memory_dir):
+        long_content = "\n".join(f"- line {i}" for i in range(100))
+        write_memory("agent", content=long_content, max_lines=10)
+        text = (memory_dir / "agent" / "global.md").read_text()
+        # Frontmatter + content: content lines should be <= 10
+        body_lines = text.split("---")[-1].strip().splitlines()
+        assert len(body_lines) <= 10
+
+    def test_returns_path(self, memory_dir):
+        result = write_memory("agent", content="test")
+        assert isinstance(result, Path)
+        assert result.name == "global.md"
+
+
+class TestReadMemory:
+
+    def test_reads_content_without_frontmatter(self, memory_dir):
+        write_memory("agent", content="- pytest\n- vitest")
+        result = read_memory("agent")
+        assert "- pytest" in result
+        assert "- vitest" in result
+        assert "---" not in result
+        assert "agent:" not in result
+
+    def test_returns_none_when_missing(self, memory_dir):
+        assert read_memory("nonexistent") is None
+
+    def test_reads_custom_key(self, memory_dir):
+        write_memory("agent", key="cua-hints", content="# VS Code\n- terminal")
+        result = read_memory("agent", key="cua-hints")
+        assert "VS Code" in result
+        assert "terminal" in result
+
+    def test_returns_none_for_missing_key(self, memory_dir):
+        write_memory("agent", content="global stuff")
+        assert read_memory("agent", key="nonexistent") is None
+
+
+class TestListMemories:
+
+    def test_lists_all_keys(self, memory_dir):
+        write_memory("agent", content="global")
+        write_memory("agent", key="repo-app", content="app info")
+        write_memory("agent", key="cua-hints", content="hints")
+        result = list_memories("agent")
+        keys = [m["key"] for m in result]
+        assert "global" in keys
+        assert "repo-app" in keys
+        assert "cua-hints" in keys
+
+    def test_returns_frontmatter_metadata(self, memory_dir):
+        write_memory("agent", content="test")
+        result = list_memories("agent")
+        assert len(result) == 1
+        assert result[0]["agent"] == "agent"
+        assert result[0]["key"] == "global"
+        assert "updated" in result[0]
+
+    def test_empty_for_unknown_agent(self, memory_dir):
+        assert list_memories("nope") == []
+
+
+class TestClearMemory:
+
+    def test_clears_one_key(self, memory_dir):
+        write_memory("agent", content="global")
+        write_memory("agent", key="extra", content="extra")
+        count = clear_memory("agent", key="extra")
+        assert count == 1
+        assert read_memory("agent") is not None
+        assert read_memory("agent", key="extra") is None
+
+    def test_clears_all(self, memory_dir):
+        write_memory("agent", content="global")
+        write_memory("agent", key="extra", content="extra")
+        count = clear_memory("agent")
+        assert count == 2
+        assert read_memory("agent") is None
+        assert read_memory("agent", key="extra") is None
+
+    def test_returns_zero_for_unknown(self, memory_dir):
+        assert clear_memory("nope") == 0
+
+
+class TestRepoKey:
+
+    def test_converts_path_to_key(self):
+        assert repo_key("/home/user/my-app") == "repo-home-user-my-app"
+
+    def test_handles_home_shortcut(self):
+        result = repo_key("~/projects/cool-app")
+        assert "repo-" in result
+        assert "/" not in result
+
+    def test_handles_windows_path(self):
+        result = repo_key("C:\\Users\\me\\project")
+        assert "/" not in result
+        assert "\\" not in result
+        assert "repo-" in result

--- a/forge/utils/scaffold/agentic.md.template
+++ b/forge/utils/scaffold/agentic.md.template
@@ -128,6 +128,18 @@ This workflow includes steps that execute autonomously via the Computer Use Engi
 
 ---
 
+## Memory
+
+This workflow uses persistent memory stored at `FORGE_HOME/memory/{{WORKFLOW_NAME_KEBAB}}/`.
+Memory persists across runs and is shared across all CLI providers.
+
+- **Read** at the start of relevant steps to recall prior context
+- **Write** at the end of relevant steps to save what was learned
+- Max 30 lines per memory file to keep token cost low
+- See `forge/patterns/11-persistent-memory.md` for conventions
+
+---
+
 ## Quality Checks
 
 | Step | Check |

--- a/forge/utils/scaffold/step.md.template
+++ b/forge/utils/scaffold/step.md.template
@@ -123,6 +123,24 @@ This file is read by the execution engine to track step status. Always write it,
 
 ---
 
+## Memory Operations
+<!-- Optional: persistent memory across runs. Remove this section if not needed.
+     See forge/patterns/11-persistent-memory.md for details.
+
+     Read memory at step start:
+       from forge.scripts.src.memory import read_memory
+       context = read_memory("{{WORKFLOW_NAME}}")
+
+     Write memory at step end:
+       from forge.scripts.src.memory import write_memory
+       write_memory("{{WORKFLOW_NAME}}", content="- key insight from this step")
+
+     For computer use steps, read CUA hints for consistent element_hint strings:
+       hints = read_memory("{{WORKFLOW_NAME}}", key="cua-hints")
+-->
+
+---
+
 ## Quality Check
 <!-- A short bulleted list of pass/fail questions.
      Each question tests whether this step is actually complete.


### PR DESCRIPTION
## Summary

File-based persistent memory system that any forge agent can use to remember context across runs. Stored at `FORGE_HOME/memory/{agent}/{key}.md` with YAML frontmatter. CLI-agnostic -- works identically with Claude Code, Codex, Gemini, or any future provider.

## What's included

### memory.py utility
- `read_memory(agent, key)` -- read memory content (strips frontmatter)
- `write_memory(agent, key, content, max_lines=30)` -- write with auto-generated frontmatter, truncates to keep token cost low
- `list_memories(agent)` -- list all keys with metadata
- `clear_memory(agent, key)` -- clear one or all
- `repo_key(path)` -- convert repo path to safe memory key

### CUA element hints convention
Agents store standardized `element_hint` strings in `cua-hints` key. Steps that use computer use read these hints and pass exact strings to click/navigate calls. Spatial cache gets consistent keys across runs = cache hits = faster execution over time. No CUA code changes needed.

### Pattern documentation
`forge/patterns/11-persistent-memory.md` -- when to use, file format, directory structure, CUA hints convention, constraints.

### Template updates
- `step.md.template` -- commented Memory Operations section
- `agentic.md.template` -- Memory config section
- `02_Workflow_Architect.md` -- considers memory as a pattern

### Roadmap
`forge/docs/memory-roadmap.md` -- Phase 2 (SQLite + FTS) and Phase 3 (sqlite-vec for semantic search). Same interface, upgradeable backend, always local, always free.

## Test plan

- [x] 19 tests for memory.py (write/read/list/clear/frontmatter/max_lines/repo_key)
- [x] All existing scaffold tests still pass
- [x] Cross-platform: uses `Path.home()`, docs reference `FORGE_HOME` not `~/.forge`