### PR TITLE
fix: Windows cross-platform test and installer compatibility

### DIFF
--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -17,7 +17,14 @@ from pathlib import Path
 
 import pytest
 
-PYTHON = str(Path(__file__).resolve().parent.parent / ".venv" / "bin" / "python")
+import sys as _sys
+if _sys.platform == "win32":
+    _venv_python = Path(__file__).resolve().parent.parent / ".venv" / "Scripts" / "python.exe"
+else:
+    _venv_python = Path(__file__).resolve().parent.parent / ".venv" / "bin" / "python"
+# Fall back to the current interpreter when the CLI venv doesn't exist
+# (e.g., running tests on Windows with system Python).
+PYTHON = str(_venv_python) if _venv_python.exists() else _sys.executable
 PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
 FAKE_PORT = 18321
 

--- a/cli/tests/test_port_check.py
+++ b/cli/tests/test_port_check.py
@@ -134,14 +134,19 @@ def runner():
 
 @pytest.fixture
 def tmp_forge(tmp_path, monkeypatch):
+    import sys
     import cli.commands.service as svc
     forge_home = tmp_path / ".forge"
     pid_dir = forge_home / "pids"
     forge_repo = tmp_path / "Agent-Forge"
     pid_dir.mkdir(parents=True)
     forge_repo.mkdir(parents=True)
-    (forge_repo / "api" / ".venv" / "bin").mkdir(parents=True)
-    (forge_repo / "api" / ".venv" / "bin" / "python").write_text("#!/bin/sh")
+    if sys.platform == "win32":
+        (forge_repo / "api" / ".venv" / "Scripts").mkdir(parents=True)
+        (forge_repo / "api" / ".venv" / "Scripts" / "python.exe").write_text("")
+    else:
+        (forge_repo / "api" / ".venv" / "bin").mkdir(parents=True)
+        (forge_repo / "api" / ".venv" / "bin" / "python").write_text("#!/bin/sh")
     monkeypatch.setattr(svc, "FORGE_HOME", forge_home)
     monkeypatch.setattr(svc, "FORGE_REPO", forge_repo)
     monkeypatch.setattr(svc, "PID_DIR", pid_dir)

--- a/cli/tests/test_service.py
+++ b/cli/tests/test_service.py
@@ -3,10 +3,13 @@
 from pathlib import Path
 from unittest import mock
 import os
+import sys
 
 import click
 from click.testing import CliRunner
 import pytest
+
+_IS_WINDOWS = sys.platform == "win32"
 
 
 @pytest.fixture
@@ -16,15 +19,19 @@ def runner():
 
 @pytest.fixture
 def tmp_forge(tmp_path, monkeypatch):
-    """Set up fake FORGE_HOME structure."""
+    """Set up fake FORGE_HOME structure with platform-appropriate venv layout."""
     import cli.commands.service as svc
     forge_home = tmp_path / ".forge"
     forge_repo = forge_home / "Agent-Forge"
     pid_dir = forge_home / "pids"
     forge_repo.mkdir(parents=True)
     pid_dir.mkdir(parents=True)
-    (forge_repo / "api" / ".venv" / "bin").mkdir(parents=True)
-    (forge_repo / "api" / ".venv" / "bin" / "python").write_text("#!/bin/sh")
+    if _IS_WINDOWS:
+        (forge_repo / "api" / ".venv" / "Scripts").mkdir(parents=True)
+        (forge_repo / "api" / ".venv" / "Scripts" / "python.exe").write_text("")
+    else:
+        (forge_repo / "api" / ".venv" / "bin").mkdir(parents=True)
+        (forge_repo / "api" / ".venv" / "bin" / "python").write_text("#!/bin/sh")
     (forge_repo / "frontend").mkdir(parents=True)
 
     monkeypatch.setattr(svc, "FORGE_HOME", forge_home)
@@ -40,14 +47,16 @@ class TestReadPid:
 
     def test_returns_pid_when_alive(self, tmp_forge, monkeypatch):
         from cli.commands.service import _read_pid, PID_DIR
+        import cli.commands.service as svc
         (PID_DIR / "api.pid").write_text("12345")
-        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(svc, "_pid_alive", lambda pid: True)
         assert _read_pid("api") == 12345
 
     def test_returns_none_for_stale_pid(self, tmp_forge, monkeypatch):
         from cli.commands.service import _read_pid, PID_DIR
+        import cli.commands.service as svc
         (PID_DIR / "api.pid").write_text("99999")
-        monkeypatch.setattr(os, "kill", mock.Mock(side_effect=ProcessLookupError))
+        monkeypatch.setattr(svc, "_pid_alive", lambda pid: False)
         assert _read_pid("api") is None
         assert not (PID_DIR / "api.pid").exists()
 
@@ -55,12 +64,20 @@ class TestReadPid:
 class TestKillTree:
     def test_kills_parent(self, monkeypatch):
         from cli.commands.service import _kill_tree
-        killed = []
-        monkeypatch.setattr("subprocess.run", lambda *a, **kw: mock.Mock(stdout="", returncode=1))
-        monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append(pid))
-        _kill_tree(1234)
-        assert 1234 in killed
+        if _IS_WINDOWS:
+            # On Windows, _kill_tree calls taskkill /PID <pid> /T /F
+            calls = []
+            monkeypatch.setattr("subprocess.run", lambda *a, **kw: calls.append(a[0]) or mock.Mock(stdout="", returncode=0))
+            _kill_tree(1234)
+            assert any("1234" in str(c) for c in calls)
+        else:
+            killed = []
+            monkeypatch.setattr("subprocess.run", lambda *a, **kw: mock.Mock(stdout="", returncode=1))
+            monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append(pid))
+            _kill_tree(1234)
+            assert 1234 in killed
 
+    @pytest.mark.skipif(_IS_WINDOWS, reason="Windows _kill_tree uses taskkill /T which kills the whole tree in one call")
     def test_kills_children_first(self, monkeypatch):
         from cli.commands.service import _kill_tree
         killed = []
@@ -153,11 +170,12 @@ class TestWaitForApi:
 
 class TestStop:
     def test_stops_running_services(self, runner, tmp_forge, monkeypatch):
+        import cli.commands.service as svc
         from cli.commands.service import stop, PID_DIR
         (PID_DIR / "api.pid").write_text("111")
         (PID_DIR / "frontend.pid").write_text("222")
-        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
-        monkeypatch.setattr("cli.commands.service._kill_tree", lambda pid: None)
+        monkeypatch.setattr(svc, "_pid_alive", lambda pid: True)
+        monkeypatch.setattr(svc, "_kill_tree", lambda pid: None)
 
         result = runner.invoke(stop)
         assert result.exit_code == 0
@@ -173,10 +191,11 @@ class TestStop:
 
 class TestStatus:
     def test_shows_running(self, runner, tmp_forge, monkeypatch):
+        import cli.commands.service as svc
         from cli.commands.service import status, PID_DIR
         (PID_DIR / "api.pid").write_text("111")
         (PID_DIR / "frontend.pid").write_text("222")
-        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(svc, "_pid_alive", lambda pid: True)
 
         result = runner.invoke(status)
         assert result.exit_code == 0

--- a/registry/installer.py
+++ b/registry/installer.py
@@ -3,13 +3,34 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import stat
+import sys
 from pathlib import Path
 from typing import Optional
 
 from registry.config import get_agents_dir, load_config
 from registry.manifest import Manifest, load_manifest, validate_manifest
 from registry.packer import unpack
+
+
+def _rmtree(path: Path) -> None:
+    """Remove a directory tree, handling read-only files on Windows.
+
+    On Windows, git pack files and index files are created as read-only,
+    which causes shutil.rmtree to fail with PermissionError.  This handler
+    clears the read-only flag and retries the deletion.
+    """
+    def _on_error(func, fpath, exc_info):
+        # If the error is a PermissionError on Windows, clear read-only and retry
+        if sys.platform == "win32" and isinstance(exc_info[1], PermissionError):
+            os.chmod(fpath, stat.S_IWRITE)
+            func(fpath)
+        else:
+            raise exc_info[1]
+
+    shutil.rmtree(path, onerror=_on_error)
 
 
 def install(
@@ -44,7 +65,7 @@ def install(
                 f"Agent '{manifest.name}' already installed at {install_dir}. "
                 f"Use --force to overwrite."
             )
-        shutil.rmtree(install_dir)
+        _rmtree(install_dir)
 
     unpack(agnt_path, install_dir)
     return install_dir
@@ -58,7 +79,7 @@ def uninstall(name: str, agents_dir: Optional[Path] = None) -> bool:
     dest_root = agents_dir or get_agents_dir()
     install_dir = dest_root / name
     if install_dir.exists():
-        shutil.rmtree(install_dir)
+        _rmtree(install_dir)
         return True
     return False
 

--- a/registry/tests/test_security.py
+++ b/registry/tests/test_security.py
@@ -55,7 +55,10 @@ class TestZipSlip:
 
         dest = tmp_path / "output"
         with zipfile.ZipFile(zip_path, "r") as zf:
-            with pytest.raises(ValueError, match="absolute path"):
+            # On Unix, caught as "absolute path". On Windows, /etc is not
+            # absolute (no drive letter) so it falls through to the escape
+            # check: "escapes target directory".
+            with pytest.raises(ValueError, match="absolute path|escapes target directory"):
                 safe_extract(zf, dest)
 
     def test_blocks_dotdot_in_middle(self, tmp_path):
@@ -315,7 +318,10 @@ class TestLocalPathValidation:
     def test_blocks_symlink_escape(self, tmp_path):
         """Symlink that resolves outside root must be rejected."""
         link = tmp_path / "evil_link"
-        link.symlink_to("/etc")
+        try:
+            link.symlink_to("/etc")
+        except OSError:
+            pytest.skip("Symlink creation requires elevated privileges on Windows")
         with pytest.raises(ValueError, match="Path traversal"):
             validate_local_path(Path("evil_link/passwd"), tmp_path)
 


### PR DESCRIPTION
## Summary

- Fix 44 test failures when running CLI and registry tests on Windows
- Make test fixtures platform-aware (Unix bin/python vs Windows Scripts/python.exe)
- Mock _pid_alive directly instead of os.kill (Windows uses tasklist, not signals)
- Handle read-only .git pack files in registry/installer.py _rmtree on Windows
- Accept alternate error messages in security tests (Windows path semantics differ)
- Skip symlink test when privileges are unavailable (Windows without Developer Mode)

Closes #99, Closes #100, Closes #101, Closes #102, Closes #103

## Test plan

- [x] 310 tests pass on WSL (0 skipped)
- [x] 308 tests pass on Windows (2 skipped: symlink privilege, Windows _kill_tree children)
- [x] 683 computer_use tests pass
- [x] No regressions on either platform