### PR TITLE
fix: WSL clean install failures (venv + daemon mss)

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -249,6 +249,34 @@ def _find_windows_python() -> str | None:
     return None
 
 
+def _ensure_daemon_deps(win_python: str) -> None:
+    """Install daemon dependencies (mss) on the Windows-side Python if missing."""
+    try:
+        result = subprocess.run(
+            [
+                "powershell.exe", "-NoProfile", "-Command",
+                f'& "{win_python}" -c "import mss"',
+            ],
+            capture_output=True, timeout=15,
+        )
+        if result.returncode == 0:
+            return
+    except Exception:
+        pass
+
+    logger.info("Installing mss on Windows Python...")
+    try:
+        subprocess.run(
+            [
+                "powershell.exe", "-NoProfile", "-Command",
+                f'& "{win_python}" -m pip install --quiet mss',
+            ],
+            capture_output=True, timeout=60,
+        )
+    except Exception as e:
+        logger.warning("Failed to install mss on Windows Python: %s", e)
+
+
 def _deploy_and_launch_daemon(win_python: str) -> None:
     bridge_dir = str(PROJECT_ROOT / "computer_use" / "bridge")
     deploy_dir = _get_windows_userprofile()
@@ -261,6 +289,9 @@ def _deploy_and_launch_daemon(win_python: str) -> None:
         src = os.path.join(bridge_dir, fname)
         if os.path.exists(src):
             shutil.copy2(src, os.path.join(deploy_dir, fname))
+
+    # Install mss on Windows Python before launching
+    _ensure_daemon_deps(win_python)
 
     # Convert to Windows path
     try:

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -302,6 +302,48 @@ class TestComputerUseSetupService:
             assert cu_setup._python_command() == "python3"
 
 
+class TestEnsureDaemonDeps:
+    """Tests for _ensure_daemon_deps: install mss on Windows Python before daemon launch."""
+
+    def test_skips_install_when_mss_already_present(self):
+        """If mss is already importable on Windows Python, skip pip install."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
+            # Only one call: the import check. No pip install.
+            assert mock_run.call_count == 1
+            assert "import mss" in mock_run.call_args_list[0][0][0][-1]
+
+    def test_installs_mss_when_missing(self):
+        """If mss import fails, pip install mss on Windows Python."""
+        with patch("subprocess.run") as mock_run:
+            # First call (import check) fails, second call (pip install) succeeds
+            fail_result = type("R", (), {"returncode": 1})()
+            ok_result = type("R", (), {"returncode": 0})()
+            mock_run.side_effect = [fail_result, ok_result]
+            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
+            assert mock_run.call_count == 2
+            pip_cmd = mock_run.call_args_list[1][0][0][-1]
+            assert "pip install" in pip_cmd
+            assert "mss" in pip_cmd
+
+    def test_handles_import_check_exception(self):
+        """If the import check subprocess itself throws, still try pip install."""
+        with patch("subprocess.run") as mock_run:
+            ok_result = type("R", (), {"returncode": 0})()
+            mock_run.side_effect = [OSError("no powershell"), ok_result]
+            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
+            assert mock_run.call_count == 2
+
+    def test_handles_pip_install_exception(self):
+        """If pip install throws, log warning but don't crash."""
+        with patch("subprocess.run") as mock_run:
+            fail_result = type("R", (), {"returncode": 1})()
+            mock_run.side_effect = [fail_result, OSError("pip failed")]
+            # Should not raise
+            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
+
+
 class TestMcpServerName:
     """MCP server names must be prefixed with 'vadgr-' to avoid conflicts with CLI built-in names."""
 

--- a/setup.sh
+++ b/setup.sh
@@ -163,18 +163,32 @@ setup_repo() {
 }
 
 ensure_venv_module() {
-    if python3 -m venv --help >/dev/null 2>&1; then return; fi
+    # Check both venv and ensurepip. venv --help can succeed even when
+    # ensurepip is missing, which causes venv creation to fail later.
+    if python3 -c "import venv, ensurepip" 2>/dev/null; then return; fi
     info "Installing python3-venv package..."
     local py_minor
     py_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
     if command_exists apt-get; then
-        sudo apt-get install -y -qq "python3.${py_minor}-venv" || sudo apt-get install -y -qq python3-venv
+        sudo apt-get update -qq >/dev/null 2>&1 || true
+        sudo apt-get install -y -qq "python3.${py_minor}-venv" 2>/dev/null \
+            || sudo apt-get install -y -qq python3-venv 2>/dev/null \
+            || true
+        # If default repos didn't have it, try deadsnakes PPA
+        if ! python3 -c "import venv, ensurepip" 2>/dev/null; then
+            if command_exists add-apt-repository; then
+                info "Trying deadsnakes PPA..."
+                sudo add-apt-repository -y ppa:deadsnakes/ppa >/dev/null 2>&1
+                sudo apt-get update -qq >/dev/null 2>&1
+                sudo apt-get install -y -qq "python3.${py_minor}-venv" 2>/dev/null || true
+            fi
+        fi
     elif command_exists dnf; then
         sudo dnf install -y -q python3-libs
     elif command_exists pacman; then
         sudo pacman -S --noconfirm python
     fi
-    python3 -m venv --help >/dev/null 2>&1 || fail "python3 venv module not available. Install it manually."
+    python3 -c "import venv, ensurepip" 2>/dev/null || fail "Could not install python3-venv. Install it manually: sudo apt install python3.${py_minor}-venv"
 }
 
 setup_venv() {


### PR DESCRIPTION
## Summary
- **setup.sh (#160)**: `ensure_venv_module` checked `python3 -m venv --help` which succeeds even without `ensurepip`, so venv creation silently fails on clean WSL installs. Now checks `import venv, ensurepip`, runs `apt-get update` before installing, and shows actionable error message.
- **computer_use_setup.py (#161)**: The bridge daemon needs `mss` for screenshots but it was never installed on the Windows-side Python. Added `_ensure_daemon_deps` that checks for mss and pip-installs it before launching the daemon.

Closes #160, closes #161

## Test plan
- [ ] All 89 computer_use tests pass
- [ ] All 39 API computer_use setup tests pass
- [ ] Verify on a clean WSL install: `curl -fsSL ... | bash` completes without venv errors
- [ ] Verify `vadgr computer-use enable` installs mss on Windows Python and daemon starts
- [ ] Verify `screenshot()` works after fresh setup