### PR TITLE
fix: add SILENT_REJECT sentinel, remove redundant allowlist check in server

### DIFF
--- a/gateway/security.py
+++ b/gateway/security.py
@@ -27,6 +27,16 @@ _DEFAULT_RATE_LIMIT = 10
 _DEFAULT_RATE_WINDOW = 3600  # seconds
 
 
+class _SilentReject:
+    """Sentinel returned by SecurityGuard.check() when a sender is not in the allowlist."""
+
+    def __repr__(self) -> str:
+        return "SILENT_REJECT"
+
+
+SILENT_REJECT = _SilentReject()
+
+
 @dataclass
 class SecurityConfig:
     """Security configuration for the gateway."""
@@ -49,8 +59,8 @@ class SecurityGuard:
             path.parent.mkdir(parents=True, exist_ok=True)
             self._audit_log = path
 
-    def check(self, message: InboundMessage) -> str | None:
-        """Validate a message. Returns an error string if rejected, None if OK."""
+    def check(self, message: InboundMessage) -> str | _SilentReject | None:
+        """Validate a message. Returns an error string if rejected, SILENT_REJECT if silently rejected, None if OK."""
         self._audit(message)
 
         # 1. Sender allowlist
@@ -61,7 +71,7 @@ class SecurityGuard:
                     message.sender_id,
                     message.sender_name,
                 )
-                return None  # Silent reject -- don't reveal bot exists to strangers
+                return SILENT_REJECT  # Silent reject -- don't reveal bot exists to strangers
 
         # 2. Rate limiting
         if self._is_rate_limited(message.sender_id):

--- a/gateway/server.py
+++ b/gateway/server.py
@@ -18,7 +18,7 @@ from gateway.api_client import VadgrAPIClient
 from gateway.config import GatewayConfig, load_config
 from gateway.models import InboundMessage, OutboundMessage
 from gateway.router import MessageRouter
-from gateway.security import SecurityGuard
+from gateway.security import SILENT_REJECT, SecurityGuard
 
 logger = logging.getLogger(__name__)
 
@@ -93,10 +93,7 @@ async def _process_message(
 
     # Security check
     rejection = security.check(message)
-    if rejection is None and message.sender_id not in (
-        app.state.config.security.allowed_senders or [message.sender_id]
-    ):
-        # Silent reject for unknown senders (don't reveal bot exists)
+    if rejection is SILENT_REJECT:
         return
     if rejection:
         await adapter.send_message(OutboundMessage(

--- a/gateway/tests/test_security.py
+++ b/gateway/tests/test_security.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 from gateway.models import InboundMessage
-from gateway.security import SecurityConfig, SecurityGuard
+from gateway.security import SILENT_REJECT, SecurityConfig, SecurityGuard
 
 
 def _msg(sender_id="5731200000", text="hello"):
@@ -25,8 +25,8 @@ class TestAllowlist:
 
     def test_unknown_sender_silently_rejected(self):
         guard = SecurityGuard(SecurityConfig(allowed_senders=["5731200000"]))
-        # Returns None (silent reject, not an error message)
-        assert guard.check(_msg(sender_id="9999999999")) is None
+        # Returns SILENT_REJECT sentinel (silent reject, not an error message and not None)
+        assert guard.check(_msg(sender_id="9999999999")) is SILENT_REJECT
 
     def test_empty_allowlist_allows_everyone(self):
         guard = SecurityGuard(SecurityConfig(allowed_senders=[]))
@@ -96,3 +96,60 @@ class TestAuditLog:
         guard = SecurityGuard(SecurityConfig())
         # Should not raise
         guard.check(_msg())
+
+
+class TestSilentRejectSentinel:
+    """
+    Issue #117: security.check() currently returns None for both allowed and
+    silently-rejected senders, forcing server.py to re-implement the allowlist
+    check (lines 96-99). The fix adds a SILENT_REJECT sentinel so the server
+    can distinguish the two outcomes without duplicating logic.
+
+    These tests define the expected behavior after the fix and must fail before
+    any implementation changes are made.
+    """
+
+    def test_unknown_sender_returns_non_none_sentinel(self):
+        """check() must return a distinguishable sentinel for unknown senders, not None."""
+        guard = SecurityGuard(SecurityConfig(allowed_senders=["5731200000"]))
+        result = guard.check(_msg(sender_id="9999999999"))
+        assert result is not None, (
+            "check() returned None for an unknown sender. "
+            "Expected a SILENT_REJECT sentinel so server.py does not need to "
+            "re-implement the allowlist check."
+        )
+
+    def test_allowed_sender_still_returns_none(self):
+        """Allowed senders must continue to return None (no rejection of any kind)."""
+        guard = SecurityGuard(SecurityConfig(allowed_senders=["5731200000"]))
+        result = guard.check(_msg(sender_id="5731200000"))
+        assert result is None
+
+    def test_silent_reject_sentinel_is_defined(self):
+        """SILENT_REJECT must be a module-level constant in gateway.security."""
+        import gateway.security as sec
+        assert hasattr(sec, "SILENT_REJECT"), (
+            "SILENT_REJECT sentinel not found in gateway.security. "
+            "It must be added as a module-level constant."
+        )
+
+    def test_silent_reject_is_not_none(self):
+        """SILENT_REJECT sentinel must not be None -- that is the value for 'allowed'."""
+        import gateway.security as sec
+        assert hasattr(sec, "SILENT_REJECT"), "SILENT_REJECT not defined in gateway.security"
+        assert sec.SILENT_REJECT is not None, "SILENT_REJECT must differ from None"
+
+    def test_unknown_sender_returns_silent_reject_not_error_string(self):
+        """Silent reject is not an error message -- it must not be a non-empty string."""
+        import gateway.security as sec
+        assert hasattr(sec, "SILENT_REJECT"), "SILENT_REJECT not defined in gateway.security"
+        guard = SecurityGuard(SecurityConfig(allowed_senders=["5731200000"]))
+        result = guard.check(_msg(sender_id="9999999999"))
+        assert result is sec.SILENT_REJECT, (
+            f"Expected SILENT_REJECT sentinel, got {result!r}"
+        )
+
+    def test_empty_allowlist_still_returns_none_for_everyone(self):
+        """With no allowlist configured, everyone is allowed -- check() returns None."""
+        guard = SecurityGuard(SecurityConfig(allowed_senders=[]))
+        assert guard.check(_msg(sender_id="anyone")) is None

--- a/gateway/tests/test_server.py
+++ b/gateway/tests/test_server.py
@@ -1,0 +1,96 @@
+"""Tests for the gateway webhook server pipeline (_process_message)."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.models import CommandResult, InboundMessage
+from gateway.server import _process_message
+
+
+def _msg(sender_id="5731200000", text="hello"):
+    return InboundMessage(
+        channel="whatsapp",
+        chat_id=f"{sender_id}@s.whatsapp.net",
+        sender_id=sender_id,
+        sender_name="Test",
+        text=text,
+    )
+
+
+def _make_app(security_check_return=None, allowed_senders=None, router_response="Done"):
+    """Build a minimal mock FastAPI app with wired state."""
+    app = MagicMock()
+    app.state.config.security.allowed_senders = allowed_senders or []
+
+    security = MagicMock()
+    security.check.return_value = security_check_return
+    app.state.security = security
+
+    router = AsyncMock()
+    router.handle.return_value = CommandResult(response=router_response)
+    app.state.router = router
+
+    return app
+
+
+class TestProcessMessageSilentReject:
+    """
+    Issue #117: server.py re-checks the allowlist after security.check() has
+    already handled it (lines 96-99). After the fix, _process_message must rely
+    solely on the SILENT_REJECT sentinel returned by security.check() instead
+    of duplicating the allowlist logic.
+    """
+
+    @pytest.mark.asyncio
+    async def test_silent_reject_drops_message_silently(self):
+        """When security.check() returns SILENT_REJECT, no response must be sent."""
+        import gateway.security as sec
+        assert hasattr(sec, "SILENT_REJECT"), (
+            "SILENT_REJECT sentinel not found in gateway.security -- "
+            "add it before this server test can exercise the correct behavior."
+        )
+        adapter = AsyncMock()
+        app = _make_app(security_check_return=sec.SILENT_REJECT)
+
+        await _process_message(app, _msg(sender_id="9999999999"), adapter)
+
+        adapter.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_silent_reject_does_not_reach_router(self):
+        """When security returns SILENT_REJECT, the router must not be invoked."""
+        import gateway.security as sec
+        assert hasattr(sec, "SILENT_REJECT"), (
+            "SILENT_REJECT sentinel not found in gateway.security -- "
+            "add it before this server test can exercise the correct behavior."
+        )
+        adapter = AsyncMock()
+        app = _make_app(security_check_return=sec.SILENT_REJECT)
+
+        await _process_message(app, _msg(sender_id="9999999999"), adapter)
+
+        app.state.router.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowed_sender_reaches_router(self):
+        """When security returns None (allowed), the message must be routed normally."""
+        adapter = AsyncMock()
+        app = _make_app(security_check_return=None)
+
+        await _process_message(app, _msg(sender_id="5731200000"), adapter)
+
+        app.state.router.handle.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_error_string_sends_rejection_response(self):
+        """When security returns a non-sentinel string, that string is sent to the user."""
+        adapter = AsyncMock()
+        app = _make_app(security_check_return="Slow down! Too many commands.")
+
+        await _process_message(app, _msg(), adapter)
+
+        adapter.send_message.assert_called_once()
+        sent = adapter.send_message.call_args[0][0]
+        assert "Slow down" in sent.text


### PR DESCRIPTION
## Summary

`server.py` was re-checking the sender allowlist after `security.check()` had already handled it, creating a fragile double-check where the two checks could diverge. This fix introduces a `SILENT_REJECT` sentinel in `security.py` so allowlist rejection is distinguishable from a clean pass, then removes the redundant allowlist re-check in `server.py`.

## Changes

- `gateway/security.py` — added `_SilentReject` class and `SILENT_REJECT` singleton sentinel; allowlist rejection now returns `SILENT_REJECT` instead of `None`; updated return type annotation and docstring
- `gateway/server.py` — imported `SILENT_REJECT`; replaced the 4-line redundant allowlist re-check with a single `if rejection is SILENT_REJECT: return`
- `gateway/tests/test_security.py` — updated `test_unknown_sender_silently_rejected` to assert `is SILENT_REJECT`; added `TestSilentRejectSentinel` with 6 new tests covering the sentinel contract
- `gateway/tests/test_server.py` — new file; added `TestProcessMessageSilentReject` with 4 tests covering the server's behavior on `SILENT_REJECT`, error strings, and allowed senders

## Test results

```
PYTHONPATH=. api/.venv/bin/python -m pytest gateway/tests/ -v

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 52 items

gateway/tests/test_security.py::TestSilentRejectSentinel::test_unknown_sender_returns_non_none_sentinel PASSED
gateway/tests/test_security.py::TestSilentRejectSentinel::test_allowed_sender_still_returns_none PASSED
gateway/tests/test_security.py::TestSilentRejectSentinel::test_silent_reject_sentinel_is_defined PASSED
gateway/tests/test_security.py::TestSilentRejectSentinel::test_silent_reject_is_not_none PASSED
gateway/tests/test_security.py::TestSilentRejectSentinel::test_unknown_sender_returns_silent_reject_not_error_string PASSED
gateway/tests/test_security.py::TestSilentRejectSentinel::test_empty_allowlist_still_returns_none_for_everyone PASSED
gateway/tests/test_server.py::TestProcessMessageSilentReject::test_silent_reject_drops_message_silently PASSED
gateway/tests/test_server.py::TestProcessMessageSilentReject::test_silent_reject_does_not_reach_router PASSED
gateway/tests/test_server.py::TestProcessMessageSilentReject::test_allowed_sender_reaches_router PASSED
gateway/tests/test_server.py::TestProcessMessageSilentReject::test_error_string_sends_rejection_response PASSED
[... 42 more tests ...]

============================== 52 passed in 0.23s ==============================
```

## Related

Closes #117