### PR TITLE
fix: make memory respect FORGE_HOME env var

### DIFF
--- a/cli/stream.py
+++ b/cli/stream.py
@@ -14,7 +14,6 @@ from rich.console import Console
 from cli.output import format_duration, print_success, print_error
 
 _SPINNER_STYLE = "dots"
-_FORGE_PID_DIR = Path.home() / ".forge" / "pids"
 _STEP_COMPLETE_PAD = 40
 _MAX_STEP_NAME_LEN = 45
 

--- a/forge/scripts/src/memory.py
+++ b/forge/scripts/src/memory.py
@@ -1,18 +1,21 @@
 """Persistent memory for forge agents.
 
-Stores markdown files with YAML frontmatter at ~/.forge/memory/{agent}/{key}.md.
+Stores markdown files with YAML frontmatter at FORGE_HOME/memory/{agent}/{key}.md.
 CLI-agnostic: works with Claude Code, Codex, Gemini, or any provider.
+Respects the FORGE_HOME environment variable (defaults to ~/.forge).
 """
 
 from __future__ import annotations
 
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 
-MEMORY_DIR = Path.home() / ".forge" / "memory"
+_FORGE_HOME = Path(os.environ.get("FORGE_HOME", Path.home() / ".forge"))
+MEMORY_DIR = _FORGE_HOME / "memory"
 
 
 def _frontmatter(agent: str, key: str) -> str:

--- a/forge/scripts/tests/test_memory.py
+++ b/forge/scripts/tests/test_memory.py
@@ -150,3 +150,27 @@ class TestRepoKey:
         assert "/" not in result
         assert "\\" not in result
         assert "repo-" in result
+
+
+class TestForgeHomeEnvVar:
+
+    def test_memory_dir_respects_forge_home_env(self, tmp_path, monkeypatch):
+        """MEMORY_DIR should derive from FORGE_HOME env var when set."""
+        custom_home = tmp_path / "custom-forge"
+        monkeypatch.setenv("FORGE_HOME", str(custom_home))
+        import importlib
+        import forge.scripts.src.memory as mem_mod
+        importlib.reload(mem_mod)
+        try:
+            assert mem_mod.MEMORY_DIR == custom_home / "memory"
+        finally:
+            monkeypatch.delenv("FORGE_HOME", raising=False)
+            importlib.reload(mem_mod)
+
+    def test_memory_dir_defaults_to_dot_forge(self, monkeypatch):
+        """Without FORGE_HOME, MEMORY_DIR should default to ~/.forge/memory."""
+        monkeypatch.delenv("FORGE_HOME", raising=False)
+        import importlib
+        import forge.scripts.src.memory as mem_mod
+        importlib.reload(mem_mod)
+        assert mem_mod.MEMORY_DIR == Path.home() / ".forge" / "memory"


### PR DESCRIPTION
## Summary
- `forge/scripts/src/memory.py`: MEMORY_DIR now derives from FORGE_HOME env var (defaults to ~/.forge)
- `cli/stream.py`: removed unused _FORGE_PID_DIR (dead code)
- Enables dev repo testing with `FORGE_HOME=. python -m cli start`

## Test plan
- [x] test_memory_dir_respects_forge_home_env -- FORGE_HOME=custom path works
- [x] test_memory_dir_defaults_to_dot_forge -- fallback to ~/.forge/memory
- [x] All 21 memory tests pass
- [x] All 179 CLI tests pass