### PR TITLE
fix: prevent Rich Console from wrapping lines under 200 chars

### DIFF
--- a/cli/output.py
+++ b/cli/output.py
@@ -79,7 +79,7 @@ def print_kv(pairs: list[tuple[str, str]]):
 
 def _styled(markup: str) -> str:
     buf = StringIO()
-    Console(file=buf, highlight=False, force_terminal=True).print(markup)
+    Console(file=buf, highlight=False, force_terminal=True, width=200).print(markup)
     return buf.getvalue()
 
 

--- a/cli/tests/test_output.py
+++ b/cli/tests/test_output.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from cli.output import format_table, format_status, render_table, print_kv, format_duration
+from cli.output import format_table, format_status, render_table, print_kv, format_duration, _styled
 
 
 class TestFormatTable:
@@ -74,3 +74,19 @@ class TestPrintKV:
         print_kv([])
         out = capsys.readouterr().out
         assert out == "" or out.strip() == ""
+
+
+class TestStyled:
+    def test_no_wrap_under_200_chars(self):
+        # Reproduce the bug: a message ~81 characters long must not be split across lines.
+        # e.g. "[vadgr] qa-engineer imported and ready (ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"
+        msg = "qa-engineer imported and ready (ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"
+        markup = f"[pale_green3]\\[vadgr][/] {msg}"
+        result = _styled(markup)
+        # Strip ANSI/Rich escape sequences: count non-empty lines in the output.
+        # With the bug, Rich wraps after column 80 producing 2+ lines.
+        # After the fix, the full message must appear on a single line.
+        lines = [l for l in result.splitlines() if l.strip()]
+        assert len(lines) == 1, (
+            f"Expected 1 line, got {len(lines)}. Output:\n{result!r}"
+        )


### PR DESCRIPTION
## What

Added `width=200` to the `Console(...)` constructor in `cli/output.py:_styled()` (line 82).

Also added `TestStyled::test_no_wrap_under_200_chars` to `cli/tests/test_output.py` to prevent regression.

## Why

Rich defaults to 80 columns when `force_terminal=True` is set on a non-TTY buffer. The `agents import` success message — `[vadgr] qa-engineer imported and ready (ID: <uuid>)` — is ~81 characters, so it wrapped mid-line after `(ID: `. Setting `width=200` gives enough room for all short status messages.

## How it was tested

- New unit test `TestStyled::test_no_wrap_under_200_chars` verified the fix directly: constructs the 81-char message, calls `_styled()`, and asserts exactly one non-empty line is returned.
- Full CLI test suite: **122 passed, 48 pre-existing failures** (same failure count on master without this change — confirmed via `git stash`).
- API test suite: **430 passed, 1 pre-existing failure** (unrelated to this change).

Closes #108