### PR TITLE
rebrand: open-source AI agents that work on your computer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,10 @@
 Vadgr
 Copyright 2026 Victor Santiago Montaño Diaz
 
-Vadgr is an agent-agnostic meta-framework for creating agentic workflows.
-It includes a desktop automation engine for autonomous computer use.
+Vadgr is a platform for AI agents that work on your computer. Describe
+your task, Vadgr builds the agent, and the agent runs autonomously --
+writing code, controlling apps, and delivering results. Works with
+Claude, Codex, Gemini, or any CLI agent tool.
 
 https://github.com/santiagomd11/Agent-Forge
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@
 
 
 <p align="center">
-  <i><b>Independent agents that can operate on any task, no matter how complex.</b></i>
+  <i><b>Open-source AI agents that work on your computer.</b></i>
 </p>
 
-Vadgr gives AI agents the ability to think through problems (forge) and interact with the real world (computer use). Each module works on its own or together with the others. Cross-platform: runs on Windows, Linux, and macOS (Work progres).
+Describe your work. Vadgr builds an agent for it. The agent runs on your machine -- writing code, controlling apps, clicking buttons, and delivering results -- while you do something else. Works with Claude Code, Codex, Gemini, or any CLI agent tool. Cross-platform: Linux, Windows (WSL2), and macOS (in progress).
 
-
-##  Paltform
+## Platform
 
 <div align="left">
 
@@ -143,31 +142,31 @@ graph LR
 
 ### [cli/](cli/) - Command-Line Interface
 
-Unified CLI built with Click. Manages agents, runs, registry, and system info. Talks to the API over HTTP for agent/run operations; calls the registry module directly for package management. Each module has its own venv.
+Unified CLI built with Click. Manages agents, runs, registry, and services. Talks to the API over HTTP for agent/run operations; calls the registry module directly for package management.
 
 ### [api/](api/) - REST API + Execution Engine
 
-FastAPI backend for agent CRUD, forge generation, and execution. Calls any CLI agent tool as a subprocess via config-driven providers. See [api/README.md](api/README.md) for setup details.
+FastAPI backend for agent CRUD, generation, and execution. Spawns any CLI agent tool (Claude Code, Codex, Gemini) as a subprocess via config-driven providers. Supports multi-step orchestration with approval gates, resume, and retry. See [api/README.md](api/README.md).
 
 ### [frontend/](frontend/) - Web Dashboard
 
-React 19 + TypeScript + Vite dashboard for managing agents and viewing runs. See [frontend/README.md](frontend/README.md) for setup details.
+React 19 + TypeScript + Vite dashboard for creating agents, monitoring runs in real-time, and configuring integrations (Discord gateway, computer use). See [frontend/README.md](frontend/README.md).
 
-### [forge/](forge/) - Workflow Generation Engine
+### [forge/](forge/) - Agent Generation Engine
 
-Designs and generates complete agentic workflow projects through a 7-step conversational process. Agent-agnostic: works with any AI coding agent that can read files and follow instructions.
+Describe what you want automated. Forge generates a complete agent project through a 7-step process: requirements, architecture, scaffold, orchestrator, prompts, scripts, and review. Agent-agnostic: works with any AI coding tool.
 
-### [computer_use/](computer_use/) - Desktop Automation Engine
+### [computer_use/](computer_use/) - Desktop Automation
 
-Captures screenshots, locates UI elements, and executes mouse/keyboard actions across **Windows, macOS, and Linux** (including WSL2). Works as a Python library, MCP server, or CLI tool. Runs natively on the host.
+Gives agents eyes and hands. Captures screenshots, locates UI elements via accessibility APIs, and executes mouse/keyboard actions. Includes a spatial cache (muscle memory) that makes repeated interactions faster over time. Works as an MCP server across Windows, Linux, WSL2, and macOS.
+
+### [gateway/](gateway/) - Messaging Integration
+
+Chat with agents from Discord. List agents, run them, monitor progress, and receive results -- all from Discord DMs or @mentions. Session-aware conversations with security (input sanitization, sender allowlist, audit logging).
 
 ### [registry/](registry/) - Agent Package Manager
 
-Package, publish, and install agent workflows. Supports three backends: GitHub (releases + raw content), any HTTP server, or a local folder. Agents are distributed as `.agnt` archives (zip with manifest). Includes SHA256 integrity verification, SSRF protection, and zip slip prevention.
-
-### paper/ - Research Paper
-
-Academic paper documenting the framework.
+Package, publish, and install agents as `.agnt` archives. Supports GitHub, HTTP, and local registries. Includes SHA256 integrity verification, SSRF protection, and zip slip prevention.
 
 ## Structure
 
@@ -176,36 +175,38 @@ Vadgr/
 ├── cli/                   # Unified command-line interface
 │   ├── main.py            # Root Click group
 │   ├── http.py            # HTTP client for API
-│   ├── commands/          # agents, runs, registry, info
+│   ├── commands/          # agents, runs, registry, gateway, info
 │   └── tests/             # Unit + integration tests
 ├── api/                   # REST API + execution engine
 │   ├── main.py            # FastAPI app
 │   ├── routes/            # HTTP endpoints
-│   ├── services/          # Business logic
-│   ├── engine/            # CLI provider executor
+│   ├── services/          # Business logic + gateway setup
+│   ├── engine/            # CLI provider executor + DAG orchestration
 │   └── persistence/       # SQLite database
 ├── frontend/              # React web dashboard
 │   ├── src/pages/         # Dashboard, Agents, Runs, Settings
 │   ├── src/components/    # UI components
-│   └── src/hooks/         # TanStack Query hooks
-├── forge/                 # Workflow generation engine (standalone)
+│   └── src/hooks/         # TanStack Query + messaging gateway hooks
+├── forge/                 # Agent generation engine (standalone)
 │   ├── agentic.md         # 7-step orchestrator
 │   ├── Prompts/           # Specialized agent prompts
-│   ├── patterns/          # 10 reusable workflow patterns
-│   └── examples/          # 3 example workflows
-├── computer_use/          # Desktop automation engine (standalone)
-│   ├── core/              # Engine facade, types, actions
+│   ├── patterns/          # Reusable workflow patterns
+│   └── examples/          # Example agents
+├── computer_use/          # Desktop automation (standalone)
+│   ├── core/              # Engine, spatial cache, actions
 │   ├── platform/          # OS backends (Linux, Windows, macOS, WSL2)
+│   ├── grounding/         # UI element location (accessibility + vision)
 │   └── mcp_server.py      # MCP server
+├── gateway/               # Messaging integration
+│   ├── src/               # Discord adapter, router, security, API client
+│   └── tests/             # 70 tests
 ├── registry/              # Agent package manager
-│   ├── cli.py             # Click CLI (pack, pull, push, search)
 │   ├── security.py        # Zip safety, SSRF, SHA256, TLS
 │   ├── server.py          # Self-hosted HTTP registry server
 │   └── adapters/          # GitHub, HTTP, local backends
-├── providers.yaml         # CLI provider configs (claude, codex, aider, etc.)
+├── providers.yaml         # CLI provider configs (Claude, Codex, Gemini)
 ├── data/                  # SQLite database (created at runtime)
-├── output/                # Generated agent workflows
-└── paper/                 # Research paper
+└── output/                # Generated agents land here
 ```
 
 ## Technologies

--- a/api/Agent_Forge_API.postman_collection.json
+++ b/api/Agent_Forge_API.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "name": "Agent Forge API",
-    "description": "E2E test suite for the Agent Forge API.\n\nRun order matters -- requests use collection variables set by earlier requests.\n\nFlow: Providers -> Health -> Create Agent -> Poll Ready -> Get -> Cosmetic Update -> Substantive Update -> Poll Updated -> Busy Update (409) -> Run Agent -> List Runs -> List Agents -> Minimal Create -> Validation Tests -> Delete Tests -> Runs -> Computer Use.",
+    "name": "Vadgr API",
+    "description": "E2E test suite for the Vadgr API.\n\nRun order matters -- requests use collection variables set by earlier requests.\n\nFlow: Providers -> Health -> Create Agent -> Poll Ready -> Get -> Cosmetic Update -> Substantive Update -> Poll Updated -> Busy Update (409) -> Run Agent -> List Runs -> List Agents -> Minimal Create -> Validation Tests -> Delete Tests -> Runs -> Computer Use.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-forge-frontend",
+  "name": "vadgr-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/frontend/src/hooks/__tests__/useTheme.test.tsx
+++ b/frontend/src/hooks/__tests__/useTheme.test.tsx
@@ -41,11 +41,11 @@ describe('ThemeProvider', () => {
   it('persists theme to localStorage', () => {
     render(<ThemeProvider><TestConsumer /></ThemeProvider>);
     fireEvent.click(screen.getByText('toggle'));
-    expect(localStorage.getItem('agent-forge-theme')).toBe('light');
+    expect(localStorage.getItem('vadgr-theme')).toBe('light');
   });
 
   it('reads stored theme from localStorage', () => {
-    localStorage.setItem('agent-forge-theme', 'light');
+    localStorage.setItem('vadgr-theme', 'light');
     render(<ThemeProvider><TestConsumer /></ThemeProvider>);
     expect(screen.getByTestId('theme').textContent).toBe('light');
   });

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -9,7 +9,7 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue>({ theme: 'dark', toggle: () => {} });
 
-const STORAGE_KEY = 'agent-forge-theme';
+const STORAGE_KEY = 'vadgr-theme';
 
 function getInitialTheme(): Theme {
   try {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -11,7 +11,7 @@ import { PixelMoon, PixelSun, PixelGear, PixelClock } from '../components/ui/Pix
 import { getInflight, toggleComputerUse as toggleCu } from '../hooks/useComputerUse';
 import { getGatewayInflight, updateDiscordGateway, type GatewayStatus } from '../hooks/useMessagingGateway';
 
-const STORAGE_KEY = 'agent-forge-settings';
+const STORAGE_KEY = 'vadgr-settings';
 
 interface AppSettings {
   defaultProvider: string;


### PR DESCRIPTION
## Summary
- Updated product positioning from "meta-framework for agentic workflows" to "open-source AI agents that work on your computer"
- README: new tagline, intro paragraph, module descriptions (includes gateway), updated project structure
- NOTICE: updated product description to match new positioning
- Frontend: renamed localStorage keys from `agent-forge-*` to `vadgr-*`, renamed package to `vadgr-frontend`
- Postman collection: renamed to "Vadgr API"

## Test plan
- [x] Frontend theme tests pass (5/5) after localStorage key rename
- [ ] Verify frontend loads correctly with new localStorage keys
- [ ] Verify README renders properly on GitHub