### PR TITLE
feat: run resume with step checkpointing, executor hang fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Agent-Forge/
 │   ├── output.py                      # Table formatting, status colors
 │   ├── commands/                      # Command groups
 │   │   ├── agents.py                  # list, get, create, delete, run
-│   │   ├── runs.py                    # list, get, cancel, approve, logs
+│   │   ├── runs.py                    # list, get, cancel, approve, resume, logs
 │   │   ├── registry.py                # pack, pull, push, search, serve
 │   │   └── info.py                    # health, providers
 │   └── tests/                         # Unit + integration tests (69 tests)
@@ -108,7 +108,7 @@ forge agents list / get / create / update / delete
 forge agents export <id> / import <file.agnt> # Export/import agents
 forge run <name> [--input key=val]            # Run an agent
 forge run <name> --background                 # Run without streaming
-forge runs list / get / cancel / approve / logs
+forge runs list / get / cancel / approve / resume / logs
 forge health / providers                      # System info
 forge computer-use enable / disable / status  # Desktop automation
 forge registry pack / pull / push / search    # Package management

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ vadgr start
 | `vadgr runs list [--status failed]` | List runs |
 | `vadgr runs get <id>` | Show run details |
 | `vadgr runs cancel <id>` | Cancel a running run |
+| `vadgr runs resume <id>` | Resume a failed run from last completed step |
 | `vadgr runs logs <id>` | Show run logs |
 
 **Info:**

--- a/api/engine/executor.py
+++ b/api/engine/executor.py
@@ -28,6 +28,26 @@ def _read_step_result(agent_outputs_dir: str, step_num: int) -> dict:
     return {"status": "completed"}
 
 
+def _step_result_exists(agent_outputs_dir: str, step_num: int) -> dict | None:
+    """Read step_NN_result.json only if the file exists on disk.
+
+    Returns the parsed dict if found, None if missing.
+    Unlike _read_step_result, does NOT default to completed.
+    """
+    path = Path(agent_outputs_dir) / f"step_{step_num:02d}_result.json"
+    try:
+        if path.exists():
+            data = json.loads(path.read_text())
+            if "status" in data:
+                return data
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+_MAX_STEP_RETRIES = 1  # Retry once on crash (no result.json written)
+
+
 class AgentExecutor:
     """Executes a single agent node."""
 
@@ -153,10 +173,15 @@ class AgentExecutor:
         CLI steps use stream-json for live logs. Desktop steps use regular
         json to avoid the base64 screenshot chunk buffer crash. Context
         flows between steps through output files on disk.
+
+        Resume: steps with a completed result.json on disk are skipped.
+        Retry: if a step crashes (no result.json), it retries once.
         """
         steps = agent.get("steps", [])
         workspace = _PROJECT_ROOT
         last_output = ""
+        agent_outputs_dir = Path(workspace) / agent.get("forge_path", "") / f"output/{run_id}/agent_outputs"
+        recent_logs: list[str] = []  # Ring buffer for error context
 
         for i, step in enumerate(steps, 1):
             step_name = step["name"] if isinstance(step, dict) else step
@@ -167,38 +192,103 @@ class AgentExecutor:
             # Step context is included in event data for log routing
             step_ctx = {"step_num": i, "step_name": step_name}
 
-            await callback("agent_log", {
-                "agent_id": agent["id"],
-                "message": f"--- Step {i}: {step_name} {'[Desktop]' if uses_cu else '[CLI]'} ---",
-                **step_ctx,
-            })
+            # --- Resume: skip steps that already completed ---
+            existing = _step_result_exists(str(agent_outputs_dir), i)
+            if existing and existing.get("status") == "completed":
+                await callback("agent_log", {
+                    "agent_id": agent["id"],
+                    "message": f"--- Step {i}: {step_name} [skipped, already completed] ---",
+                    **step_ctx,
+                })
+                await callback("step_completed", {
+                    "agent_id": agent["id"],
+                    "status": "completed",
+                    "duration": 0,
+                    "summary": existing.get("summary", "(resumed)"),
+                    "error": "",
+                    **step_ctx,
+                })
+                continue
 
-            prompt = build_step_prompt(agent, inputs, step_number=i, step=step, run_id=run_id)
+            # --- Execute step (with retry on crash) ---
+            for attempt in range(_MAX_STEP_RETRIES + 1):
+                if attempt > 0:
+                    await callback("agent_log", {
+                        "agent_id": agent["id"],
+                        "message": f"Retrying step {i} ({step_name}) -- attempt {attempt + 1}",
+                        **step_ctx,
+                    })
 
-            collected_output = ""
-            selected_provider = provider or self.provider
-            step_start = time.monotonic()
-            async for event in selected_provider.execute_streaming(
-                prompt=prompt,
-                workspace=workspace,
-                timeout=timeout,
-                use_stream_json=can_stream,
-                computer_use=uses_cu,
-            ):
-                if event.type == "output":
-                    if can_stream:
-                        await callback("agent_log", {
-                            "agent_id": agent["id"],
-                            "message": event.data,
-                            **step_ctx,
-                        })
-                elif event.type == "done":
-                    collected_output = event.data
-                elif event.type == "error":
+                await callback("agent_log", {
+                    "agent_id": agent["id"],
+                    "message": f"--- Step {i}: {step_name} {'[Desktop]' if uses_cu else '[CLI]'} ---",
+                    **step_ctx,
+                })
+
+                prompt = build_step_prompt(agent, inputs, step_number=i, step=step, run_id=run_id)
+                collected_output = ""
+                selected_provider = provider or self.provider
+                recent_logs.clear()
+                step_start = time.monotonic()
+                step_error = None
+
+                try:
+                    async for event in selected_provider.execute_streaming(
+                        prompt=prompt,
+                        workspace=workspace,
+                        timeout=timeout,
+                        use_stream_json=can_stream,
+                        computer_use=uses_cu,
+                    ):
+                        if event.type == "output":
+                            # Keep last 5 log messages for error context
+                            recent_logs.append(event.data)
+                            if len(recent_logs) > 5:
+                                recent_logs.pop(0)
+                            if can_stream:
+                                await callback("agent_log", {
+                                    "agent_id": agent["id"],
+                                    "message": event.data,
+                                    **step_ctx,
+                                })
+                        elif event.type == "done":
+                            collected_output = event.data
+                        elif event.type == "error":
+                            step_error = event.data
+                except Exception as exc:
+                    step_error = str(exc)
+
+                step_duration = time.monotonic() - step_start
+
+                # Check if the agent wrote a result file (ground truth)
+                step_result = _step_result_exists(str(agent_outputs_dir), i)
+
+                if step_result and step_result.get("status") == "completed":
+                    # Agent finished its work successfully
+                    break
+                elif step_result and step_result.get("status") == "failed":
+                    # Agent ran but reported failure -- don't retry
+                    error_detail = step_result.get("error", step_error or "Unknown error")
+                    last_actions = "; ".join(recent_logs[-3:]) if recent_logs else ""
                     raise RuntimeError(
-                        f"Step {i} ({step_name}) failed: {event.data}"
+                        f"Step {i} ({step_name}) failed: {error_detail}"
+                        + (f" | Last actions: {last_actions}" if last_actions else "")
                     )
-            step_duration = time.monotonic() - step_start
+                elif step_error:
+                    # Process crashed or timed out -- retry if we have attempts left
+                    if attempt < _MAX_STEP_RETRIES:
+                        continue
+                    last_actions = "; ".join(recent_logs[-3:]) if recent_logs else ""
+                    raise RuntimeError(
+                        f"Step {i} ({step_name}) crashed: {step_error}"
+                        + (f" | Last actions: {last_actions}" if last_actions else "")
+                    )
+                else:
+                    # No result file but no error either -- treat as success
+                    step_result = {"status": "completed", "summary": ""}
+                    break
+
+            # step_duration was set inside the retry loop at line 261
 
             # Validate desktop steps actually used computer use
             if uses_cu:
@@ -219,9 +309,9 @@ class AgentExecutor:
 
             last_output = collected_output
 
-            # Read structured step result if the agent wrote one
-            agent_outputs_dir = Path(workspace) / agent.get("forge_path", "") / f"output/{run_id}/agent_outputs"
-            step_result = _read_step_result(str(agent_outputs_dir), i)
+            # Use the on-disk result (may have been set during retry loop)
+            if step_result is None:
+                step_result = _read_step_result(str(agent_outputs_dir), i)
 
             await callback("step_completed", {
                 "agent_id": agent["id"],

--- a/api/engine/providers.py
+++ b/api/engine/providers.py
@@ -506,6 +506,7 @@ class CLIAgentProvider:
                         )
                         if result is not None:
                             final_result = result
+                            break  # Claude is done; stop reading -- child processes may hold pipe open
                         elif msg is not None:
                             collected.append(msg)
                             yield ExecutionEvent(type="output", data=msg)
@@ -513,14 +514,20 @@ class CLIAgentProvider:
                         collected.append(text)
                         yield ExecutionEvent(type="output", data=text)
 
-                await proc.wait()
-                if proc.returncode != 0:
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    await kill_process_tree(proc)
+                # If we got a result event, the step succeeded -- ignore exit code
+                # (process may have been killed to clean up orphan children)
+                if final_result is not None:
+                    yield ExecutionEvent(type="done", data=final_result)
+                elif proc.returncode not in (None, 0):
                     stderr_data = await proc.stderr.read()
                     error_msg = stderr_data.decode().strip() if stderr_data else "Unknown error"
                     yield ExecutionEvent(type="error", data=error_msg)
                 else:
-                    done_data = final_result if final_result is not None else "\n".join(collected)
-                    yield ExecutionEvent(type="done", data=done_data)
+                    yield ExecutionEvent(type="done", data="\n".join(collected))
 
             async for event in read_stream():
                 yield event

--- a/api/routes/runs.py
+++ b/api/routes/runs.py
@@ -91,6 +91,39 @@ async def cancel_run(run_id: str, request: Request):
     return updated
 
 
+@router.post("/api/runs/{run_id}/resume")
+async def resume_run(run_id: str, request: Request):
+    run_repo = request.app.state.run_repo
+    run = await run_repo.get(run_id)
+    if not run:
+        return _not_found(run_id)
+    # Idempotent: if already running (e.g. button spammed), return current state
+    if run["status"] == "running":
+        return {"run_id": run_id, "status": "running", "message": "Already running"}
+    if run["status"] not in ("failed",):
+        return JSONResponse(
+            status_code=409,
+            content={"error": {
+                "code": "RUN_NOT_RESUMABLE",
+                "message": f"Only failed runs can be resumed (current status: {run['status']})",
+                "details": {},
+            }},
+        )
+    # Prevent duplicate tasks if there's already an active one for this run
+    existing_task = request.app.state.active_run_tasks.get(run_id)
+    if existing_task and not existing_task.done():
+        return {"run_id": run_id, "status": "running", "message": "Already resuming"}
+
+    import asyncio
+    execution_service = request.app.state.execution_service
+    task = asyncio.create_task(execution_service.resume_standalone_agent(run_id))
+    request.app.state.active_run_tasks[run_id] = task
+    task.add_done_callback(
+        lambda _: request.app.state.active_run_tasks.pop(run_id, None)
+    )
+    return {"run_id": run_id, "status": "running", "message": "Resuming from last completed step"}
+
+
 @router.post("/api/runs/{run_id}/approve")
 async def approve_run(run_id: str, request: Request):
     run_repo = request.app.state.run_repo

--- a/api/services/execution_service.py
+++ b/api/services/execution_service.py
@@ -108,6 +108,45 @@ class ExecutionService:
             await self.run_repo.update_status(run_id, "failed", outputs={"error": str(e)})
             await self.emit(run_id, "run_failed", {"error": str(e)})
 
+    async def resume_standalone_agent(self, run_id: str):
+        """Resume a failed standalone agent run from the last completed step."""
+        run = await self.run_repo.get(run_id)
+        agent = await self.agent_repo.get(run["agent_id"])
+        provider_key = run.get("provider") or agent.get("provider")
+        model = run.get("model") or agent.get("model")
+        timeout = 1800 if agent.get("computer_use") else 900
+        provider = await self._get_run_provider(provider_key, model, timeout)
+        execution_agent = {
+            **agent,
+            "provider": provider_key,
+            "model": model,
+        }
+
+        # Don't recreate output dirs -- they exist from the original run
+        await self.run_repo.update_status(run_id, "running")
+        await self.emit(run_id, "run_resumed", {"forge_path": agent.get("forge_path", "")})
+
+        try:
+            async def callback(event_type, data):
+                await self.emit(run_id, event_type, data)
+
+            result = await self.executor.execute(
+                execution_agent,
+                run["inputs"],
+                callback,
+                run_id=run_id,
+                provider=provider,
+            )
+            await self.run_repo.update_status(run_id, "completed", outputs=result)
+            await self.emit(run_id, "run_completed", {"outputs": result})
+        except asyncio.CancelledError:
+            await self.run_repo.update_status(run_id, "failed")
+            await self.emit(run_id, "run_failed", {"error": "Run was cancelled"})
+            raise
+        except Exception as e:
+            await self.run_repo.update_status(run_id, "failed", outputs={"error": str(e)})
+            await self.emit(run_id, "run_failed", {"error": str(e)})
+
     async def run_project(self, run_id: str):
         """Execute a project run following DAG topology."""
         run = await self.run_repo.get(run_id)

--- a/api/tests/test_executor.py
+++ b/api/tests/test_executor.py
@@ -934,3 +934,426 @@ class TestExecuteSingleDiskOutputs:
 
         result = await executor.execute(agent, {}, callback, run_id="run-00")
         assert result == {"summary": "parsed output"}
+
+
+class TestResumeAndRetry:
+    """Tests for step resume (skip completed) and retry (crash recovery)."""
+
+    def _make_step_agent(self, forge_path="output/test-resume"):
+        return {
+            "id": "resume-agent",
+            "name": "Resume Test",
+            "computer_use": False,
+            "provider": "claude_code",
+            "forge_path": forge_path,
+            "description": "Test resume",
+            "output_schema": [],
+            "steps": [
+                {"name": "Step A", "computer_use": False},
+                {"name": "Step B", "computer_use": False},
+                {"name": "Step C", "computer_use": False},
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_resume_skips_completed_steps(self, tmp_path):
+        """Steps with completed result.json on disk should be skipped."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = self._make_step_agent(forge_path)
+        run_id = "test-run-resume"
+
+        # Create output dir and write step 1 as completed
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        (outputs_dir / "step_01_result.json").write_text(
+            '{"status": "completed", "summary": "Already done"}'
+        )
+
+        call_count = 0
+
+        async def fake_streaming(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            yield ExecutionEvent(type="done", data="step done")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # Should have executed only 2 steps (B and C), not 3
+        assert call_count == 2
+
+        # Check that step 1 was logged as skipped
+        log_messages = [
+            c.args[1]["message"] for c in callback.call_args_list
+            if c.args[0] == "agent_log"
+        ]
+        assert any("skipped, already completed" in m for m in log_messages)
+        assert any("Step B" in m and "[CLI]" in m for m in log_messages)
+
+    @pytest.mark.asyncio
+    async def test_resume_reruns_failed_step(self, tmp_path):
+        """Steps with failed result.json should be re-executed, not skipped."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = self._make_step_agent(forge_path)
+        run_id = "test-run-retry-failed"
+
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        # Step 1 completed, step 2 failed
+        (outputs_dir / "step_01_result.json").write_text(
+            '{"status": "completed", "summary": "Done"}'
+        )
+        (outputs_dir / "step_02_result.json").write_text(
+            '{"status": "failed", "error": "something broke"}'
+        )
+
+        async def fake_streaming(**kwargs):
+            # On re-run, step 2 succeeds -- overwrite the result file
+            (outputs_dir / "step_02_result.json").write_text(
+                '{"status": "completed", "summary": "Fixed"}'
+            )
+            yield ExecutionEvent(type="done", data="ok")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # Step 1 skipped, steps 2 and 3 executed
+        log_messages = [
+            c.args[1]["message"] for c in callback.call_args_list
+            if c.args[0] == "agent_log"
+        ]
+        assert any("Step A" in m and "skipped" in m for m in log_messages)
+        assert any("Step B" in m and "[CLI]" in m for m in log_messages)
+
+    @pytest.mark.asyncio
+    async def test_retry_on_crash_then_succeed(self, tmp_path):
+        """A step that crashes (error event, no result.json) should retry once."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "Flaky Step", "computer_use": False}],
+        }
+        run_id = "test-run-crash-retry"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+
+        attempt = 0
+
+        async def fake_streaming(**kwargs):
+            nonlocal attempt
+            attempt += 1
+            if attempt == 1:
+                # First attempt crashes
+                yield ExecutionEvent(type="error", data="connection reset")
+            else:
+                # Second attempt succeeds
+                yield ExecutionEvent(type="done", data="ok")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # Should have been called twice (crash + retry)
+        assert attempt == 2
+
+        # Check retry was logged
+        log_messages = [
+            c.args[1]["message"] for c in callback.call_args_list
+            if c.args[0] == "agent_log"
+        ]
+        assert any("Retrying" in m for m in log_messages)
+
+    @pytest.mark.asyncio
+    async def test_crash_twice_raises_with_context(self, tmp_path):
+        """A step that crashes on both attempts raises with last actions in the error."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "Always Crashes", "computer_use": False}],
+        }
+        run_id = "test-run-double-crash"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+
+        async def fake_streaming(**kwargs):
+            yield ExecutionEvent(type="output", data="Using tool: Bash")
+            yield ExecutionEvent(type="output", data="Running pytest...")
+            yield ExecutionEvent(type="error", data="process killed")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with pytest.raises(RuntimeError, match="Always Crashes.*crashed.*process killed"):
+            with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+                await executor.execute(agent, {}, callback, run_id=run_id)
+
+    @pytest.mark.asyncio
+    async def test_failed_result_raises_with_error_detail(self, tmp_path):
+        """A step that writes failed result.json raises with the error from the file."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "Fails Gracefully", "computer_use": False}],
+        }
+        run_id = "test-run-graceful-fail"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+
+        async def fake_streaming(**kwargs):
+            # Agent writes its own failure result
+            (outputs_dir / "step_01_result.json").write_text(
+                '{"status": "failed", "error": "API returned 500 on /health"}'
+            )
+            yield ExecutionEvent(type="done", data="")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with pytest.raises(RuntimeError, match="Fails Gracefully.*failed.*API returned 500"):
+            with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+                await executor.execute(agent, {}, callback, run_id=run_id)
+
+    @pytest.mark.asyncio
+    async def test_all_steps_completed_skips_entire_run(self, tmp_path):
+        """If all steps have completed result.json, no provider calls are made."""
+        from api.engine.executor import AgentExecutor
+
+        forge_path = str(tmp_path / "agent")
+        agent = self._make_step_agent(forge_path)
+        run_id = "test-run-all-done"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+
+        for i in range(1, 4):
+            (outputs_dir / f"step_{i:02d}_result.json").write_text(
+                f'{{"status": "completed", "summary": "Step {i} done"}}'
+            )
+
+        call_count = 0
+
+        async def fake_streaming(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            yield ExecutionEvent(type="done", data="should not happen")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # No provider calls -- everything was already done
+        assert call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_reruns_step_with_invalid_json(self, tmp_path):
+        """A result.json with invalid JSON is treated as missing -- step re-executes."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "Corrupt Step", "computer_use": False}],
+        }
+        run_id = "test-run-corrupt-json"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        # Write invalid JSON
+        (outputs_dir / "step_01_result.json").write_text("{not valid json")
+
+        call_count = 0
+
+        async def fake_streaming(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            yield ExecutionEvent(type="done", data="ok")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # Invalid JSON means file is treated as missing -- step must re-execute
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resume_reruns_step_with_no_status_field(self, tmp_path):
+        """A result.json without a 'status' field is treated as missing -- step re-executes."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "No Status Step", "computer_use": False}],
+        }
+        run_id = "test-run-no-status"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        # Write JSON with no status field
+        (outputs_dir / "step_01_result.json").write_text('{"summary": "done but no status"}')
+
+        call_count = 0
+
+        async def fake_streaming(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            yield ExecutionEvent(type="done", data="ok")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # No status field means _step_result_exists returns None -- step must re-execute
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resume_skipped_step_uses_default_summary(self, tmp_path):
+        """A completed step with no 'summary' field emits step_completed with summary='(resumed)'."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "Silent Step", "computer_use": False}],
+        }
+        run_id = "test-run-no-summary"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        # Completed but no summary field
+        (outputs_dir / "step_01_result.json").write_text('{"status": "completed"}')
+
+        provider = AsyncMock()
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # Find the step_completed event for the skipped step
+        step_completed_calls = [
+            c for c in callback.call_args_list
+            if c.args[0] == "step_completed"
+        ]
+        assert len(step_completed_calls) == 1
+        data = step_completed_calls[0].args[1]
+        assert data["summary"] == "(resumed)"
+        assert data["duration"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_reruns_step_with_unknown_status(self, tmp_path):
+        """A result.json with status='running' (not 'completed') causes the step to re-execute."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [{"name": "Running Step", "computer_use": False}],
+        }
+        run_id = "test-run-unknown-status"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        # Status is 'running' -- not 'completed', should not be skipped
+        (outputs_dir / "step_01_result.json").write_text('{"status": "running"}')
+
+        call_count = 0
+
+        async def fake_streaming(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            (outputs_dir / "step_01_result.json").write_text('{"status": "completed", "summary": "fixed"}')
+            yield ExecutionEvent(type="done", data="ok")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        # 'running' status is not 'completed' -- step must be re-executed
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resume_skipped_step_emits_duration_zero(self, tmp_path):
+        """Skipped (already completed) steps emit step_completed with duration=0."""
+        from api.engine.executor import AgentExecutor
+        from api.engine.providers import ExecutionEvent
+
+        forge_path = str(tmp_path / "agent")
+        agent = {
+            **self._make_step_agent(forge_path),
+            "steps": [
+                {"name": "Already Done", "computer_use": False},
+                {"name": "New Step", "computer_use": False},
+            ],
+        }
+        run_id = "test-run-duration-zero"
+        outputs_dir = tmp_path / "agent" / f"output/{run_id}/agent_outputs"
+        outputs_dir.mkdir(parents=True)
+        (outputs_dir / "step_01_result.json").write_text('{"status": "completed", "summary": "done"}')
+
+        async def fake_streaming(**kwargs):
+            yield ExecutionEvent(type="done", data="ok")
+
+        provider = AsyncMock()
+        provider.execute_streaming = fake_streaming
+        callback = AsyncMock()
+        executor = AgentExecutor(provider, AsyncMock())
+
+        with patch("api.engine.executor._PROJECT_ROOT", str(tmp_path)):
+            await executor.execute(agent, {}, callback, run_id=run_id)
+
+        step_completed_calls = [
+            c for c in callback.call_args_list
+            if c.args[0] == "step_completed"
+        ]
+        # First step_completed is for the skipped step
+        assert step_completed_calls[0].args[1]["duration"] == 0
+        assert step_completed_calls[0].args[1]["step_name"] == "Already Done"

--- a/api/tests/test_runs.py
+++ b/api/tests/test_runs.py
@@ -530,3 +530,113 @@ class TestRunLogsEndpoint:
             assert resp.json() == []
         finally:
             runs_mod._PROJECT_ROOT = original_root
+
+
+class TestRunResume:
+
+    @pytest.mark.asyncio
+    async def test_resume_failed_run_returns_200(self, client, app):
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        await app.state.run_repo.update_status(run_id, "failed")
+        resp = await client.post(f"/api/runs/{run_id}/resume")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["run_id"] == run_id
+        assert data["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_resume_running_run_is_idempotent(self, client, app):
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        await app.state.run_repo.update_status(run_id, "running")
+        resp = await client.post(f"/api/runs/{run_id}/resume")
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "Already running"
+
+    @pytest.mark.asyncio
+    async def test_resume_completed_run_returns_409(self, client, app):
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        await app.state.run_repo.update_status(run_id, "completed")
+        resp = await client.post(f"/api/runs/{run_id}/resume")
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_resume_nonexistent_run_returns_404(self, client):
+        resp = await client.post("/api/runs/nonexistent-id/resume")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_resume_queued_run_returns_409(self, client, app):
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        # Run starts as queued -- do not change status
+        resp = await client.post(f"/api/runs/{run_id}/resume")
+        assert resp.status_code == 409
+        data = resp.json()
+        assert data["error"]["code"] == "RUN_NOT_RESUMABLE"
+        assert "queued" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_resume_awaiting_approval_run_returns_409(self, client, app):
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        await app.state.run_repo.update_status(run_id, "awaiting_approval")
+        resp = await client.post(f"/api/runs/{run_id}/resume")
+        assert resp.status_code == 409
+        data = resp.json()
+        assert data["error"]["code"] == "RUN_NOT_RESUMABLE"
+        assert "awaiting_approval" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_resume_cancelled_run_returns_409(self, client, app):
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        await app.state.run_repo.update_status(run_id, "cancelled")
+        resp = await client.post(f"/api/runs/{run_id}/resume")
+        assert resp.status_code == 409
+        data = resp.json()
+        assert data["error"]["code"] == "RUN_NOT_RESUMABLE"
+        assert "cancelled" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_resume_duplicate_active_task_returns_already_resuming(self, client, app):
+        """If an active asyncio task is already resuming the run, return 200 with 'Already resuming'."""
+        import asyncio
+        agent = await client.post("/api/agents", json={"name": "T", "description": ""})
+        agent_id = agent.json()["id"]
+        await app.state.agent_repo.update(agent_id, status="ready")
+        run = await client.post(f"/api/agents/{agent_id}/run", json={"inputs": {}})
+        run_id = run.json()["run_id"]
+        await app.state.run_repo.update_status(run_id, "failed")
+
+        # Plant a fake active task that is not done
+        never_done = asyncio.get_event_loop().create_future()
+        app.state.active_run_tasks[run_id] = never_done
+
+        try:
+            resp = await client.post(f"/api/runs/{run_id}/resume")
+            assert resp.status_code == 200
+            assert resp.json()["message"] == "Already resuming"
+        finally:
+            never_done.cancel()
+            app.state.active_run_tasks.pop(run_id, None)

--- a/api/tests/test_services.py
+++ b/api/tests/test_services.py
@@ -1468,6 +1468,160 @@ class TestExecutionService:
         assert n1["id"] in data["outputs_so_far"]
         assert data["outputs_so_far"][n1["id"]] == {"result": "done"}
 
+    @pytest.mark.asyncio
+    async def test_resume_standalone_agent_emits_run_resumed_not_run_started(self, db):
+        from api.persistence.repositories import AgentRepository, RunRepository
+
+        agent_repo = AgentRepository(db)
+        run_repo = RunRepository(db)
+
+        agent = await agent_repo.create(name="Resumable", description="")
+        run = await run_repo.create(agent_id=agent["id"], inputs={"k": "v"})
+        await run_repo.update_status(run["id"], "failed")
+
+        executor_mock = AsyncMock()
+        executor_mock.execute.return_value = {"result": "ok"}
+        emit_mock = AsyncMock()
+
+        service = ExecutionService(
+            agent_repo=agent_repo,
+            run_repo=run_repo,
+            project_repo=None,
+            executor=executor_mock,
+            emit=emit_mock,
+        )
+        await service.resume_standalone_agent(run["id"])
+
+        emitted_event_types = [c.args[1] for c in emit_mock.call_args_list]
+        assert "run_resumed" in emitted_event_types
+        assert "run_started" not in emitted_event_types
+
+    @pytest.mark.asyncio
+    async def test_resume_standalone_agent_success_sets_status_completed(self, db):
+        from api.persistence.repositories import AgentRepository, RunRepository
+
+        agent_repo = AgentRepository(db)
+        run_repo = RunRepository(db)
+
+        agent = await agent_repo.create(name="Resumable", description="")
+        run = await run_repo.create(agent_id=agent["id"], inputs={})
+        await run_repo.update_status(run["id"], "failed")
+
+        executor_mock = AsyncMock()
+        executor_mock.execute.return_value = {"output": "done"}
+        emit_mock = AsyncMock()
+
+        service = ExecutionService(
+            agent_repo=agent_repo,
+            run_repo=run_repo,
+            project_repo=None,
+            executor=executor_mock,
+            emit=emit_mock,
+        )
+        await service.resume_standalone_agent(run["id"])
+
+        updated = await run_repo.get(run["id"])
+        assert updated["status"] == "completed"
+        assert updated["outputs"] == {"output": "done"}
+
+    @pytest.mark.asyncio
+    async def test_resume_standalone_agent_failure_sets_status_failed(self, db):
+        from api.persistence.repositories import AgentRepository, RunRepository
+
+        agent_repo = AgentRepository(db)
+        run_repo = RunRepository(db)
+
+        agent = await agent_repo.create(name="Resumable", description="")
+        run = await run_repo.create(agent_id=agent["id"], inputs={})
+        await run_repo.update_status(run["id"], "failed")
+
+        executor_mock = AsyncMock()
+        executor_mock.execute.side_effect = RuntimeError("step 2 failed")
+        emit_mock = AsyncMock()
+
+        service = ExecutionService(
+            agent_repo=agent_repo,
+            run_repo=run_repo,
+            project_repo=None,
+            executor=executor_mock,
+            emit=emit_mock,
+        )
+        await service.resume_standalone_agent(run["id"])
+
+        updated = await run_repo.get(run["id"])
+        assert updated["status"] == "failed"
+        emitted_types = [c.args[1] for c in emit_mock.call_args_list]
+        assert "run_failed" in emitted_types
+
+    @pytest.mark.asyncio
+    async def test_resume_standalone_agent_does_not_recreate_output_dirs(self, db):
+        from api.persistence.repositories import AgentRepository, RunRepository
+        import api.services.execution_service as execution_service_mod
+
+        agent_repo = AgentRepository(db)
+        run_repo = RunRepository(db)
+
+        agent = await agent_repo.create(name="Resumable", description="")
+        run = await run_repo.create(agent_id=agent["id"], inputs={})
+        await run_repo.update_status(run["id"], "failed")
+
+        executor_mock = AsyncMock()
+        executor_mock.execute.return_value = {}
+        emit_mock = AsyncMock()
+
+        service = ExecutionService(
+            agent_repo=agent_repo,
+            run_repo=run_repo,
+            project_repo=None,
+            executor=executor_mock,
+            emit=emit_mock,
+        )
+
+        with patch.object(execution_service_mod, "_ensure_run_output_dirs") as mock_ensure:
+            await service.resume_standalone_agent(run["id"])
+            mock_ensure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resume_standalone_agent_uses_run_provider_and_model(self, db):
+        from api.persistence.repositories import AgentRepository, RunRepository
+
+        agent_repo = AgentRepository(db)
+        run_repo = RunRepository(db)
+
+        agent = await agent_repo.create(
+            name="Resumable", description="",
+            provider="claude_code", model="claude-sonnet-4-6",
+        )
+        run = await run_repo.create(
+            agent_id=agent["id"], inputs={},
+            provider="codex", model="gpt-5-codex",
+        )
+        await run_repo.update_status(run["id"], "failed")
+
+        executor_mock = AsyncMock()
+        executor_mock.execute.return_value = {}
+        emit_mock = AsyncMock()
+        provider_instance = object()
+        provider_factory = AsyncMock(return_value=provider_instance)
+
+        service = ExecutionService(
+            agent_repo=agent_repo,
+            run_repo=run_repo,
+            project_repo=None,
+            executor=executor_mock,
+            emit=emit_mock,
+            provider_factory=provider_factory,
+        )
+        await service.resume_standalone_agent(run["id"])
+
+        # Must use run's provider/model override, not agent's
+        provider_factory.assert_awaited_once_with(
+            provider_key="codex",
+            model="gpt-5-codex",
+            timeout=900,
+        )
+        assert executor_mock.execute.await_args.kwargs["provider"] is provider_instance
+
 
 def _make_streaming_provider(output='{"result": "done"}'):
     """Create a mock CLI provider whose execute_streaming yields a done event.

--- a/cli/commands/runs.py
+++ b/cli/commands/runs.py
@@ -35,7 +35,17 @@ def list_runs(ctx, status: str | None):
         duration = r.get("duration", "-")
         if isinstance(duration, (int, float)):
             duration = f"{duration:.0f}s"
-        rows.append([r["id"][:8], agent, status_text(r.get("status", "?")), str(duration)])
+        run_status = status_text(r.get("status", "?"))
+        # Show which step failed for failed runs
+        outputs = r.get("outputs") or {}
+        if r.get("status") == "failed" and isinstance(outputs, dict):
+            error = outputs.get("error", "")
+            # Extract step number from error like "Step 3 (Test CLI) failed: ..."
+            if error.startswith("Step "):
+                parts = error.split(")", 1)
+                if parts:
+                    run_status = f"failed ({parts[0]})"
+        rows.append([r["id"][:8], agent, run_status, str(duration)])
     print_table(["Run ID", "Agent", "Status", "Duration"], rows)
 
 
@@ -66,6 +76,13 @@ def get_run(ctx, run_id: str):
         for i, s in enumerate(steps, 1):
             click.echo(f"  {i}. {s.get('name', '?')} -- {format_status(s.get('status', '?'))}")
 
+    # Show error detail and resume hint for failed runs
+    if data.get("status") == "failed":
+        outputs = data.get("outputs") or {}
+        if isinstance(outputs, dict) and outputs.get("error"):
+            click.echo(f"\nError: {outputs['error']}")
+        click.echo(f"\nResume with: vadgr runs resume {data['id'][:8]}")
+
 
 @runs_group.command("cancel")
 @click.argument("run_id")
@@ -85,6 +102,23 @@ def approve_run(ctx, run_id: str):
     run_id = _resolve_run_id(ctx, run_id)
     api_post(ctx, f"/api/runs/{run_id}/approve")
     print_success(f"Approved run {run_id}")
+
+
+@runs_group.command("resume")
+@click.argument("run_id")
+@click.pass_context
+def resume_run(ctx, run_id: str):
+    """Resume a failed run from its last completed step."""
+    run_id = _resolve_run_id(ctx, run_id)
+    data = api_post(ctx, f"/api/runs/{run_id}/resume")
+    if isinstance(data, dict):
+        msg = data.get("message", "")
+        if "Already" in msg:
+            print_warning(msg)
+        else:
+            print_success(f"Resuming run {run_id}")
+    else:
+        print_success(f"Resume requested for {run_id}")
 
 
 @runs_group.command("logs")

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -271,3 +271,94 @@ class TestRunsLogs:
         result = runner.invoke(runs_group, ["logs", ""], obj={"api_url": "http://x"})
         assert result.exit_code != 0
         assert "Run ID is required." in result.output
+
+
+class TestRunsResume:
+    """Tests for `vadgr runs resume`."""
+
+    def test_help_exits_zero(self, runner):
+        from cli.commands.runs import runs_group
+        result = runner.invoke(runs_group, ["resume", "--help"], obj={"api_url": "http://x"})
+        assert result.exit_code == 0
+        assert "RUN_ID" in result.output
+        assert "Resume" in result.output
+
+    def test_resume_failed_run_prints_success(self, runner):
+        """Valid input: full ID, API returns success payload."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = {"run_id": _RUN_FULL_ID, "status": "running", "message": "Resuming from last completed step"}
+            result = runner.invoke(runs_group, ["resume", _RUN_FULL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            assert "Resuming" in result.output
+            mp.assert_called_once_with(mock.ANY, f"/api/runs/{_RUN_FULL_ID}/resume")
+
+    def test_resume_resolves_partial_id(self, runner):
+        """Valid input: partial ID resolves to full UUID before calling the endpoint."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = {"run_id": _RUN_FULL_ID, "status": "running", "message": "Resuming from last completed step"}
+            result = runner.invoke(runs_group, ["resume", _RUN_PARTIAL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            # Must call the full UUID endpoint, not the partial
+            mp.assert_called_once_with(mock.ANY, f"/api/runs/{_RUN_FULL_ID}/resume")
+
+    def test_resume_already_running_prints_warning(self, runner):
+        """Invalid state: API returns 'Already running' -- should print warning, not success."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = {"message": "Already running"}
+            result = runner.invoke(runs_group, ["resume", _RUN_FULL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            assert "Already running" in result.output
+            # Warning path must NOT print the generic success message
+            assert "Resuming run" not in result.output
+
+    def test_resume_already_resuming_prints_warning(self, runner):
+        """Invalid state: API returns 'Already resuming' -- should print warning."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = {"message": "Already resuming"}
+            result = runner.invoke(runs_group, ["resume", _RUN_FULL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            assert "Already resuming" in result.output
+            assert "Resuming run" not in result.output
+
+    def test_resume_empty_id_exits_nonzero(self, runner):
+        """Edge case: empty string ID -- must reject with non-zero exit and clear error."""
+        from cli.commands.runs import runs_group
+        result = runner.invoke(runs_group, ["resume", ""], obj={"api_url": "http://x"})
+        assert result.exit_code != 0
+        assert "Run ID is required." in result.output
+
+    def test_resume_nonexistent_id_exits_nonzero(self, runner):
+        """Edge case: ID not found in any run -- non-zero exit with clear error."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get") as mg:
+            mg.return_value = [{"id": _RUN_FULL_ID, "agent_name": "my-agent", "status": "failed", "duration": 0}]
+            result = runner.invoke(runs_group, ["resume", "deadbeef"], obj={"api_url": "http://x"})
+            assert result.exit_code != 0
+            assert "deadbeef" in result.output
+
+    def test_resume_no_runs_at_all_exits_nonzero(self, runner):
+        """Edge case: API returns empty run list -- _resolve_run_id raises ClickException."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get") as mg:
+            mg.return_value = []
+            result = runner.invoke(runs_group, ["resume", "any-id"], obj={"api_url": "http://x"})
+            assert result.exit_code != 0
+            assert "No runs found." in result.output
+
+    def test_resume_non_dict_response_still_succeeds(self, runner):
+        """Edge case: API returns a non-dict (e.g. None) -- falls back to generic success."""
+        from cli.commands.runs import runs_group
+        with mock.patch("cli.commands.runs.api_get", side_effect=_mock_runs_get), \
+             mock.patch("cli.commands.runs.api_post") as mp:
+            mp.return_value = None
+            result = runner.invoke(runs_group, ["resume", _RUN_FULL_ID], obj={"api_url": "http://x"})
+            assert result.exit_code == 0
+            assert "Resume requested" in result.output


### PR DESCRIPTION
## Summary
- Fix executor hanging when Claude spawns background children (break on result event)
- Add run resume: `vadgr runs resume <id>` skips completed steps, retries crashed steps once
- Idempotent resume endpoint (spam-safe)
- Rich error messages with last agent actions on failure

## Test plan
- [x] Unit tests: resume skip, rerun failed, retry crash, error context, all-done skip
- [x] API tests: resume failed/running/completed/queued/cancelled/duplicate
- [x] Integration: cancel mid-step, resume, verify skip
- [x] Idempotency: spam 3x while running