### PR TITLE
fix: bind Vite dev server to 0.0.0.0 for WSL2 access

### DIFF
--- a/frontend/src/__tests__/vite.config.test.ts
+++ b/frontend/src/__tests__/vite.config.test.ts
@@ -1,0 +1,9 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import config from '../../vite.config';
+
+describe('vite.config', () => {
+  it('server.host is set so the dev server is reachable outside 127.0.0.1', () => {
+    expect((config as any).server?.host).toBeTruthy();
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ const API_TARGET = `http://127.0.0.1:${API_PORT}`
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    host: true,
     port: FRONTEND_PORT,
     proxy: {
       '/api/ws': {


### PR DESCRIPTION
## What

Added `host: true` to the `server` block in `frontend/vite.config.ts`. This causes Vite to bind on `0.0.0.0` instead of `127.0.0.1`.

Added `frontend/src/__tests__/vite.config.test.ts` to assert that `server.host` is set in the exported config.

## Why

On WSL2, `127.0.0.1` is the WSL2 loopback — unreachable from the Windows host browser. Without `host: true`, the dev server is inaccessible from any browser running on Windows, even though the server is running. Setting `host: true` makes the server bind on the WSL2 network interface (e.g., `172.28.x.x:3000`), which Windows can reach.

## How it was tested

- Unit: `cd frontend && npx vitest run` — 103 tests across 14 files, 0 failures. New test `src/__tests__/vite.config.test.ts` asserts `server.host` is truthy.
- Visual: Started the dev server after the fix, confirmed `ss -tlnp | grep :3000` shows `*:3000 LISTEN` (bound to all interfaces). Navigated to `http://172.28.76.183:3000` in Windows browser — Agent Forge dashboard loaded successfully. Before the fix, `localhost:3000` returned ERR_CONNECTION_REFUSED from Windows.

Closes #111