### PR TITLE
fix: install all daemon deps (mss + Pillow) not just mss

### DIFF
--- a/api/services/computer_use_setup.py
+++ b/api/services/computer_use_setup.py
@@ -264,41 +264,63 @@ def _check_win_python_module(win_python: str, module: str) -> bool:
         return False
 
 
-def _ensure_daemon_deps(win_python: str) -> bool:
-    """Install daemon dependencies (mss) on the Windows-side Python.
+# Packages the Windows daemon needs beyond stdlib.
+# daemon.py imports mss (screenshots) and PIL (JPEG conversion).
+_DAEMON_DEPS = ["mss", "Pillow"]
+_DAEMON_IMPORT_NAMES = {"Pillow": "PIL"}  # pip name -> import name
 
-    Returns True if mss is available after this call, False otherwise.
+
+def _ensure_daemon_deps(win_python: str) -> bool:
+    """Install daemon dependencies on the Windows-side Python.
+
+    Returns True if all deps are importable after this call.
     """
-    if _check_win_python_module(win_python, "mss"):
+    missing = []
+    for pkg in _DAEMON_DEPS:
+        mod = _DAEMON_IMPORT_NAMES.get(pkg, pkg)
+        if not _check_win_python_module(win_python, mod):
+            missing.append(pkg)
+
+    if not missing:
         return True
 
-    logger.info("Installing mss on Windows Python (%s)...", win_python)
+    logger.info(
+        "Installing daemon deps on Windows Python (%s): %s",
+        win_python, ", ".join(missing),
+    )
     try:
         result = subprocess.run(
             [
                 "powershell.exe", "-NoProfile", "-Command",
-                f'& "{win_python}" -m pip install mss',
+                f'& "{win_python}" -m pip install {" ".join(missing)}',
             ],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True, text=True, timeout=120,
         )
         if result.returncode != 0:
             logger.warning(
-                "pip install mss failed (exit %d): %s",
+                "pip install failed (exit %d): %s",
                 result.returncode, result.stderr.strip(),
             )
     except Exception as e:
-        logger.warning("Failed to install mss on Windows Python: %s", e)
+        logger.warning("Failed to install daemon deps: %s", e)
 
-    # Verify it actually worked
-    installed = _check_win_python_module(win_python, "mss")
-    if not installed:
+    # Verify everything is importable
+    still_missing = []
+    for pkg in _DAEMON_DEPS:
+        mod = _DAEMON_IMPORT_NAMES.get(pkg, pkg)
+        if not _check_win_python_module(win_python, mod):
+            still_missing.append(pkg)
+
+    if still_missing:
         logger.error(
-            "mss is not available on Windows Python (%s). "
-            "Screenshots will fail. Install manually: "
-            "open PowerShell and run: %s -m pip install mss",
-            win_python, win_python,
+            "Daemon deps not available on Windows Python (%s): %s. "
+            "Screenshots will fail. Install manually in PowerShell: "
+            "%s -m pip install %s",
+            win_python, ", ".join(still_missing),
+            win_python, " ".join(still_missing),
         )
-    return installed
+        return False
+    return True
 
 
 def _deploy_and_launch_daemon(win_python: str) -> None:

--- a/api/tests/test_settings.py
+++ b/api/tests/test_settings.py
@@ -303,26 +303,41 @@ class TestComputerUseSetupService:
 
 
 class TestEnsureDaemonDeps:
-    """Tests for _ensure_daemon_deps: install mss on Windows Python before daemon launch."""
+    """Tests for _ensure_daemon_deps: install daemon deps on Windows Python."""
 
-    def test_returns_true_when_mss_already_present(self):
-        """If mss is already importable, return True without pip install."""
+    def test_returns_true_when_all_deps_present(self):
+        """If all deps are importable, return True without pip install."""
         with patch.object(cu_setup, "_check_win_python_module", return_value=True):
             assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is True
 
-    def test_installs_and_verifies_mss(self):
-        """If mss missing, pip install then verify. Returns True on success."""
-        with patch.object(cu_setup, "_check_win_python_module", side_effect=[False, True]), \
+    def test_installs_missing_deps_and_verifies(self):
+        """If some deps missing, pip install then verify. Returns True on success."""
+        # First round: mss ok, PIL missing. After install: both ok.
+        checks = iter([True, False, True, True])
+        with patch.object(cu_setup, "_check_win_python_module", side_effect=checks), \
              patch("subprocess.run") as mock_run:
             ok_result = type("R", (), {"returncode": 0, "stderr": ""})()
             mock_run.return_value = ok_result
             assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is True
-            # pip install was called
             pip_cmd = mock_run.call_args_list[0][0][0][-1]
-            assert "pip install mss" in pip_cmd
+            assert "Pillow" in pip_cmd
+            assert "mss" not in pip_cmd  # mss was already present
+
+    def test_installs_all_when_none_present(self):
+        """If no deps present, install all in one pip call."""
+        # First round: all missing. After install: all ok.
+        checks = iter([False, False, True, True])
+        with patch.object(cu_setup, "_check_win_python_module", side_effect=checks), \
+             patch("subprocess.run") as mock_run:
+            ok_result = type("R", (), {"returncode": 0, "stderr": ""})()
+            mock_run.return_value = ok_result
+            assert cu_setup._ensure_daemon_deps("C:\\Python312\\python.exe") is True
+            pip_cmd = mock_run.call_args_list[0][0][0][-1]
+            assert "mss" in pip_cmd
+            assert "Pillow" in pip_cmd
 
     def test_returns_false_when_install_fails(self):
-        """If pip install fails and mss still not importable, return False."""
+        """If pip fails and deps still missing, return False."""
         with patch.object(cu_setup, "_check_win_python_module", return_value=False), \
              patch("subprocess.run") as mock_run:
             fail_result = type("R", (), {"returncode": 1, "stderr": "no pip"})()


### PR DESCRIPTION
## Summary

Follow-up to #163. The daemon needs both **mss** (screenshots) and **Pillow** (JPEG conversion), but the previous fix only installed mss. After mss was fixed, screenshot() failed with `No module named 'PIL'`.

- `_DAEMON_DEPS` list makes it explicit what the daemon needs
- `_DAEMON_IMPORT_NAMES` maps pip names to import names (Pillow -> PIL)
- Checks each module individually, installs only what's missing in one pip call
- Verifies all are importable after install, blocks daemon launch if not

Verified on this machine: Windows Python has both `mss 10.1.0` and `pillow 12.1.1` installed, which is why it works here but fails on clean installs.

## Test plan
- [ ] 70 tests pass (test_settings.py + test_daemon.py)
- [ ] Fresh WSL install: `vadgr computer-use enable` installs both mss and Pillow
- [ ] `screenshot()` works end to end