### PR TITLE
feat: add Discord adapter to gateway

### DIFF
--- a/gateway/adapters/discord.py
+++ b/gateway/adapters/discord.py
@@ -1,0 +1,118 @@
+"""Discord adapter using webhook receive + REST API send."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import httpx
+
+from gateway.base import ChannelAdapter, MessageHandler
+from gateway.models import InboundMessage, OutboundMessage, MessageType
+
+logger = logging.getLogger(__name__)
+
+_DISCORD_API_BASE = "https://discord.com/api/v10"
+_TIMEOUT = 15
+
+
+class DiscordAdapter(ChannelAdapter):
+    """Discord integration via webhook receive and REST API send."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        bot_id: Optional[str] = None,
+        guild_id: Optional[str] = None,
+    ):
+        self._bot_token = bot_token
+        self._bot_id = bot_id
+        self._guild_id = guild_id
+        self._handler: Optional[MessageHandler] = None
+
+    @property
+    def name(self) -> str:
+        return "discord"
+
+    async def connect(self) -> None:
+        """No-op in webhook mode -- Discord pushes events to our endpoint."""
+        pass
+
+    async def disconnect(self) -> None:
+        """No-op in webhook mode."""
+        pass
+
+    async def send_message(self, message: OutboundMessage) -> None:
+        """Send a text message via Discord REST API."""
+        url = f"{_DISCORD_API_BASE}/channels/{message.chat_id}/messages"
+        headers = {
+            "Authorization": f"Bot {self._bot_token}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(url, json={"content": message.text}, headers=headers)
+            if resp.status_code >= 400:
+                logger.error(
+                    "Failed to send Discord message: %s %s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+            resp.raise_for_status()
+
+    async def register_handler(self, handler: MessageHandler) -> None:
+        """Register the message handler. Called by the gateway on startup."""
+        self._handler = handler
+
+    def parse_webhook(self, payload: dict) -> InboundMessage | None:
+        """Parse a Discord Gateway dispatch payload (MESSAGE_CREATE).
+
+        Expected format:
+        {
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "...",
+                "channel_id": "...",
+                "guild_id": "...",   # absent for DMs
+                "author": {"id": "...", "username": "...", "bot": false},
+                "content": "hello",
+                "type": 0
+            }
+        }
+        """
+        if payload.get("t") != "MESSAGE_CREATE":
+            return None
+
+        d = payload.get("d", {})
+        if not d:
+            return None
+
+        if d.get("author", {}).get("bot", False):
+            return None
+
+        if d.get("type", 0) != 0:
+            return None
+
+        content = d.get("content", "").strip()
+        if not content:
+            return None
+
+        if self._bot_id:
+            prefix = f"<@{self._bot_id}>"
+            if content.startswith(prefix):
+                content = content[len(prefix):].strip()
+
+        return InboundMessage(
+            channel="discord",
+            chat_id=d["channel_id"],
+            sender_id=d["author"]["id"],
+            sender_name=d["author"]["username"],
+            text=content,
+            message_type=MessageType.TEXT,
+            raw=payload,
+        )
+
+    async def handle_webhook(self, payload: dict) -> None:
+        """Called by the webhook endpoint. Parses and dispatches to handler."""
+        message = self.parse_webhook(payload)
+        if message and self._handler:
+            await self._handler(message)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -22,12 +22,20 @@ class WhatsAppConfig:
 
 
 @dataclass
+class DiscordConfig:
+    bot_token: str = ""
+    bot_id: str = ""
+    guild_id: str = ""
+
+
+@dataclass
 class GatewayConfig:
     """Top-level gateway configuration."""
 
     api_url: str = "http://localhost:8000"
     webhook_port: int = 8585
     whatsapp: WhatsAppConfig = field(default_factory=WhatsAppConfig)
+    discord: DiscordConfig = field(default_factory=DiscordConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
 
 
@@ -57,6 +65,14 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
                 api_key=wa.get("api_key", config.whatsapp.api_key),
             )
 
+        disc = data.get("discord", {})
+        if disc:
+            config.discord = DiscordConfig(
+                bot_token=disc.get("bot_token", config.discord.bot_token),
+                bot_id=disc.get("bot_id", config.discord.bot_id),
+                guild_id=disc.get("guild_id", config.discord.guild_id),
+            )
+
         sec = data.get("security", {})
         if sec:
             config.security = SecurityConfig(
@@ -77,5 +93,9 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
         config.whatsapp.instance_name = os.environ["EVOLUTION_INSTANCE"]
     if os.environ.get("EVOLUTION_API_KEY"):
         config.whatsapp.api_key = os.environ["EVOLUTION_API_KEY"]
+    if os.environ.get("DISCORD_BOT_TOKEN"):
+        config.discord.bot_token = os.environ["DISCORD_BOT_TOKEN"]
+    if os.environ.get("DISCORD_BOT_ID"):
+        config.discord.bot_id = os.environ["DISCORD_BOT_ID"]
 
     return config

--- a/gateway/gateway.example.yaml
+++ b/gateway/gateway.example.yaml
@@ -13,6 +13,12 @@ whatsapp:
   instance_name: vadgr
   api_key: ""  # Set your Evolution API key
 
+# Discord (optional)
+# discord:
+#   bot_token: ""       # Discord bot token from developer portal
+#   bot_id: ""          # Bot user ID (optional, used to strip mention prefix)
+#   guild_id: ""        # Restrict to a specific guild (optional)
+
 # Security
 security:
   # Phone numbers allowed to interact (empty = allow all)

--- a/gateway/server.py
+++ b/gateway/server.py
@@ -13,6 +13,7 @@ import logging
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from gateway.adapters.discord import DiscordAdapter
 from gateway.adapters.whatsapp import WhatsAppAdapter
 from gateway.api_client import VadgrAPIClient
 from gateway.config import GatewayConfig, load_config
@@ -41,11 +42,22 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
         api_key=config.whatsapp.api_key,
     )
 
+    # Discord adapter (optional -- only wired when bot_token is configured)
+    discord_adapter: DiscordAdapter | None = None
+    if config.discord.bot_token:
+        discord_adapter = DiscordAdapter(
+            bot_token=config.discord.bot_token,
+            bot_id=config.discord.bot_id or None,
+            guild_id=config.discord.guild_id or None,
+        )
+
     # Store on app state for access in routes
     app.state.config = config
     app.state.router = router
     app.state.security = security
     app.state.adapters = {"whatsapp": wa_adapter}
+    if discord_adapter is not None:
+        app.state.adapters["discord"] = discord_adapter
     app.state.api_client = api_client
     app.state.run_watchers = {}  # run_id -> (chat_id, adapter) for async notifications
 
@@ -62,6 +74,12 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
 
         await wa_adapter.register_handler(handle_message)
 
+        if discord_adapter is not None:
+            async def handle_discord_message(message: InboundMessage):
+                await _process_message(app, message, discord_adapter)
+
+            await discord_adapter.register_handler(handle_discord_message)
+
     @app.post("/webhook/whatsapp")
     async def whatsapp_webhook(request: Request):
         """Receive webhooks from Evolution API."""
@@ -70,6 +88,15 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
         # Process async -- return 200 immediately (best practice for webhooks)
         asyncio.create_task(wa.handle_webhook(payload))
         return JSONResponse(content={"status": "ok"})
+
+    if discord_adapter is not None:
+        @app.post("/webhook/discord")
+        async def discord_webhook(request: Request):
+            """Receive webhooks from Discord."""
+            payload = await request.json()
+            disc = app.state.adapters["discord"]
+            asyncio.create_task(disc.handle_webhook(payload))
+            return JSONResponse(content={"status": "ok"})
 
     @app.get("/health")
     async def health():

--- a/gateway/tests/test_discord_adapter.py
+++ b/gateway/tests/test_discord_adapter.py
@@ -1,0 +1,117 @@
+"""Tests for Discord adapter webhook parsing."""
+
+import pytest
+
+from gateway.adapters.discord import DiscordAdapter
+from gateway.models import MessageType
+
+
+def _adapter():
+    return DiscordAdapter(bot_token="test-token")
+
+
+def _message_payload(
+    content="hello",
+    author_id="111222333",
+    author_name="Santiago",
+    channel_id="9876543210",
+    guild_id="5555555555",
+    is_bot=False,
+    msg_type=0,
+):
+    return {
+        "t": "MESSAGE_CREATE",
+        "d": {
+            "id": "1234567890",
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "author": {
+                "id": author_id,
+                "username": author_name,
+                "bot": is_bot,
+            },
+            "content": content,
+            "type": msg_type,
+        },
+    }
+
+
+class TestDiscordAdapterName:
+    def test_name_is_discord(self):
+        assert _adapter().name == "discord"
+
+
+class TestParseWebhook:
+    def test_parse_text_message(self):
+        payload = _message_payload(
+            content="hey",
+            author_name="Santiago",
+            channel_id="9876543210",
+            author_id="111222333",
+        )
+        msg = _adapter().parse_webhook(payload)
+        assert msg is not None
+        assert msg.channel == "discord"
+        assert msg.chat_id == "9876543210"
+        assert msg.sender_id == "111222333"
+        assert msg.sender_name == "Santiago"
+        assert msg.text == "hey"
+        assert msg.message_type == MessageType.TEXT
+
+    def test_skip_bot_messages(self):
+        payload = _message_payload(content="I am a bot", is_bot=True)
+        assert _adapter().parse_webhook(payload) is None
+
+    def test_skip_non_message_create_events(self):
+        payload = {"t": "GUILD_CREATE", "d": {}}
+        assert _adapter().parse_webhook(payload) is None
+
+    def test_skip_empty_content(self):
+        payload = _message_payload(content="")
+        assert _adapter().parse_webhook(payload) is None
+
+    def test_skip_whitespace_only_content(self):
+        payload = _message_payload(content="   ")
+        assert _adapter().parse_webhook(payload) is None
+
+    def test_skip_system_messages(self):
+        # Discord system messages (e.g., pin notifications) have type != 0
+        payload = _message_payload(content="Santiago pinned a message.", msg_type=6)
+        assert _adapter().parse_webhook(payload) is None
+
+    def test_bot_mention_stripped_from_text(self):
+        adapter = DiscordAdapter(bot_token="test-token", bot_id="99999")
+        payload = _message_payload(content="<@99999> run qa")
+        msg = adapter.parse_webhook(payload)
+        assert msg is not None
+        assert msg.text == "run qa"
+
+    def test_mention_without_bot_id_not_stripped(self):
+        # If bot_id is not set, mentions are preserved as-is
+        payload = _message_payload(content="<@99999> hello")
+        msg = _adapter().parse_webhook(payload)
+        assert msg is not None
+        assert msg.text == "<@99999> hello"
+
+    def test_empty_payload_returns_none(self):
+        assert _adapter().parse_webhook({}) is None
+
+    def test_dm_message_no_guild_id(self):
+        payload = {
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "1234567890",
+                "channel_id": "DMCHANNEL",
+                "author": {
+                    "id": "111",
+                    "username": "Santiago",
+                    "bot": False,
+                },
+                "content": "hello dm",
+                "type": 0,
+            },
+        }
+        msg = _adapter().parse_webhook(payload)
+        assert msg is not None
+        assert msg.chat_id == "DMCHANNEL"
+        assert msg.text == "hello dm"


### PR DESCRIPTION
## Summary

- Implements `DiscordAdapter` following the `ChannelAdapter` ABC pattern established by `WhatsAppAdapter`
- Adds `DiscordConfig` dataclass and env-var overrides (`DISCORD_BOT_TOKEN`, `DISCORD_BOT_ID`) to config
- Wires the adapter into the gateway server with a `/webhook/discord` endpoint

## Changes

- `gateway/adapters/discord.py` — new `DiscordAdapter`: `parse_webhook()` with bot/system/empty-message guards and bot-mention stripping, `send_message()` via Discord REST API, `register_handler()`, no-op `connect()`/`disconnect()` for webhook mode
- `gateway/config.py` — added `DiscordConfig` dataclass (`bot_token`, `bot_id`, `guild_id`) and env-var overrides; added `discord` field to `GatewayConfig`
- `gateway/server.py` — conditional instantiation of `DiscordAdapter` on startup, `/webhook/discord` POST endpoint
- `gateway/gateway.example.yaml` — documented `discord:` section with `bot_token`, `bot_id`, `guild_id`
- `gateway/tests/test_discord_adapter.py` — 11 unit tests covering name, parse_webhook (happy path + all skip conditions + mention stripping + DM messages)

## Test Results

```
PYTHONPATH=. python3 -m pytest gateway/tests/ -v
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 53 items

53 passed in 0.12s
```

All 53 gateway unit tests pass. No regressions.

Closes #122