### PR TITLE
fix: always redeploy daemon on enable to prevent stale mss-less process

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -249,32 +249,56 @@ def _find_windows_python() -> str | None:
     return None
 
 
-def _ensure_daemon_deps(win_python: str) -> None:
-    """Install daemon dependencies (mss) on the Windows-side Python if missing."""
+def _check_win_python_module(win_python: str, module: str) -> bool:
+    """Check if a module is importable on the Windows-side Python."""
     try:
         result = subprocess.run(
             [
                 "powershell.exe", "-NoProfile", "-Command",
-                f'& "{win_python}" -c "import mss"',
+                f'& "{win_python}" -c "import {module}"',
             ],
-            capture_output=True, timeout=15,
+            capture_output=True, text=True, timeout=15,
         )
-        if result.returncode == 0:
-            return
+        return result.returncode == 0
     except Exception:
-        pass
+        return False
 
-    logger.info("Installing mss on Windows Python...")
+
+def _ensure_daemon_deps(win_python: str) -> bool:
+    """Install daemon dependencies (mss) on the Windows-side Python.
+
+    Returns True if mss is available after this call, False otherwise.
+    """
+    if _check_win_python_module(win_python, "mss"):
+        return True
+
+    logger.info("Installing mss on Windows Python (%s)...", win_python)
     try:
-        subprocess.run(
+        result = subprocess.run(
             [
                 "powershell.exe", "-NoProfile", "-Command",
-                f'& "{win_python}" -m pip install --quiet mss',
+                f'& "{win_python}" -m pip install mss',
             ],
-            capture_output=True, timeout=60,
+            capture_output=True, text=True, timeout=60,
         )
+        if result.returncode != 0:
+            logger.warning(
+                "pip install mss failed (exit %d): %s",
+                result.returncode, result.stderr.strip(),
+            )
     except Exception as e:
         logger.warning("Failed to install mss on Windows Python: %s", e)
+
+    # Verify it actually worked
+    installed = _check_win_python_module(win_python, "mss")
+    if not installed:
+        logger.error(
+            "mss is not available on Windows Python (%s). "
+            "Screenshots will fail. Install manually: "
+            "open PowerShell and run: %s -m pip install mss",
+            win_python, win_python,
+        )
+    return installed
 
 
 def _deploy_and_launch_daemon(win_python: str) -> None:
@@ -290,8 +314,9 @@ def _deploy_and_launch_daemon(win_python: str) -> None:
         if os.path.exists(src):
             shutil.copy2(src, os.path.join(deploy_dir, fname))
 
-    # Install mss on Windows Python before launching
-    _ensure_daemon_deps(win_python)
+    if not _ensure_daemon_deps(win_python):
+        logger.warning("Skipping daemon launch -- mss not available")
+        return
 
     # Convert to Windows path
     try:
@@ -455,14 +480,12 @@ def enable_computer_use(cache_enabled: bool = True) -> dict:
         )
         _write_deps_marker()
 
-    # Manage daemon on WSL2
+    # Manage daemon on WSL2: always redeploy to ensure latest code + deps.
+    # A stale daemon (e.g. from before a reinstall) would still respond to
+    # ping but fail on screenshot because it lacks mss.
     if _is_wsl2():
-        state = _probe_daemon()
-        if state == "degraded":
-            _stop_daemon()
-            _start_daemon()
-        elif state == "stopped":
-            _start_daemon()
+        _stop_daemon()
+        _start_daemon()
 
     # Write MCP configs for all providers
     _write_all_provider_configs(cache_enabled=cache_enabled)

--- a/api/tests/test_daemon.py
+++ b/api/tests/test_daemon.py
@@ -101,21 +101,10 @@ class TestGetStatusIncludesDaemon:
 
 
 class TestEnableManagesDaemon:
-    def test_enable_starts_daemon_when_stopped(self):
+    def test_enable_always_redeploys_daemon(self):
+        """Enable must always stop+start to replace stale daemons that lack deps."""
         from api.services.computer_use_setup import enable_computer_use
-        with patch("api.services.computer_use_setup._probe_daemon", return_value="stopped"), \
-             patch("api.services.computer_use_setup._start_daemon", return_value=True) as m_start, \
-             patch("api.services.computer_use_setup._venv_healthy", return_value=True), \
-             patch("api.services.computer_use_setup._deps_need_install", return_value=False), \
-             patch("api.services.computer_use_setup._write_all_provider_configs"), \
-             patch("api.services.computer_use_setup._is_wsl2", return_value=True):
-            enable_computer_use()
-            m_start.assert_called_once()
-
-    def test_enable_restarts_degraded_daemon(self):
-        from api.services.computer_use_setup import enable_computer_use
-        with patch("api.services.computer_use_setup._probe_daemon", return_value="degraded"), \
-             patch("api.services.computer_use_setup._stop_daemon") as m_stop, \
+        with patch("api.services.computer_use_setup._stop_daemon") as m_stop, \
              patch("api.services.computer_use_setup._start_daemon", return_value=True) as m_start, \
              patch("api.services.computer_use_setup._venv_healthy", return_value=True), \
              patch("api.services.computer_use_setup._deps_need_install", return_value=False), \
@@ -124,17 +113,6 @@ class TestEnableManagesDaemon:
             enable_computer_use()
             m_stop.assert_called_once()
             m_start.assert_called_once()
-
-    def test_enable_skips_launch_when_running(self):
-        from api.services.computer_use_setup import enable_computer_use
-        with patch("api.services.computer_use_setup._probe_daemon", return_value="running"), \
-             patch("api.services.computer_use_setup._start_daemon") as m_start, \
-             patch("api.services.computer_use_setup._venv_healthy", return_value=True), \
-             patch("api.services.computer_use_setup._deps_need_install", return_value=False), \
-             patch("api.services.computer_use_setup._write_all_provider_configs"), \
-             patch("api.services.computer_use_setup._is_wsl2", return_value=True):
-            enable_computer_use()
-            m_start.assert_not_called()
 
 
 class TestDisableKillsDaemon:

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -305,43 +305,56 @@ class TestComputerUseSetupService:
 class TestEnsureDaemonDeps:
     """Tests for _ensure_daemon_deps: install mss on Windows Python before daemon launch."""
 
-    def test_skips_install_when_mss_already_present(self):
-        """If mss is already importable on Windows Python, skip pip install."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value.returncode = 0
-            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
-            # Only one call: the import check. No pip install.
-            assert mock_run.call_count == 1
-            assert "import mss" in mock_run.call_args_list[0][0][0][-1]
+    def test_returns_true_when_mss_already_present(self):
+        """If mss is already importable, return True without pip install."""
+        with patch.object(cu_setup, "_check_win_python_module", return_value=True):
+            assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is True
 
-    def test_installs_mss_when_missing(self):
-        """If mss import fails, pip install mss on Windows Python."""
-        with patch("subprocess.run") as mock_run:
-            # First call (import check) fails, second call (pip install) succeeds
-            fail_result = type("R", (), {"returncode": 1})()
-            ok_result = type("R", (), {"returncode": 0})()
-            mock_run.side_effect = [fail_result, ok_result]
-            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
-            assert mock_run.call_count == 2
-            pip_cmd = mock_run.call_args_list[1][0][0][-1]
-            assert "pip install" in pip_cmd
-            assert "mss" in pip_cmd
+    def test_installs_and_verifies_mss(self):
+        """If mss missing, pip install then verify. Returns True on success."""
+        with patch.object(cu_setup, "_check_win_python_module", side_effect=[False, True]), \
+             patch("subprocess.run") as mock_run:
+            ok_result = type("R", (), {"returncode": 0, "stderr": ""})()
+            mock_run.return_value = ok_result
+            assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is True
+            # pip install was called
+            pip_cmd = mock_run.call_args_list[0][0][0][-1]
+            assert "pip install mss" in pip_cmd
 
-    def test_handles_import_check_exception(self):
-        """If the import check subprocess itself throws, still try pip install."""
-        with patch("subprocess.run") as mock_run:
-            ok_result = type("R", (), {"returncode": 0})()
-            mock_run.side_effect = [OSError("no powershell"), ok_result]
-            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
-            assert mock_run.call_count == 2
+    def test_returns_false_when_install_fails(self):
+        """If pip install fails and mss still not importable, return False."""
+        with patch.object(cu_setup, "_check_win_python_module", return_value=False), \
+             patch("subprocess.run") as mock_run:
+            fail_result = type("R", (), {"returncode": 1, "stderr": "no pip"})()
+            mock_run.return_value = fail_result
+            assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is False
 
-    def test_handles_pip_install_exception(self):
-        """If pip install throws, log warning but don't crash."""
-        with patch("subprocess.run") as mock_run:
-            fail_result = type("R", (), {"returncode": 1})()
-            mock_run.side_effect = [fail_result, OSError("pip failed")]
-            # Should not raise
-            cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe")
+    def test_returns_false_on_pip_exception(self):
+        """If pip subprocess throws, return False."""
+        with patch.object(cu_setup, "_check_win_python_module", return_value=False), \
+             patch("subprocess.run", side_effect=OSError("no powershell")):
+            assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is False
+
+
+class TestEnableAlwaysRedeploysDaemon:
+    """Enable must always stop+start the daemon so stale processes get replaced."""
+
+    def test_enable_stops_running_daemon_before_restart(self, tmp_path):
+        """Even if daemon is 'running', enable should stop and redeploy it."""
+        _create_fake_pip(tmp_path / "cu_venv")
+        with patch.object(cu_setup, "CU_VENV_DIR", tmp_path / "cu_venv"), \
+             patch.object(cu_setup, "CU_REQUIREMENTS", tmp_path / "req.txt"), \
+             patch.object(cu_setup, "MCP_JSON_PATH", tmp_path / ".mcp.json"), \
+             patch.object(cu_setup, "GEMINI_SETTINGS_PATH", tmp_path / ".gemini" / "settings.json"), \
+             patch.object(cu_setup, "CODEX_GLOBAL_CONFIG_PATH", tmp_path / ".codex" / "config.toml"), \
+             patch.object(cu_setup, "_is_wsl2", return_value=True), \
+             patch.object(cu_setup, "_stop_daemon") as mock_stop, \
+             patch.object(cu_setup, "_start_daemon") as mock_start, \
+             patch.object(cu_setup, "_deps_need_install", return_value=False):
+            (tmp_path / "req.txt").touch()
+            cu_setup.enable_computer_use()
+            mock_stop.assert_called_once()
+            mock_start.assert_called_once()
 
 
 class TestMcpServerName:


### PR DESCRIPTION
## Summary

Fixes the actual root cause of #161 (the previous PR #162 added `_ensure_daemon_deps` but it never ran).

- **Root cause**: `enable_computer_use` skipped daemon redeployment when `_probe_daemon()` returned `"running"`. After a `rm -rf ~/.forge/Agent-Forge` reinstall, the old Windows daemon process (without mss) was still alive on port 19542. The new install's `enable` saw it as "running" and skipped `_deploy_and_launch_daemon` entirely, so `_ensure_daemon_deps` never ran.
- **Fix**: `enable_computer_use` now always stops and restarts the daemon on WSL2, ensuring latest code + deps on every enable.
- **Also**: `_ensure_daemon_deps` now logs the Windows Python path and pip stderr on failure instead of silently swallowing errors.

## Test plan
- [ ] 57 settings tests pass (including new `TestEnableAlwaysRedeploysDaemon`)
- [ ] 89 computer_use tests pass
- [ ] Fresh WSL install: `vadgr computer-use enable` installs mss and screenshot works
- [ ] Reinstall scenario: `rm -rf ~/.forge/Agent-Forge`, fresh install, `enable` replaces stale daemon