### PR TITLE
test: add empty-ID coverage for cancel, approve, logs

### DIFF
--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -219,6 +219,12 @@ class TestRunsCancel:
             assert result.exit_code == 0
             mp.assert_called_once_with(mock.ANY, f"/api/runs/{_RUN_FULL_ID}/cancel")
 
+    def test_cancel_empty_id(self, runner):
+        from cli.commands.runs import runs_group
+        result = runner.invoke(runs_group, ["cancel", ""], obj={"api_url": "http://x"})
+        assert result.exit_code != 0
+        assert "Run ID is required." in result.output
+
 
 class TestRunsApprove:
     def test_approve_resolves_partial_id(self, runner):
@@ -229,6 +235,12 @@ class TestRunsApprove:
             result = runner.invoke(runs_group, ["approve", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
             assert result.exit_code == 0
             mp.assert_called_once_with(mock.ANY, f"/api/runs/{_RUN_FULL_ID}/approve")
+
+    def test_approve_empty_id(self, runner):
+        from cli.commands.runs import runs_group
+        result = runner.invoke(runs_group, ["approve", ""], obj={"api_url": "http://x"})
+        assert result.exit_code != 0
+        assert "Run ID is required." in result.output
 
 
 class TestRunsLogs:
@@ -253,3 +265,9 @@ class TestRunsLogs:
             result = runner.invoke(runs_group, ["logs", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
             assert result.exit_code == 0
             assert "Starting step 1" in result.output
+
+    def test_logs_empty_id(self, runner):
+        from cli.commands.runs import runs_group
+        result = runner.invoke(runs_group, ["logs", ""], obj={"api_url": "http://x"})
+        assert result.exit_code != 0
+        assert "Run ID is required." in result.output


### PR DESCRIPTION
## What

Added three unit tests to `cli/tests/test_commands.py` that verify empty-string run ID is rejected by the `cancel`, `approve`, and `logs` commands:

- `TestRunsCancel::test_cancel_empty_id`
- `TestRunsApprove::test_approve_empty_id`
- `TestRunsLogs::test_logs_empty_id`

Each test asserts `exit_code != 0` and `"Run ID is required."` in the output.

## Why

Issue #106 reported that `runs logs ""`, `runs cancel ""`, and `runs approve ""` returned an opaque "Not Found" API error instead of the user-friendly "Run ID is required." message. The production guard was added in `_resolve_run_id()` (commit `1da3bf8`, merged via PR #107), but the corresponding test coverage for `cancel`, `approve`, and `logs` was never committed.

## How it was tested

Unit tests only — this is a CLI-layer fix using `click.testing.CliRunner` with mocked HTTP calls.

Final run before commit:
```
cli/tests/test_commands.py::TestRunsCancel::test_cancel_empty_id PASSED
cli/tests/test_commands.py::TestRunsApprove::test_approve_empty_id PASSED
cli/tests/test_commands.py::TestRunsLogs::test_logs_empty_id PASSED
3 passed in 0.14s
```

Full suite (`cli/tests/`): **169 passed**.

Closes #106