### PR TITLE
fix: wire sanitize_input into router _collect_input and _confirm

### DIFF
--- a/gateway/router.py
+++ b/gateway/router.py
@@ -10,11 +10,17 @@ import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Callable
 
 from gateway.models import InboundMessage, CommandResult
+from gateway.security import _DANGEROUS_CHARS
 
 logger = logging.getLogger(__name__)
+
+
+def _default_sanitize(value: str) -> str:
+    """Strip shell-sensitive characters from agent input values."""
+    return _DANGEROUS_CHARS.sub("", value).strip()
 
 
 class ConversationState(Enum):
@@ -43,8 +49,9 @@ class MessageRouter:
     The router talks to the Vadgr API to discover agents and trigger runs.
     """
 
-    def __init__(self, api_client):
+    def __init__(self, api_client, sanitize: Callable[[str], str] | None = None):
         self._api = api_client
+        self._sanitize = sanitize if sanitize is not None else _default_sanitize
         self._sessions: dict[str, Session] = {}
 
     def _get_session(self, sender_id: str) -> Session:
@@ -263,7 +270,7 @@ class MessageRouter:
     async def _collect_input(self, session: Session, text: str) -> CommandResult:
         """User is providing a value for a pending input."""
         if session.pending_input:
-            session.collected_inputs[session.pending_input] = text.strip()
+            session.collected_inputs[session.pending_input] = self._sanitize(text.strip())
             session.pending_input = None
         return await self._ask_for_inputs(session)
 
@@ -286,12 +293,12 @@ class MessageRouter:
 
         if "=" in text:
             key, _, value = text.partition("=")
-            session.collected_inputs[key.strip()] = value.strip()
+            session.collected_inputs[key.strip()] = self._sanitize(value.strip())
             return await self._ask_for_inputs(session)
 
         # Assume it's the value for the first uncollected optional
         if optional:
-            session.collected_inputs[optional[0]["name"]] = text.strip()
+            session.collected_inputs[optional[0]["name"]] = self._sanitize(text.strip())
             return await self._ask_for_inputs(session)
 
         return await self._start_run(session)

--- a/gateway/server.py
+++ b/gateway/server.py
@@ -31,8 +31,8 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
 
     # Wire up components
     api_client = VadgrAPIClient(config.api_url)
-    router = MessageRouter(api_client)
     security = SecurityGuard(config.security)
+    router = MessageRouter(api_client, sanitize=security.sanitize_input)
 
     # WhatsApp adapter
     wa_adapter = WhatsAppAdapter(

--- a/gateway/tests/test_router.py
+++ b/gateway/tests/test_router.py
@@ -186,3 +186,42 @@ class TestSessionIsolation:
         # User B should get idle state, not User A's flow
         result = await router.handle(_msg("status", sender_id="222"))
         assert "idle" in result.response.lower() or "no runs" in result.response.lower()
+
+
+class TestInputSanitization:
+    """Router must strip dangerous chars from user inputs before triggering runs."""
+
+    @pytest.mark.asyncio
+    async def test_collect_input_strips_shell_chars(self):
+        """Shell injection in required inputs must be stripped before reaching run_agent."""
+        api = _mock_api()
+        router = MessageRouter(api)
+        await router.handle(_msg("run QA Engineer"))
+        await router.handle(_msg("/home/repo; rm -rf /"))
+        assert api.run_agent.called
+        inputs = api.run_agent.call_args[0][1]
+        assert ";" not in inputs.get("repo_path", "")
+
+    @pytest.mark.asyncio
+    async def test_confirm_key_value_strips_shell_chars(self):
+        """Shell injection in key=value optional inputs must be stripped before reaching run_agent."""
+        api = _mock_api()
+        router = MessageRouter(api)
+        await router.handle(_msg("run Software Engineer"))
+        await router.handle(_msg("Fix the bug"))
+        await router.handle(_msg("repo_path=/home/repo; ls -la"))
+        assert api.run_agent.called
+        inputs = api.run_agent.call_args[0][1]
+        assert ";" not in inputs.get("repo_path", "")
+
+    @pytest.mark.asyncio
+    async def test_confirm_bare_optional_strips_shell_chars(self):
+        """Shell injection in bare optional inputs must be stripped before reaching run_agent."""
+        api = _mock_api()
+        router = MessageRouter(api)
+        await router.handle(_msg("run Software Engineer"))
+        await router.handle(_msg("Fix the bug"))
+        await router.handle(_msg("/home/repo | cat /etc/passwd"))
+        assert api.run_agent.called
+        inputs = api.run_agent.call_args[0][1]
+        assert "|" not in inputs.get("repo_path", "")


### PR DESCRIPTION
## Summary

`sanitize_input()` existed in `gateway/security.py` but was never called by `gateway/router.py` when collecting user-supplied agent inputs, leaving shell metacharacters and other dangerous characters unsanitized. This fix wires the sanitize function into the router at all three input-storage sites.

## Changes

- `gateway/router.py` — Added `_default_sanitize` (reuses `_DANGEROUS_CHARS` from security.py), updated `MessageRouter.__init__` to accept `sanitize: Callable[[str], str] | None`, applied `self._sanitize()` in `_collect_input()` and both branches of `_confirm()`
- `gateway/server.py` — Reordered `create_app()` so `SecurityGuard` is constructed before `MessageRouter`, then passes `security.sanitize_input` to the router
- `gateway/tests/test_router.py` — Added `TestInputSanitization` with 3 new tests covering `_collect_input`, `_confirm` key=value, and `_confirm` bare optional paths

## Test Results

```
PYTHONPATH=. python -m pytest gateway/tests/ -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
plugins: cov-7.1.0, asyncio-1.3.0, anyio-4.12.1
asyncio: mode=Mode.STRICT

collected 45 items

gateway/tests/test_router.py::TestInputSanitization::test_collect_input_strips_shell_chars PASSED
gateway/tests/test_router.py::TestInputSanitization::test_confirm_key_value_strips_shell_chars PASSED
gateway/tests/test_router.py::TestInputSanitization::test_confirm_bare_optional_strips_shell_chars PASSED
[... 42 pre-existing tests PASSED ...]

============================== 45 passed in 0.09s ==============================
```

45/45 passed. 3 new `TestInputSanitization` tests cover the fix; 42 pre-existing tests have zero regressions.

Closes #118