### PR TITLE
Fix test suite hangs and runs list showing raw UUIDs

### DIFF
--- a/api/persistence/repositories.py
+++ b/api/persistence/repositories.py
@@ -76,7 +76,7 @@ def _row_to_edge(row) -> dict:
 
 
 def _row_to_run(row) -> dict:
-    return {
+    d = {
         "id": row["id"],
         "project_id": row["project_id"],
         "agent_id": row["agent_id"],
@@ -89,6 +89,12 @@ def _row_to_run(row) -> dict:
         "started_at": row["started_at"],
         "completed_at": row["completed_at"],
     }
+    # agent_name comes from LEFT JOIN -- only present in joined queries
+    try:
+        d["agent_name"] = row["agent_name"]
+    except (IndexError, KeyError):
+        pass
+    return d
 
 
 class AgentRepository:
@@ -360,7 +366,10 @@ class RunRepository:
 
     async def get(self, run_id: str) -> Optional[dict]:
         cursor = await self.db.conn.execute(
-            "SELECT * FROM runs WHERE id = ?", (run_id,)
+            "SELECT r.*, a.name AS agent_name FROM runs r"
+            " LEFT JOIN agents a ON r.agent_id = a.id"
+            " WHERE r.id = ?",
+            (run_id,),
         )
         row = await cursor.fetchone()
         return _row_to_run(row) if row else None
@@ -393,26 +402,35 @@ class RunRepository:
 
     async def list_by_agent(self, agent_id: str) -> list[dict]:
         cursor = await self.db.conn.execute(
-            "SELECT * FROM runs WHERE agent_id = ? ORDER BY started_at DESC", (agent_id,)
+            "SELECT r.*, a.name AS agent_name FROM runs r"
+            " LEFT JOIN agents a ON r.agent_id = a.id"
+            " WHERE r.agent_id = ? ORDER BY r.started_at DESC",
+            (agent_id,),
         )
         return [_row_to_run(row) for row in await cursor.fetchall()]
 
     async def list_by_project(self, project_id: str) -> list[dict]:
         cursor = await self.db.conn.execute(
-            "SELECT * FROM runs WHERE project_id = ? ORDER BY started_at DESC",
+            "SELECT r.*, a.name AS agent_name FROM runs r"
+            " LEFT JOIN agents a ON r.agent_id = a.id"
+            " WHERE r.project_id = ? ORDER BY r.started_at DESC",
             (project_id,),
         )
         return [_row_to_run(row) for row in await cursor.fetchall()]
 
     async def list_all(self, status: str | None = None) -> list[dict]:
+        base = (
+            "SELECT r.*, a.name AS agent_name FROM runs r"
+            " LEFT JOIN agents a ON r.agent_id = a.id"
+        )
         if status:
             cursor = await self.db.conn.execute(
-                "SELECT * FROM runs WHERE status = ? ORDER BY started_at DESC",
+                f"{base} WHERE r.status = ? ORDER BY r.started_at DESC",
                 (status,),
             )
         else:
             cursor = await self.db.conn.execute(
-                "SELECT * FROM runs ORDER BY started_at DESC"
+                f"{base} ORDER BY r.started_at DESC"
             )
         return [_row_to_run(row) for row in await cursor.fetchall()]
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -81,10 +81,24 @@ async def app(db):
         "input_schema": [],
         "output_schema": [],
     })
-    application.state.agent_service = AgentService(
+    agent_service = AgentService(
         agent_repo=application.state.agent_repo,
         provider=provider,
     )
+    # Stub out run_forge and run_update so background tasks created by
+    # POST/PUT /api/agents don't perform real disk I/O (git init, venv
+    # creation, etc.).  Without this, 50+ background tasks pile up and
+    # the event loop never drains, causing the suite to hang.
+    _original_run_forge = agent_service.run_forge
+
+    async def _fast_run_forge(agent_id: str) -> None:
+        agent = await agent_service.agent_repo.get(agent_id)
+        if agent:
+            await agent_service.agent_repo.update(agent_id, status="ready")
+
+    agent_service.run_forge = _fast_run_forge
+    agent_service.run_update = AsyncMock()
+    application.state.agent_service = agent_service
     cu_service = ComputerUseService()
     executor = AgentExecutor(provider=provider, computer_use_service=cu_service)
 

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -9,6 +9,16 @@ import api.services.computer_use_setup as cu_setup
 from api.utils.platform import venv_bin_dir
 
 
+@pytest.fixture(autouse=True)
+def _no_wsl2_daemon(monkeypatch):
+    """Prevent enable_computer_use() from probing the real Windows daemon on WSL2.
+
+    Without this, any test that calls enable_computer_use() will hang on
+    WSL2 because _probe_daemon() opens a TCP connection to port 19542.
+    """
+    monkeypatch.setattr(cu_setup, "_is_wsl2", lambda: False)
+
+
 def _create_fake_pip(venv_path: Path) -> None:
     """Create a fake pip binary in the correct platform-specific location."""
     bin_dir = venv_bin_dir(venv_path)

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -388,38 +388,56 @@ class TestRunsLogs:
 # Registry (config commands only -- pack/pull/push tested in registry/)
 # -----------------------------------------------------------------------
 
+def _run_with_forge_home(forge_home: str, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run CLI command with an isolated FORGE_HOME so registry tests don't pollute the real config."""
+    cmd = [PYTHON, "-m", "cli", "--api-url", f"http://127.0.0.1:{FAKE_PORT}"] + list(args)
+    env = {**os.environ, "PYTHONPATH": PROJECT_ROOT, "FORGE_HOME": forge_home}
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=PROJECT_ROOT, timeout=timeout)
+
+
 class TestRegistryConfig:
+    @pytest.fixture(autouse=True)
+    def _isolated_forge_home(self, tmp_path):
+        """Each test gets its own FORGE_HOME so registry config is isolated."""
+        self._forge_home = str(tmp_path / ".forge")
+
+    def _reg_run(self, *args, **kwargs):
+        return _run_with_forge_home(self._forge_home, *args, **kwargs)
+
     def test_list(self):
-        r = _run("registry", "list")
+        r = self._reg_run("registry", "list")
         assert r.returncode == 0
-        assert "sample" in r.stdout
+        # Default config always includes 'official'
+        assert "official" in r.stdout
 
     def test_add_and_remove(self):
-        r = _run("registry", "add", "temp-test", "--type", "http", "--url", "https://fake.test")
+        r = self._reg_run("registry", "add", "temp-test", "--type", "http", "--url", "https://fake.test")
         assert r.returncode == 0
         assert "Added" in r.stdout
 
-        r = _run("registry", "list")
+        r = self._reg_run("registry", "list")
         assert "temp-test" in r.stdout
 
-        # Switch to it and back so we can remove
-        _run("registry", "use", "temp-test")
-        _run("registry", "use", "sample")
+        # Switch to temp-test and back so we can remove it
+        self._reg_run("registry", "use", "temp-test")
+        self._reg_run("registry", "use", "official")
 
-        r = _run("registry", "remove", "temp-test")
+        r = self._reg_run("registry", "remove", "temp-test")
         assert r.returncode == 0
         assert "Removed" in r.stdout
 
     def test_add_duplicate_fails(self):
-        r = _run("registry", "add", "sample", "--type", "http", "--url", "https://x")
+        # 'official' is always present in the default config
+        r = self._reg_run("registry", "add", "official", "--type", "http", "--url", "https://x")
         assert r.returncode != 0
 
     def test_use_nonexistent_fails(self):
-        r = _run("registry", "use", "nonexistent-xyz")
+        r = self._reg_run("registry", "use", "nonexistent-xyz")
         assert r.returncode != 0
 
     def test_remove_active_fails(self):
-        r = _run("registry", "remove", "sample")
+        # 'official' is the default active registry
+        r = self._reg_run("registry", "remove", "official")
         assert r.returncode != 0
 
 

--- a/forge/scripts/tests/test_gen_document.py
+++ b/forge/scripts/tests/test_gen_document.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 
 import pytest
-from docx import Document as DocxDocument
+DocxDocument = pytest.importorskip("docx", reason="python-docx not installed").Document
 
 from forge.scripts.src.gen_document import (
     Heading,

--- a/forge/scripts/tests/test_gen_xlsx.py
+++ b/forge/scripts/tests/test_gen_xlsx.py
@@ -4,7 +4,8 @@ import os
 import tempfile
 
 import pytest
-from openpyxl import load_workbook
+openpyxl = pytest.importorskip("openpyxl", reason="openpyxl not installed")
+load_workbook = openpyxl.load_workbook
 
 from forge.scripts.src.gen_xlsx import (
     generate_xlsx,


### PR DESCRIPTION
## Summary
- Fix test_settings.py hanging indefinitely on WSL2 due to unmocked daemon probe
- Fix test_agents.py full suite (59 tests) hanging after ~33 tests due to accumulated background forge tasks
- Fix `vadgr runs list` showing raw UUIDs instead of agent names by joining agents table in SQL queries
- Fix CLI registry config tests polluting ~/.forge/registry.yaml between runs
- Fix forge/scripts tests failing with import errors for optional deps (docx, openpyxl)

## Test plan
- [x] api/tests/ -- 419 passed, 1 warning (68s, was hanging before)
- [x] cli/tests/ -- 158 passed (1 pre-existing failure in test_service unrelated to this PR)
- [x] computer_use/tests/ -- 683 passed, 46 skipped
- [x] registry/tests/ -- 151 passed
- [x] forge/scripts/tests/ -- 19 passed, 2 skipped (importorskip for missing deps)
- [x] Manual: vadgr runs list now shows agent names

Closes #91, #92, #93, #94, #95