### PR TITLE
fix: resolve partial run IDs in get/cancel/approve/logs

### DIFF
--- a/cli/commands/runs.py
+++ b/cli/commands/runs.py
@@ -44,8 +44,7 @@ def list_runs(ctx, status: str | None):
 @click.pass_context
 def get_run(ctx, run_id: str):
     """Show run details."""
-    if not run_id:
-        raise click.ClickException("Run ID is required.")
+    run_id = _resolve_run_id(ctx, run_id)
     data = api_get(ctx, f"/api/runs/{run_id}")
     if not isinstance(data, dict):
         raise click.ClickException(f"Run '{run_id}' not found.")
@@ -73,6 +72,7 @@ def get_run(ctx, run_id: str):
 @click.pass_context
 def cancel_run(ctx, run_id: str):
     """Cancel a running run."""
+    run_id = _resolve_run_id(ctx, run_id)
     api_post(ctx, f"/api/runs/{run_id}/cancel")
     print_success(f"Cancelled run {run_id}")
 
@@ -82,6 +82,7 @@ def cancel_run(ctx, run_id: str):
 @click.pass_context
 def approve_run(ctx, run_id: str):
     """Approve a run waiting at an approval gate."""
+    run_id = _resolve_run_id(ctx, run_id)
     api_post(ctx, f"/api/runs/{run_id}/approve")
     print_success(f"Approved run {run_id}")
 
@@ -91,6 +92,7 @@ def approve_run(ctx, run_id: str):
 @click.pass_context
 def run_logs(ctx, run_id: str):
     """Show run logs."""
+    run_id = _resolve_run_id(ctx, run_id)
     data = api_get(ctx, f"/api/runs/{run_id}/logs")
     if not data:
         print_warning("No logs yet.")
@@ -100,3 +102,16 @@ def run_logs(ctx, run_id: str):
         ts = entry.get("timestamp", "")
         msg = entry.get("message", entry.get("data", ""))
         click.echo(f"[{ts}] {msg}")
+
+
+def _resolve_run_id(ctx, run_id: str) -> str:
+    """Resolve a partial run ID to a full UUID."""
+    if not run_id:
+        raise click.ClickException("Run ID is required.")
+    runs = api_get(ctx, "/api/runs")
+    if not runs:
+        raise click.ClickException("No runs found.")
+    for r in runs:
+        if r["id"] == run_id or r["id"].startswith(run_id):
+            return r["id"]
+    raise click.ClickException(f"No run matching '{run_id}' found.")

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -153,39 +153,103 @@ class TestRunsList:
             m.assert_called_once_with(mock.ANY, "/api/runs?status=failed")
 
 
+_RUN_FULL_ID = "abcd1234-5678-9012-3456-789012345678"
+_RUN_PARTIAL_ID = "abcd1234"
+_RUN_DETAIL = {
+    "id": _RUN_FULL_ID, "agent_name": "my-agent", "status": "completed",
+    "provider": "claude_code", "model": "opus", "duration": 30.5,
+    "created_at": "2026-03-27T10:00:00", "steps": [],
+}
+_RUN_LIST = [{"id": _RUN_FULL_ID, "agent_name": "my-agent", "status": "completed", "duration": 30.5}]
+
+
+def _mock_runs_get(ctx, path):
+    if path == "/api/runs":
+        return _RUN_LIST
+    if path == f"/api/runs/{_RUN_FULL_ID}":
+        return _RUN_DETAIL
+    if path == f"/api/runs/{_RUN_FULL_ID}/logs":
+        return [{"timestamp": "10:00:01", "type": "agent_log", "message": "Starting step 1"}]
+    return None
+
+
 class TestRunsGet:
     def test_shows_detail(self, runner):
         from cli.commands.runs import runs_group
-        with mock.patch("cli.commands.runs.api_get") as m:
-            m.return_value = {
-                "id": "run-1", "agent_name": "my-agent", "status": "completed",
-                "provider": "claude_code", "model": "opus", "duration": 30.5,
-                "created_at": "2026-03-27T10:00:00",
-                "steps": [{"name": "Step 1", "status": "completed"}],
-            }
+        _detail = {
+            "id": "run-1", "agent_name": "my-agent", "status": "completed",
+            "provider": "claude_code", "model": "opus", "duration": 30.5,
+            "created_at": "2026-03-27T10:00:00",
+            "steps": [{"name": "Step 1", "status": "completed"}],
+        }
+        def _side(ctx, path):
+            if path == "/api/runs":
+                return [{"id": "run-1", "agent_name": "my-agent", "status": "completed", "duration": 30.5}]
+            return _detail
+        with mock.patch("cli.commands.runs.api_get", side_effect=_side):
             result = runner.invoke(runs_group, ["get", "run-1"], obj={"api_url": "http://x"})
             assert result.exit_code == 0
             assert "run-1" in result.output
+
+    def test_resolves_partial_id(self, runner):
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get):
+            result = runner.invoke(runs_group, ["get", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            assert _RUN_FULL_ID in result.output
 
 
 class TestRunsCancel:
     def test_cancels(self, runner):
         from cli.commands.runs import runs_group
-        with mock.patch("cli.commands.runs.api_post") as m:
+        with mock.patch("cli.commands.runs.api_get") as mg, \
+             mock.patch("cli.commands.runs.api_post") as m:
+            mg.return_value = [{"id": "run-1", "agent_name": "my-agent", "status": "running", "duration": 0}]
             m.return_value = {"status": "cancelled"}
             result = runner.invoke(runs_group, ["cancel", "run-1"], obj={"api_url": "http://x"})
             assert result.exit_code == 0
             assert "Cancelled" in result.output or "cancelled" in result.output
 
+    def test_cancel_resolves_partial_id(self, runner):
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = {"status": "cancelled"}
+            result = runner.invoke(runs_group, ["cancel", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            mp.assert_called_once_with(mock.ANY, f"/api/runs/{_RUN_FULL_ID}/cancel")
+
+
+class TestRunsApprove:
+    def test_approve_resolves_partial_id(self, runner):
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = {"status": "approved"}
+            result = runner.invoke(runs_group, ["approve", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            mp.assert_called_once_with(mock.ANY, f"/api/runs/{_RUN_FULL_ID}/approve")
+
 
 class TestRunsLogs:
     def test_shows_logs(self, runner):
         from cli.commands.runs import runs_group
-        with mock.patch("cli.commands.runs.api_get") as m:
-            m.return_value = [
-                {"timestamp": "10:00:01", "type": "agent_log", "message": "Starting step 1"},
-                {"timestamp": "10:00:05", "type": "agent_log", "message": "Done"},
-            ]
+        _logs = [
+            {"timestamp": "10:00:01", "type": "agent_log", "message": "Starting step 1"},
+            {"timestamp": "10:00:05", "type": "agent_log", "message": "Done"},
+        ]
+        def _side(ctx, path):
+            if path == "/api/runs":
+                return [{"id": "run-1", "agent_name": "my-agent", "status": "completed", "duration": 10.0}]
+            return _logs
+        with mock.patch("cli.commands.runs.api_get", side_effect=_side):
             result = runner.invoke(runs_group, ["logs", "run-1"], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            assert "Starting step 1" in result.output
+
+    def test_logs_resolves_partial_id(self, runner):
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get):
+            result = runner.invoke(runs_group, ["logs", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
             assert result.exit_code == 0
             assert "Starting step 1" in result.output


### PR DESCRIPTION
## What

Added `_resolve_run_id(ctx, run_id)` helper in `cli/commands/runs.py` and wired it into `get_run`, `cancel_run`, `approve_run`, and `run_logs` before each API call. The helper fetches `GET /api/runs`, iterates the list, and returns the full UUID for any run whose ID starts with the given prefix.

Updated `cli/tests/test_commands.py` to add 4 new tests (one per command) and to fix 3 existing tests whose mocks conflicted with the new pre-call to `/api/runs`.

## Why

The API only does exact UUID matching. Users supplying short 8-char prefixes (e.g., `forge runs get abc12345`) got a 404. The `agents` commands already handled this via `_resolve_agent()`; `runs` commands were missing the same pattern.

## How it was tested

- 4 new unit tests added:
  - `TestRunsGet::test_resolves_partial_id`
  - `TestRunsCancel::test_cancel_resolves_partial_id`
  - `TestRunsApprove::test_approve_resolves_partial_id`
  - `TestRunsLogs::test_logs_resolves_partial_id`
- All 4 pass. All 12 pre-existing runs/health/providers tests continue to pass.
- 6 `TestAgents*` failures are pre-existing (`ModuleNotFoundError: No module named 'websockets'`), unrelated to this change, and pass in CI where `cli/requirements.txt` is fully installed.
- Full suite (166 tests) verified passing in the Step 5 environment with complete deps.

Closes #105