### PR TITLE
Fix test_not_running killing real services via port check

### DIFF
--- a/cli/tests/test_service.py
+++ b/cli/tests/test_service.py
@@ -163,8 +163,10 @@ class TestStop:
         assert result.exit_code == 0
         assert "Stopped" in result.output
 
-    def test_not_running(self, runner, tmp_forge):
+    def test_not_running(self, runner, tmp_forge, monkeypatch):
         from cli.commands.service import stop
+        # Prevent the stop command from detecting (and killing) real services
+        monkeypatch.setattr("cli.commands.service._port_in_use", lambda port: False)
         result = runner.invoke(stop)
         assert "not running" in result.output
 


### PR DESCRIPTION
## Summary
- Mock `_port_in_use` in `test_not_running` to prevent the stop command from detecting and killing real running services

## Test plan
- [x] cli/tests/test_service.py -- 19 passed (was 18 passed, 1 failed)
- [x] Full CLI suite -- 159 passed, 0 failed

Closes #97