### PR TITLE
Mobile pairing backend: Tailscale transport, two-gate auth, pair/claim/devices + run-event WS

### DIFF
--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Auth: crypto primitives, ephemeral pairing, persistent devices, gating."""

--- a/api/auth/devices.py
+++ b/api/auth/devices.py
@@ -1,0 +1,79 @@
+"""Persistent device repository (SRP).
+
+The single owner of the ``devices`` table: store a paired device with its
+token *hash* (never plaintext), look a device up by token hash for the auth
+gate, list/touch, and revoke. Swapping the storage backend touches only this
+file.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from api.persistence.database import Database
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _row_to_device(row) -> dict:
+    return {
+        "id": row["id"],
+        "machine_name": row["machine_name"],
+        "paired_at": row["paired_at"],
+        "last_seen": row["last_seen"],
+    }
+
+
+class DeviceRepository:
+    """CRUD for paired devices. Token hashes only -- never plaintext tokens."""
+
+    def __init__(self, db: Database):
+        self.db = db
+
+    async def create(self, machine_name: str, token_hash: str) -> dict:
+        device_id = str(uuid.uuid4())
+        now = _now()
+        await self.db.conn.execute(
+            """INSERT INTO devices (id, machine_name, token_hash, paired_at, last_seen)
+               VALUES (?, ?, ?, ?, ?)""",
+            (device_id, machine_name, token_hash, now, now),
+        )
+        await self.db.conn.commit()
+        return await self.get(device_id)
+
+    async def get(self, device_id: str) -> Optional[dict]:
+        cursor = await self.db.conn.execute(
+            "SELECT * FROM devices WHERE id = ?", (device_id,)
+        )
+        row = await cursor.fetchone()
+        return _row_to_device(row) if row else None
+
+    async def find_by_token_hash(self, token_hash: str) -> Optional[dict]:
+        cursor = await self.db.conn.execute(
+            "SELECT * FROM devices WHERE token_hash = ?", (token_hash,)
+        )
+        row = await cursor.fetchone()
+        return _row_to_device(row) if row else None
+
+    async def list_all(self) -> list[dict]:
+        cursor = await self.db.conn.execute(
+            "SELECT * FROM devices ORDER BY paired_at DESC"
+        )
+        return [_row_to_device(row) for row in await cursor.fetchall()]
+
+    async def touch(self, device_id: str) -> None:
+        await self.db.conn.execute(
+            "UPDATE devices SET last_seen = ? WHERE id = ?", (_now(), device_id)
+        )
+        await self.db.conn.commit()
+
+    async def delete(self, device_id: str) -> bool:
+        cursor = await self.db.conn.execute(
+            "DELETE FROM devices WHERE id = ?", (device_id,)
+        )
+        await self.db.conn.commit()
+        return cursor.rowcount > 0

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -1,0 +1,160 @@
+"""The two gates -- and nothing else (SRP).
+
+Every request passes through, in order:
+
+  Gate 0  loopback bypass: a 127.0.0.0/8 source is allowed outright (the CLI
+          and the frontend served on localhost are unchanged).
+  Gate 1  network: ``transport.is_authorized_source(peer_ip)`` -- a non-tailnet
+          source is rejected *before* the token is even looked at.
+  Gate 2  token: a valid ``Authorization: Bearer <token>`` (or ``?token=`` for
+          WS) must hash to a stored device row.
+
+The middleware depends only on the ``TransportProvider`` port (DIP) plus the
+device repo -- never on Tailscale directly. Implemented as a pure ASGI
+middleware (no ``BaseHTTPMiddleware``) so it adds no per-request task group,
+keeping event-loop scheduling stable for the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from api.auth.tokens import hash_token
+from api.transport.base import TransportProvider
+
+logger = logging.getLogger(__name__)
+
+# Paths reachable without a token -- the phone's connectivity probe and the
+# pair/claim handshake itself (a phone has no token yet when it claims).
+_PUBLIC_PATHS = {"/api/health", "/api/auth/pair", "/api/auth/claim"}
+
+
+def _client_host(scope: Scope) -> Optional[str]:
+    client = scope.get("client")
+    return client[0] if client else None
+
+
+def _extract_bearer(headers: list) -> Optional[str]:
+    for raw_key, raw_val in headers:
+        if raw_key.lower() == b"authorization":
+            parts = raw_val.decode("latin-1").split(None, 1)
+            if len(parts) == 2 and parts[0].lower() == "bearer":
+                return parts[1].strip()
+    return None
+
+
+async def _send_json_error(send: Send, status: int, code: str, message: str) -> None:
+    body = json.dumps(
+        {"error": {"code": code, "message": message, "details": {}}}
+    ).encode("utf-8")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+async def authenticate_device(app, token: Optional[str]) -> Optional[dict]:
+    """Gate 2 helper, shared by HTTP and WS. Returns the device row on success
+    (and touches its ``last_seen``), or ``None``."""
+    if not token:
+        return None
+    device_repo = getattr(app.state, "device_repo", None)
+    if device_repo is None:
+        return None
+    device = await device_repo.find_by_token_hash(hash_token(token))
+    if device is None:
+        return None
+    try:
+        await device_repo.touch(device["id"])
+    except Exception:  # pragma: no cover -- best-effort bookkeeping
+        logger.warning("device_repo.touch failed for %s", device["id"])
+    return device
+
+
+async def authorize_ws(
+    app,
+    transport: TransportProvider,
+    client_host: Optional[str],
+    token: Optional[str],
+) -> bool:
+    """Run the two gates for a WebSocket handshake (the middleware never sees
+    the WS handshake -- Starlette dispatches it straight to the route)."""
+    # Gate 0: loopback bypass.
+    if _is_loopback(client_host):
+        return True
+    # Gate 1: network authorization.
+    if client_host is None or not transport.is_authorized_source(client_host):
+        return False
+    # Gate 2: token.
+    return await authenticate_device(app, token) is not None
+
+
+def _is_loopback(host: Optional[str]) -> bool:
+    if host is None:
+        return False
+    h = host.lower()
+    return h in {"127.0.0.1", "::1", "localhost", "testclient"} or h.startswith("127.")
+
+
+class TwoGateMiddleware:
+    """Pure ASGI middleware enforcing Gate 0/1/2 on HTTP requests."""
+
+    def __init__(self, app: ASGIApp, transport: TransportProvider):
+        self.app = app
+        self.transport = transport
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "GET")
+        path = scope.get("path", "")
+
+        # CORS preflight -> defer to CORSMiddleware.
+        if method == "OPTIONS" or path in _PUBLIC_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        host = _client_host(scope)
+
+        # Gate 0: loopback bypass.
+        if _is_loopback(host):
+            await self.app(scope, receive, send)
+            return
+
+        # Gate 1: network authorization (before any token work).
+        if host is None or not self.transport.is_authorized_source(host):
+            await _send_json_error(
+                send,
+                403,
+                "SOURCE_NOT_AUTHORIZED",
+                "Source is not an authorized peer on this transport.",
+            )
+            return
+
+        # Gate 2: token.
+        token = _extract_bearer(scope.get("headers", []))
+        app_obj = scope.get("app")
+        device = await authenticate_device(app_obj, token) if app_obj else None
+        if device is None:
+            await _send_json_error(
+                send,
+                401,
+                "INVALID_TOKEN" if token else "MISSING_TOKEN",
+                "A valid Bearer token is required.",
+            )
+            return
+
+        await self.app(scope, receive, send)

--- a/api/auth/pairing_store.py
+++ b/api/auth/pairing_store.py
@@ -1,0 +1,60 @@
+"""Ephemeral one-time pairing tokens -- the pair->claim handshake (SRP).
+
+Pairing tokens are minted by ``POST /api/auth/pair`` and redeemed exactly
+once by ``POST /api/auth/claim``. They are short-lived and process-local
+(never persisted): a desktop hands one to a phone via the QR, the phone
+claims it for a persistent token, and it is consumed. Expired tokens are
+swept lazily on access.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+from api.auth.tokens import generate_pairing_token
+
+PAIRING_TTL_SECONDS = 300  # 5 minutes
+
+
+@dataclass
+class _Pending:
+    token: str
+    expires_at: float
+
+
+class PairingStore:
+    """Thread-safe, in-memory store of unredeemed pairing tokens."""
+
+    def __init__(self, ttl_seconds: int = PAIRING_TTL_SECONDS):
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+        self._pending: dict[str, _Pending] = {}
+
+    def mint(self) -> tuple[str, float]:
+        """Create a pairing token. Returns ``(token, expires_at_monotonic)``."""
+        token = generate_pairing_token()
+        expires_at = time.monotonic() + self._ttl
+        with self._lock:
+            self._pending[token] = _Pending(token=token, expires_at=expires_at)
+        return token, expires_at
+
+    def consume(self, token: str) -> bool:
+        """Atomically validate and remove a token. One-time: a second consume
+        of the same token returns ``False``. Expired tokens also return
+        ``False`` and are swept."""
+        now = time.monotonic()
+        with self._lock:
+            for stale in [t for t, p in self._pending.items() if p.expires_at <= now]:
+                self._pending.pop(stale, None)
+            pending = self._pending.pop(token, None)
+        return pending is not None and pending.expires_at > now
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._pending)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._pending.clear()

--- a/api/auth/tokens.py
+++ b/api/auth/tokens.py
@@ -1,0 +1,38 @@
+"""Token primitives -- pure crypto, no I/O (SRP).
+
+Tokens are opaque, high-entropy random strings. Only their SHA-256 hash is
+ever stored. Verification is constant-time. Nothing here touches disk, the
+network, or a database -- swapping the hash or entropy touches only this file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+
+# 32 bytes of entropy -> ~43 url-safe chars. Comfortably beyond brute force.
+_TOKEN_ENTROPY_BYTES = 32
+# Pairing tokens are short-lived and one-time, so a slightly smaller secret
+# is fine, but we keep them strong anyway.
+_PAIRING_ENTROPY_BYTES = 24
+
+
+def generate_token() -> str:
+    """A new persistent bearer token (opaque, high-entropy)."""
+    return secrets.token_urlsafe(_TOKEN_ENTROPY_BYTES)
+
+
+def generate_pairing_token() -> str:
+    """A new one-time, short-lived pairing token."""
+    return secrets.token_urlsafe(_PAIRING_ENTROPY_BYTES)
+
+
+def hash_token(token: str) -> str:
+    """SHA-256 hex digest -- what we store at rest, never the plaintext."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def verify_token(token: str, token_hash: str) -> bool:
+    """Constant-time check that ``token`` hashes to ``token_hash``."""
+    return hmac.compare_digest(hash_token(token), token_hash)

--- a/api/config.py
+++ b/api/config.py
@@ -8,6 +8,8 @@ DEFAULT_FRONTEND_PORT = 3000
 
 
 class Settings(BaseSettings):
+    # Host is no longer hard-coded -- it comes from transport.bind_host() at
+    # startup (main.py). This default is only a fallback for legacy callers.
     host: str = "127.0.0.1"
     port: int = DEFAULT_API_PORT
     frontend_port: int = DEFAULT_FRONTEND_PORT

--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.config import settings
 from api.persistence.database import Database
 from api.persistence.repositories import AgentRepository, ProjectRepository, RunRepository
+from api.auth.devices import DeviceRepository
+from api.auth.pairing_store import PairingStore
+from api.auth.middleware import TwoGateMiddleware
+from api.transport import create_transport
 from api.websocket.manager import ConnectionManager
 from api.websocket.events import make_event
 from api.engine.executor import AgentExecutor
@@ -21,11 +25,16 @@ from api.services.artifact_service import ArtifactService
 from api.services.execution_service import ExecutionService
 from api.services.log_writer import LogWriter
 from api.routes import health, agents, projects, runs, computer_use, providers, ws
+from api.routes import auth as auth_routes
+from api.routes import devices as devices_routes
 from api.routes import settings as settings_routes
 
 
-def create_app(db: Optional[Database] = None) -> FastAPI:
-    """Create the FastAPI app. Pass a Database for testing (in-memory)."""
+def create_app(db: Optional[Database] = None, transport=None) -> FastAPI:
+    """Create the FastAPI app. Pass a Database for testing (in-memory) and an
+    optional ``transport`` (a ``TransportProvider``); defaults to the configured
+    transport via ``VADGR_TRANSPORT``."""
+    transport = transport or create_transport()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -40,6 +49,9 @@ def create_app(db: Optional[Database] = None) -> FastAPI:
         app.state.agent_repo = AgentRepository(app.state.db)
         app.state.project_repo = ProjectRepository(app.state.db)
         app.state.run_repo = RunRepository(app.state.db)
+        app.state.device_repo = DeviceRepository(app.state.db)
+        app.state.pairing_store = PairingStore()
+        app.state.transport = transport
         app.state.ws_manager = ConnectionManager()
         app.state.artifact_service = ArtifactService(Path(__file__).resolve().parent.parent)
         app.state.active_run_tasks: dict[str, asyncio.Task] = {}
@@ -111,6 +123,11 @@ def create_app(db: Optional[Database] = None) -> FastAPI:
             await app.state.db.disconnect()
 
     app = FastAPI(title="Vadgr API", version=settings.version, lifespan=lifespan)
+    app.state.transport = transport
+
+    # The two-gate auth middleware. Added before CORS so CORS wraps it and
+    # responses (incl. 401/403) still carry CORS headers.
+    app.add_middleware(TwoGateMiddleware, transport=transport)
 
     app.add_middleware(
         CORSMiddleware,
@@ -126,6 +143,8 @@ def create_app(db: Optional[Database] = None) -> FastAPI:
     app.include_router(runs.router)
     app.include_router(computer_use.router)
     app.include_router(providers.router)
+    app.include_router(auth_routes.router)
+    app.include_router(devices_routes.router)
     app.include_router(settings_routes.router)
     app.include_router(ws.router)
 

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -2,4 +2,6 @@
 
 from .common import AgentType, RunStatus, AgentRunStatus, ErrorResponse, ErrorEnvelope
 from .agent import SchemaField, AgentCreate, AgentUpdate, Agent, AgentRunRequest
-from .run import RunCreate, Run, AgentRun, RunStartResponse
+from .run import RunCreate, Run, AgentRun, RunStartResponse, RunEvent, RunEventType
+from .device import Device
+from .auth import PairResponse, ClaimRequest, ClaimResponse

--- a/api/models/auth.py
+++ b/api/models/auth.py
@@ -1,0 +1,28 @@
+"""Pairing / claim contract models (the seam mobile codegens from)."""
+
+from pydantic import BaseModel
+
+from .common import StrictBody
+
+
+class PairResponse(BaseModel):
+    """Desktop -> QR. ``host`` is ``transport.advertise_host()``, never 127.0.0.1."""
+
+    host: str
+    port: int
+    pairing_token: str  # one-time, short-lived
+    machine_name: str
+
+
+class ClaimRequest(StrictBody):
+    """Phone -> server. Carries the one-time pairing token."""
+
+    pairing_token: str
+    device_name: str
+
+
+class ClaimResponse(BaseModel):
+    """Server -> phone. The persistent token is returned exactly once."""
+
+    token: str  # long-lived persistent token
+    device_id: str

--- a/api/models/device.py
+++ b/api/models/device.py
@@ -1,0 +1,16 @@
+"""Device model -- a paired phone as an auth principal."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Device(BaseModel):
+    """A paired device. The persistent ``token_hash`` is never serialized here;
+    it lives only in the ``devices`` table."""
+
+    id: str
+    machine_name: str
+    paired_at: datetime
+    last_seen: Optional[datetime] = None

--- a/api/models/run.py
+++ b/api/models/run.py
@@ -1,11 +1,30 @@
 """Run and agent run Pydantic models."""
 
 from datetime import datetime
+from enum import Enum
 from typing import Any, Optional
 
 from pydantic import BaseModel
 
 from .common import RunStatus, AgentRunStatus, StrictBody
+
+
+class RunEventType(str, Enum):
+    STARTED = "started"
+    TOOL_CALL = "tool_call"
+    OUTPUT = "output"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class RunEvent(BaseModel):
+    """The WS stream payload. Transient -- derived from run/agent-run state,
+    never persisted as a table."""
+
+    type: RunEventType
+    timestamp: datetime
+    payload: dict = {}
 
 
 class RunCreate(StrictBody):

--- a/api/persistence/database.py
+++ b/api/persistence/database.py
@@ -84,6 +84,16 @@ CREATE TABLE IF NOT EXISTS agent_runs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_agent_runs_run ON agent_runs(run_id);
+
+CREATE TABLE IF NOT EXISTS devices (
+    id TEXT PRIMARY KEY,
+    machine_name TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    paired_at TEXT NOT NULL,
+    last_seen TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_devices_token_hash ON devices(token_hash);
 """
 
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -1,0 +1,77 @@
+"""Pairing endpoints: mint a one-time token (pair) and redeem it (claim)."""
+
+import socket
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from api.auth import tokens
+from api.config import settings
+from api.models.auth import ClaimRequest, ClaimResponse, PairResponse
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+def _machine_name() -> str:
+    try:
+        return socket.gethostname()
+    except Exception:
+        return "vadgr"
+
+
+@router.post("/pair", response_model=PairResponse)
+async def pair(request: Request):
+    """Mint a one-time, short-lived pairing token and return the QR payload.
+
+    Refuses (503) when the transport can't advertise a reachable host -- we
+    never hand out a localhost QR a phone could not use."""
+    transport = request.app.state.transport
+    host = transport.advertise_host()
+    if host is None:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": {
+                    "code": "TRANSPORT_UNAVAILABLE",
+                    "message": (
+                        "Transport cannot advertise a reachable address. Enable "
+                        "Tailscale (VADGR_TRANSPORT=tailscale) to pair over your tailnet."
+                    ),
+                    "details": {"transport": transport.name},
+                }
+            },
+        )
+
+    pairing_token, _ = request.app.state.pairing_store.mint()
+    return PairResponse(
+        host=host,
+        port=settings.port,
+        pairing_token=pairing_token,
+        machine_name=_machine_name(),
+    )
+
+
+@router.post("/claim", response_model=ClaimResponse)
+async def claim(body: ClaimRequest, request: Request):
+    """Redeem a pairing token (one-time) for a persistent device token.
+
+    The plaintext token is returned exactly once; only its hash is stored."""
+    consumed = request.app.state.pairing_store.consume(body.pairing_token)
+    if not consumed:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "error": {
+                    "code": "INVALID_PAIRING_TOKEN",
+                    "message": "Pairing token is invalid, already used, or expired.",
+                    "details": {},
+                }
+            },
+        )
+
+    token = tokens.generate_token()
+    device = await request.app.state.device_repo.create(
+        machine_name=body.device_name,
+        token_hash=tokens.hash_token(token),
+    )
+    return ClaimResponse(token=token, device_id=device["id"])

--- a/api/routes/devices.py
+++ b/api/routes/devices.py
@@ -1,0 +1,37 @@
+"""Device management: list paired devices, revoke one."""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from api.models.device import Device
+
+router = APIRouter(prefix="/api/devices", tags=["devices"])
+
+
+@router.get("", response_model=list[Device])
+async def list_devices(request: Request):
+    rows = await request.app.state.device_repo.list_all()
+    return [Device(**row) for row in rows]
+
+
+@router.delete("/{device_id}")
+async def revoke_device(device_id: str, request: Request):
+    """Revoke a device. Future requests with its token fail Gate 2; any live WS
+    connections it holds are dropped now (revocation propagation)."""
+    deleted = await request.app.state.device_repo.delete(device_id)
+    if not deleted:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": {
+                    "code": "DEVICE_NOT_FOUND",
+                    "message": f"Device '{device_id}' not found.",
+                    "details": {},
+                }
+            },
+        )
+    # Drop any live WS connections owned by this device.
+    ws_manager = getattr(request.app.state, "ws_manager", None)
+    if ws_manager is not None and hasattr(ws_manager, "disconnect_device"):
+        await ws_manager.disconnect_device(device_id)
+    return {"status": "revoked", "device_id": device_id}

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,6 @@
-"""Health check endpoint."""
+"""Health check endpoint -- also the phone's post-pair connectivity probe."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from api.config import settings
 
@@ -8,7 +8,8 @@ router = APIRouter()
 
 
 @router.get("/api/health")
-async def health():
+async def health(request: Request):
+    transport = getattr(request.app.state, "transport", None)
     return {
         "status": "healthy",
         "modules": {
@@ -17,4 +18,5 @@ async def health():
         },
         "platform": "wsl2",
         "version": settings.version,
+        "transport": transport.status() if transport is not None else None,
     }

--- a/api/routes/ws.py
+++ b/api/routes/ws.py
@@ -1,12 +1,71 @@
-"""WebSocket route for live run streaming."""
+"""WebSocket routes for live run streaming.
+
+Two surfaces:
+  - ``/api/ws/runs/{run_id}``      -- the existing desktop stream (raw events).
+  - ``/api/runs/{run_id}/stream``  -- the mobile stream: same machinery, but
+    every frame is a contract ``RunEvent`` and the connection is guarded by the
+    two-gate auth (header or ``?token=``).
+"""
 
 import json
 import logging
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from api.auth.middleware import authorize_ws, authenticate_device, _is_loopback
+from api.models.run import RunEvent, RunEventType
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+# Map internal broadcast event types -> the mobile RunEvent contract.
+_EVENT_TYPE_MAP = {
+    "run_started": RunEventType.STARTED,
+    "step_started": RunEventType.TOOL_CALL,
+    "tool_call": RunEventType.TOOL_CALL,
+    "step_output": RunEventType.OUTPUT,
+    "output": RunEventType.OUTPUT,
+    "approval_required": RunEventType.PAUSED,
+    "run_completed": RunEventType.COMPLETED,
+    "run_failed": RunEventType.FAILED,
+}
+
+
+def _to_run_event(internal: dict) -> RunEvent | None:
+    mapped = _EVENT_TYPE_MAP.get(internal.get("type"))
+    if mapped is None:
+        return None
+    ts = internal.get("timestamp")
+    try:
+        timestamp = datetime.fromisoformat(ts) if ts else datetime.now(timezone.utc)
+    except (TypeError, ValueError):
+        timestamp = datetime.now(timezone.utc)
+    return RunEvent(type=mapped, timestamp=timestamp, payload=internal.get("data", {}))
+
+
+class _RunEventTranslator:
+    """Wraps a WebSocket so the manager's ``send_json`` of internal events is
+    translated into mobile ``RunEvent`` frames. Non-mappable events are dropped.
+
+    Only ``accept``/``send_json``/``close`` are used by ConnectionManager, so we
+    proxy those and forward identity for membership checks."""
+
+    def __init__(self, ws: WebSocket):
+        self._ws = ws
+
+    async def accept(self, *a, **kw):
+        # The route already accepted (after auth); avoid a double accept.
+        return None
+
+    async def send_json(self, event: dict):
+        run_event = _to_run_event(event)
+        if run_event is not None:
+            await self._ws.send_text(run_event.model_dump_json())
+
+    async def close(self, *a, **kw):
+        await self._ws.close(*a, **kw)
 
 
 @router.websocket("/api/ws/runs/{run_id}")
@@ -43,3 +102,44 @@ async def run_websocket(websocket: WebSocket, run_id: str):
                     )
     except WebSocketDisconnect:
         manager.disconnect(run_id, websocket)
+
+
+@router.websocket("/api/runs/{run_id}/stream")
+async def run_stream(websocket: WebSocket, run_id: str):
+    """Mobile run stream. Two-gate authed; emits contract RunEvents."""
+    app = websocket.app
+    transport = app.state.transport
+    client_host = websocket.client.host if websocket.client else None
+    token = websocket.query_params.get("token")
+    if not token:
+        auth_header = websocket.headers.get("authorization")
+        if auth_header:
+            parts = auth_header.split(None, 1)
+            if len(parts) == 2 and parts[0].lower() == "bearer":
+                token = parts[1].strip()
+
+    if not await authorize_ws(app, transport, client_host, token):
+        await websocket.close(code=4401, reason="Unauthorized")
+        return
+
+    run_repo = app.state.run_repo
+    run = await run_repo.get(run_id)
+    if not run:
+        await websocket.close(code=4004, reason="Run not found")
+        return
+
+    # Resolve the owning device id (loopback has none) for revocation tracking.
+    device_id = None
+    if not _is_loopback(client_host):
+        device = await authenticate_device(app, token)
+        device_id = device["id"] if device else None
+
+    await websocket.accept()
+    manager = app.state.ws_manager
+    translator = _RunEventTranslator(websocket)
+    await manager.connect(run_id, translator, device_id=device_id)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(run_id, translator)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -60,6 +60,12 @@ async def app(db):
     application.state.agent_repo = AgentRepository(db)
     application.state.project_repo = ProjectRepository(db)
     application.state.run_repo = RunRepository(db)
+    from api.auth.devices import DeviceRepository
+    from api.auth.pairing_store import PairingStore
+    from api.transport import LoopbackTransport
+    application.state.device_repo = DeviceRepository(db)
+    application.state.pairing_store = PairingStore()
+    application.state.transport = LoopbackTransport()
     from api.websocket.manager import ConnectionManager
     from api.engine.executor import AgentExecutor
     from api.engine.providers import CLIAgentProvider, ProviderConfig

--- a/api/tests/test_auth_middleware.py
+++ b/api/tests/test_auth_middleware.py
@@ -1,0 +1,154 @@
+"""Two-gate middleware: gate order, loopback bypass, rejects, happy path.
+
+Exercises the pure-ASGI ``TwoGateMiddleware`` directly with crafted scopes so
+we control the peer IP (httpx's ASGITransport always reports 127.0.0.1)."""
+
+import pytest
+
+from api.auth import tokens
+from api.auth.devices import DeviceRepository
+from api.auth.middleware import TwoGateMiddleware, authorize_ws
+
+
+class _FakeTransport:
+    name = "fake"
+
+    def is_authorized_source(self, peer_ip):
+        return peer_ip.startswith("100.")
+
+    def advertise_host(self):
+        return "host"
+
+    def is_available(self):
+        return True
+
+    def bind_host(self):
+        return "100.1.2.3"
+
+    def status(self):
+        return {}
+
+
+class _AppState:
+    pass
+
+
+class _App:
+    def __init__(self, device_repo):
+        self.state = _AppState()
+        self.state.device_repo = device_repo
+
+
+async def _call(middleware, *, host, path="/api/devices", token=None):
+    headers = []
+    if token is not None:
+        headers.append((b"authorization", f"Bearer {token}".encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": headers,
+        "client": (host, 12345) if host is not None else None,
+        "app": middleware._app_for_test,
+    }
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(msg):
+        sent.append(msg)
+
+    await middleware(scope, receive, send)
+    status = next((m["status"] for m in sent if m["type"] == "http.response.start"), None)
+    return status, sent
+
+
+def _make_middleware(device_repo):
+    reached = {"hit": False}
+
+    async def inner(scope, receive, send):
+        reached["hit"] = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = TwoGateMiddleware(inner, transport=_FakeTransport())
+    mw._app_for_test = _App(device_repo)
+    mw._reached = reached
+    return mw
+
+
+@pytest.mark.asyncio
+async def test_gate0_loopback_bypasses_everything(db):
+    mw = _make_middleware(DeviceRepository(db))
+    status, _ = await _call(mw, host="127.0.0.1", token=None)
+    assert status == 200
+    assert mw._reached["hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_gate1_non_tailnet_rejected_before_token(db):
+    mw = _make_middleware(DeviceRepository(db))
+    # A LAN peer with NO token: must be rejected at gate 1 (403), not gate 2.
+    status, _ = await _call(mw, host="192.168.1.50", token=None)
+    assert status == 403
+    assert mw._reached["hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_gate2_authorized_source_bad_token_rejected(db):
+    mw = _make_middleware(DeviceRepository(db))
+    status, _ = await _call(mw, host="100.64.1.2", token="bogus")
+    assert status == 401
+    assert mw._reached["hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_gate2_authorized_source_missing_token_rejected(db):
+    mw = _make_middleware(DeviceRepository(db))
+    status, _ = await _call(mw, host="100.64.1.2", token=None)
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_happy_path_tailnet_peer_with_valid_token(db):
+    repo = DeviceRepository(db)
+    token = tokens.generate_token()
+    await repo.create("Phone", tokens.hash_token(token))
+    mw = _make_middleware(repo)
+    status, _ = await _call(mw, host="100.64.1.2", token=token)
+    assert status == 200
+    assert mw._reached["hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_public_paths_skip_gates(db):
+    mw = _make_middleware(DeviceRepository(db))
+    for path in ("/api/health", "/api/auth/pair", "/api/auth/claim"):
+        status, _ = await _call(mw, host="8.8.8.8", path=path, token=None)
+        assert status == 200, path
+
+
+# --- WS authorize helper ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authorize_ws_loopback_allowed(db):
+    app = _App(DeviceRepository(db))
+    assert await authorize_ws(app, _FakeTransport(), "127.0.0.1", None) is True
+
+
+@pytest.mark.asyncio
+async def test_authorize_ws_non_tailnet_rejected(db):
+    app = _App(DeviceRepository(db))
+    assert await authorize_ws(app, _FakeTransport(), "192.168.0.5", "anything") is False
+
+
+@pytest.mark.asyncio
+async def test_authorize_ws_tailnet_requires_valid_token(db):
+    repo = DeviceRepository(db)
+    token = tokens.generate_token()
+    await repo.create("Phone", tokens.hash_token(token))
+    app = _App(repo)
+    assert await authorize_ws(app, _FakeTransport(), "100.64.1.2", token) is True
+    assert await authorize_ws(app, _FakeTransport(), "100.64.1.2", "bad") is False

--- a/api/tests/test_auth_primitives.py
+++ b/api/tests/test_auth_primitives.py
@@ -1,0 +1,104 @@
+"""Unit tests for the auth SRP split: tokens, pairing_store, devices."""
+
+import time
+
+import pytest
+
+from api.auth import tokens
+from api.auth.pairing_store import PairingStore
+from api.auth.devices import DeviceRepository
+
+
+# --- tokens.py (pure crypto) ------------------------------------------------
+
+
+def test_generated_tokens_are_high_entropy_and_unique():
+    a, b = tokens.generate_token(), tokens.generate_token()
+    assert a != b
+    assert len(a) >= 32  # token_urlsafe(32) -> ~43 chars
+
+
+def test_hash_is_sha256_hex_and_not_plaintext():
+    tok = tokens.generate_token()
+    h = tokens.hash_token(tok)
+    assert h != tok
+    assert len(h) == 64
+    int(h, 16)  # valid hex
+
+
+def test_verify_token_constant_time_roundtrip():
+    tok = tokens.generate_token()
+    assert tokens.verify_token(tok, tokens.hash_token(tok)) is True
+    assert tokens.verify_token("wrong", tokens.hash_token(tok)) is False
+
+
+def test_pairing_token_distinct_from_persistent_token():
+    assert tokens.generate_pairing_token() != tokens.generate_token()
+
+
+# --- pairing_store.py (ephemeral, one-time) ---------------------------------
+
+
+def test_mint_then_consume_once():
+    store = PairingStore()
+    token, _ = store.mint()
+    assert store.consume(token) is True
+    # One-time: a replay fails.
+    assert store.consume(token) is False
+
+
+def test_consume_unknown_token_fails():
+    assert PairingStore().consume("nope") is False
+
+
+def test_expired_pairing_token_is_rejected():
+    store = PairingStore(ttl_seconds=0)
+    token, _ = store.mint()
+    time.sleep(0.01)
+    assert store.consume(token) is False
+
+
+def test_size_tracks_pending():
+    store = PairingStore()
+    assert store.size() == 0
+    store.mint()
+    store.mint()
+    assert store.size() == 2
+
+
+# --- devices.py (persistent repo) -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_device_create_and_lookup_by_hash(db):
+    repo = DeviceRepository(db)
+    h = tokens.hash_token(tokens.generate_token())
+    device = await repo.create("Pixel 8", h)
+    assert device["machine_name"] == "Pixel 8"
+    found = await repo.find_by_token_hash(h)
+    assert found["id"] == device["id"]
+
+
+@pytest.mark.asyncio
+async def test_device_lookup_miss_returns_none(db):
+    repo = DeviceRepository(db)
+    assert await repo.find_by_token_hash("deadbeef") is None
+
+
+@pytest.mark.asyncio
+async def test_revoked_device_no_longer_authenticates(db):
+    repo = DeviceRepository(db)
+    h = tokens.hash_token(tokens.generate_token())
+    device = await repo.create("Phone", h)
+    assert await repo.delete(device["id"]) is True
+    assert await repo.find_by_token_hash(h) is None
+
+
+@pytest.mark.asyncio
+async def test_touch_updates_last_seen(db):
+    repo = DeviceRepository(db)
+    h = tokens.hash_token(tokens.generate_token())
+    device = await repo.create("Phone", h)
+    await repo.touch(device["id"])
+    refreshed = await repo.get(device["id"])
+    assert refreshed["last_seen"] is not None

--- a/api/tests/test_pair_claim_endpoints.py
+++ b/api/tests/test_pair_claim_endpoints.py
@@ -1,0 +1,128 @@
+"""pair -> claim -> devices loop, over loopback (Gate 0 bypass)."""
+
+import pytest
+
+from api.auth import tokens
+from api.transport import TailscaleTransport
+
+
+class _FakeTailscale(TailscaleTransport):
+    """Tailscale-shaped transport that advertises a host (so pair succeeds)
+    without a live tailnet."""
+
+    def __init__(self):
+        pass
+
+    name = "tailscale"
+
+    def advertise_host(self):
+        return "my-box.tailnet-1234.ts.net"
+
+    def is_available(self):
+        return True
+
+    def is_authorized_source(self, peer_ip):
+        return peer_ip.startswith("100.")
+
+    def bind_host(self):
+        return "100.1.2.3"
+
+    def status(self):
+        return {"name": "tailscale", "available": True}
+
+
+@pytest.mark.asyncio
+async def test_pair_refuses_when_transport_cannot_advertise(client):
+    # Default test transport is loopback -> advertise_host() is None.
+    resp = await client.post("/api/auth/pair")
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "TRANSPORT_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_pair_returns_qr_payload_when_advertisable(app, client):
+    app.state.transport = _FakeTailscale()
+    resp = await client.post("/api/auth/pair")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["host"] == "my-box.tailnet-1234.ts.net"
+    assert body["host"] != "127.0.0.1"
+    assert body["pairing_token"]
+    assert "machine_name" in body and "port" in body
+
+
+@pytest.mark.asyncio
+async def test_full_pair_claim_devices_loop(app, client):
+    app.state.transport = _FakeTailscale()
+
+    # 1. pair -> pairing token
+    pair = (await client.post("/api/auth/pair")).json()
+    pairing_token = pair["pairing_token"]
+
+    # 2. claim -> persistent token + device
+    claim = await client.post(
+        "/api/auth/claim",
+        json={"pairing_token": pairing_token, "device_name": "Pixel 8"},
+    )
+    assert claim.status_code == 200
+    claimed = claim.json()
+    assert claimed["token"] and claimed["device_id"]
+
+    # Token is stored hashed, never plaintext.
+    stored = await app.state.device_repo.find_by_token_hash(
+        tokens.hash_token(claimed["token"])
+    )
+    assert stored is not None and stored["id"] == claimed["device_id"]
+
+    # 3. devices lists it (loopback bypasses the gates)
+    devices = (await client.get("/api/devices")).json()
+    assert any(d["id"] == claimed["device_id"] for d in devices)
+    assert all("token_hash" not in d for d in devices)  # never serialized
+
+
+@pytest.mark.asyncio
+async def test_pairing_token_is_one_time(app, client):
+    app.state.transport = _FakeTailscale()
+    pairing_token = (await client.post("/api/auth/pair")).json()["pairing_token"]
+    first = await client.post(
+        "/api/auth/claim",
+        json={"pairing_token": pairing_token, "device_name": "A"},
+    )
+    assert first.status_code == 200
+    # Replay the same token -> rejected.
+    second = await client.post(
+        "/api/auth/claim",
+        json={"pairing_token": pairing_token, "device_name": "B"},
+    )
+    assert second.status_code == 401
+    assert second.json()["error"]["code"] == "INVALID_PAIRING_TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_claim_with_bogus_token_rejected(client):
+    resp = await client.post(
+        "/api/auth/claim",
+        json={"pairing_token": "not-a-real-token", "device_name": "X"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_revoke_device(app, client):
+    app.state.transport = _FakeTailscale()
+    pairing_token = (await client.post("/api/auth/pair")).json()["pairing_token"]
+    claimed = (
+        await client.post(
+            "/api/auth/claim",
+            json={"pairing_token": pairing_token, "device_name": "P"},
+        )
+    ).json()
+
+    revoke = await client.delete(f"/api/devices/{claimed['device_id']}")
+    assert revoke.status_code == 200
+    assert await app.state.device_repo.find_by_token_hash(
+        tokens.hash_token(claimed["token"])
+    ) is None
+
+    missing = await client.delete("/api/devices/does-not-exist")
+    assert missing.status_code == 404

--- a/api/tests/test_run_stream_ws.py
+++ b/api/tests/test_run_stream_ws.py
@@ -1,0 +1,127 @@
+"""WS /api/runs/{run_id}/stream: RunEvent translation + auth + revocation."""
+
+from datetime import datetime, timezone
+
+import anyio
+import pytest
+import pytest_asyncio
+from starlette.testclient import TestClient
+
+from api.main import create_app
+from api.persistence.database import Database
+from api.routes.ws import _to_run_event, _RunEventTranslator
+from api.models.run import RunEventType
+from api.transport import LoopbackTransport
+
+
+# --- pure translation -------------------------------------------------------
+
+
+def test_internal_event_maps_to_run_event():
+    ev = _to_run_event(
+        {
+            "type": "run_started",
+            "data": {"x": 1},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    assert ev.type == RunEventType.STARTED
+    assert ev.payload == {"x": 1}
+
+
+def test_run_completed_maps_to_completed():
+    assert _to_run_event({"type": "run_completed", "data": {}}).type == RunEventType.COMPLETED
+
+
+def test_unmappable_event_dropped():
+    assert _to_run_event({"type": "task_progress", "data": {}}) is None
+
+
+def test_translator_only_forwards_mapped_events():
+    sent = []
+
+    class _Sock:
+        async def send_text(self, txt):
+            sent.append(txt)
+
+    translator = _RunEventTranslator(_Sock())
+
+    async def run():
+        await translator.send_json({"type": "task_progress", "data": {}})  # dropped
+        await translator.send_json(
+            {
+                "type": "run_failed",
+                "data": {"e": 1},
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+    anyio.run(run)
+    assert len(sent) == 1
+    assert '"failed"' in sent[0]
+
+
+# --- live socket via TestClient (lifespan wires state from our db) -----------
+
+
+@pytest_asyncio.fixture
+async def live_db():
+    database = Database(":memory:")
+    await database.connect()
+    await database.create_tables()
+    await database.conn.execute("INSERT INTO runs (id, status) VALUES ('run-1', 'running')")
+    await database.conn.commit()
+    yield database
+    await database.disconnect()
+
+
+def test_stream_loopback_accepts_and_translates(live_db):
+    app = create_app(live_db, transport=LoopbackTransport())
+    with TestClient(app) as tc:
+        with tc.websocket_connect("/api/runs/run-1/stream") as ws:
+            # Broadcast an internal event from within the app's event loop via
+            # the manager; the translator must deliver a contract RunEvent.
+            tc.portal.call(
+                lambda: app.state.ws_manager.broadcast_event(
+                    "run-1",
+                    {
+                        "type": "run_started",
+                        "data": {"hello": "world"},
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+            )
+            frame = ws.receive_json()
+            assert frame["type"] == "started"
+            assert frame["payload"] == {"hello": "world"}
+
+
+def test_stream_unknown_run_is_rejected(live_db):
+    app = create_app(live_db, transport=LoopbackTransport())
+    with TestClient(app) as tc:
+        with pytest.raises(Exception):
+            with tc.websocket_connect("/api/runs/does-not-exist/stream"):
+                pass
+
+
+class _DenyAll(LoopbackTransport):
+    """Treats the TestClient peer as a non-loopback, non-authorized source so
+    the WS auth path rejects (no token)."""
+
+    def is_authorized_source(self, peer_ip):
+        return False
+
+
+def test_stream_rejects_unauthorized_non_loopback(live_db, monkeypatch):
+    import api.routes.ws as ws_module
+    import api.auth.middleware as mw_module
+
+    # Force both the WS route and the shared authorize_ws helper to treat the
+    # TestClient peer as a non-loopback source.
+    monkeypatch.setattr(ws_module, "_is_loopback", lambda host: False)
+    monkeypatch.setattr(mw_module, "_is_loopback", lambda host: False)
+    app = create_app(live_db, transport=_DenyAll())
+    with TestClient(app) as tc:
+        with pytest.raises(Exception):
+            with tc.websocket_connect("/api/runs/run-1/stream"):
+                pass

--- a/api/tests/test_transport.py
+++ b/api/tests/test_transport.py
@@ -231,3 +231,52 @@ def test_localapi_parses_real_tailscaled_response(tmp_path):
 
     thread.join(timeout=5.0)
     assert result == _FAKE_STATUS
+
+
+def test_localapi_selects_transport_by_platform():
+    """Default transport follows the OS: named pipe on Windows, unix socket else."""
+    from api.transport import factory as F
+
+    assert TailscaledLocalAPI()._use_pipe == F._IS_WINDOWS
+
+
+def test_localapi_windows_uses_the_named_pipe(monkeypatch):
+    """On native Windows the request goes over the named pipe (not the unix socket),
+    and a real `200` response parses."""
+    from api.transport import factory as F
+
+    canned = (
+        b"HTTP/1.0 200 OK\r\nContent-Type: application/json\r\n\r\n"
+        + json.dumps(_FAKE_STATUS).encode()
+    )
+    seen = {}
+
+    def fake_pipe(pipe_path, request):
+        seen["pipe_path"], seen["request"] = pipe_path, request
+        return canned
+
+    monkeypatch.setattr(F, "_windows_pipe_roundtrip", fake_pipe)
+    monkeypatch.setattr(
+        F, "_unix_socket_roundtrip",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("unix socket on Windows")),
+    )
+
+    assert TailscaledLocalAPI(use_pipe=True).status() == _FAKE_STATUS
+    assert "ProtectedPrefix" in seen["pipe_path"]  # the Windows Tailscale pipe
+    assert seen["request"].startswith(b"GET /localapi/v0/status HTTP/1.0")
+
+
+def test_localapi_posix_uses_the_unix_socket(monkeypatch):
+    """On POSIX the request goes over the unix socket, never the named pipe."""
+    from api.transport import factory as F
+
+    monkeypatch.setattr(
+        F, "_windows_pipe_roundtrip",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("named pipe on POSIX")),
+    )
+    monkeypatch.setattr(
+        F, "_unix_socket_roundtrip",
+        lambda path, req: b"HTTP/1.0 200 OK\r\n\r\n" + json.dumps(_FAKE_STATUS).encode(),
+    )
+
+    assert TailscaledLocalAPI(use_pipe=False).status() == _FAKE_STATUS

--- a/api/tests/test_transport.py
+++ b/api/tests/test_transport.py
@@ -167,3 +167,67 @@ def test_factory_reads_env(monkeypatch):
 def test_factory_rejects_unknown():
     with pytest.raises(ValueError):
         create_transport("headscale")
+
+
+# --- TailscaledLocalAPI wire behaviour --------------------------------------
+# The adapter contract tests above use a faked LocalAPI; these exercise the real
+# socket client against a stand-in tailscaled. The Go server emits a
+# Transfer-Encoding: chunked body on HTTP/1.1, which the minimal client does not
+# decode -- so the request must be HTTP/1.0 (close-delimited body).
+
+import json
+import socket
+import threading
+
+from api.transport.factory import TailscaledLocalAPI
+
+_FAKE_STATUS = {"BackendState": "Running", "Self": {"TailscaleIPs": ["100.0.0.1"]}}
+
+
+def _respond_like_tailscaled(srv):
+    """Serve one request: chunked on HTTP/1.1 (as Go does), raw body on HTTP/1.0."""
+    try:
+        conn, _ = srv.accept()
+    except OSError:
+        return
+    with conn:
+        req = b""
+        while b"\r\n\r\n" not in req:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            req += chunk
+        body = json.dumps(_FAKE_STATUS).encode()
+        request_line = req.split(b"\r\n", 1)[0]
+        if b"HTTP/1.1" in request_line:
+            payload = (
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                b"Transfer-Encoding: chunked\r\n\r\n"
+                + f"{len(body):x}".encode()
+                + b"\r\n"
+                + body
+                + b"\r\n0\r\n\r\n"
+            )
+        else:
+            payload = (
+                b"HTTP/1.0 200 OK\r\nContent-Type: application/json\r\n\r\n" + body
+            )
+        conn.sendall(payload)
+    srv.close()
+
+
+def test_localapi_parses_real_tailscaled_response(tmp_path):
+    """Regression: a healthy tailscaled must yield a parsed dict. Fails if the
+    client requests HTTP/1.1 (the stand-in then chunks and the body won't parse)."""
+    sock_path = str(tmp_path / "tailscaled.sock")
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(sock_path)
+    srv.listen(1)
+    srv.settimeout(5.0)
+    thread = threading.Thread(target=_respond_like_tailscaled, args=(srv,), daemon=True)
+    thread.start()
+
+    result = TailscaledLocalAPI(socket_path=sock_path).status()
+
+    thread.join(timeout=5.0)
+    assert result == _FAKE_STATUS

--- a/api/tests/test_transport.py
+++ b/api/tests/test_transport.py
@@ -1,0 +1,169 @@
+"""Adapter-contract tests for the transport providers.
+
+Both adapters are exercised against the same behavioural contract
+(transport.md's table) so substitutability holds. Tailscale uses a faked
+LocalAPI -- no live tailnet.
+"""
+
+import pytest
+
+from api.transport import (
+    LoopbackTransport,
+    TailscaleTransport,
+    TransportProvider,
+    create_transport,
+)
+
+
+# --- Loopback ---------------------------------------------------------------
+
+
+def test_loopback_binds_to_loopback_never_wildcard():
+    t = LoopbackTransport()
+    assert t.bind_host() == "127.0.0.1"
+    assert t.bind_host() != "0.0.0.0"
+
+
+def test_loopback_never_advertises_a_host():
+    # Can't pair a remote phone to localhost -> None so pair refuses.
+    assert LoopbackTransport().advertise_host() is None
+
+
+def test_loopback_is_always_available():
+    assert LoopbackTransport().is_available() is True
+
+
+@pytest.mark.parametrize(
+    "ip,allowed",
+    [
+        ("127.0.0.1", True),
+        ("127.0.0.5", True),
+        ("100.101.102.103", False),
+        ("192.168.1.10", False),
+        ("not-an-ip", False),
+    ],
+)
+def test_loopback_authorizes_only_loopback(ip, allowed):
+    assert LoopbackTransport().is_authorized_source(ip) is allowed
+
+
+def test_loopback_status_shape():
+    s = LoopbackTransport().status()
+    assert s["name"] == "loopback"
+    assert s["available"] is True
+    assert s["advertise_host"] is None
+
+
+def test_loopback_satisfies_protocol():
+    assert isinstance(LoopbackTransport(), TransportProvider)
+
+
+# --- Tailscale (faked LocalAPI) ---------------------------------------------
+
+
+class FakeLocalAPI:
+    def __init__(self, status=None, known_peers=None):
+        self._status = status
+        self._known_peers = set(known_peers or [])
+
+    def status(self):
+        return self._status
+
+    def whois(self, peer_ip):
+        return {"Node": {"Name": "phone"}} if peer_ip in self._known_peers else None
+
+
+_UP_STATUS = {
+    "BackendState": "Running",
+    "Self": {
+        "TailscaleIPs": ["100.101.102.103", "fd7a:115c::1"],
+        "DNSName": "my-box.tailnet-1234.ts.net.",
+    },
+}
+
+
+def test_tailscale_binds_to_tailnet_ip_never_wildcard_or_loopback():
+    t = TailscaleTransport(FakeLocalAPI(status=_UP_STATUS))
+    assert t.bind_host() == "100.101.102.103"
+    assert t.bind_host() != "0.0.0.0"
+    assert t.bind_host() != "127.0.0.1"
+
+
+def test_tailscale_advertises_magicdns_never_loopback():
+    t = TailscaleTransport(FakeLocalAPI(status=_UP_STATUS))
+    host = t.advertise_host()
+    assert host == "my-box.tailnet-1234.ts.net"
+    assert host != "127.0.0.1"
+
+
+def test_tailscale_advertises_ip_when_no_magicdns():
+    status = {"BackendState": "Running", "Self": {"TailscaleIPs": ["100.1.2.3"]}}
+    assert TailscaleTransport(FakeLocalAPI(status=status)).advertise_host() == "100.1.2.3"
+
+
+def test_tailscale_unavailable_when_socket_down():
+    t = TailscaleTransport(FakeLocalAPI(status=None))
+    assert t.is_available() is False
+    assert t.advertise_host() is None
+
+
+def test_tailscale_unavailable_when_logged_out():
+    status = {"BackendState": "NeedsLogin", "Self": {"TailscaleIPs": ["100.1.2.3"]}}
+    assert TailscaleTransport(FakeLocalAPI(status=status)).is_available() is False
+
+
+def test_tailscale_bind_host_raises_when_unavailable():
+    with pytest.raises(RuntimeError):
+        TailscaleTransport(FakeLocalAPI(status=None)).bind_host()
+
+
+def test_tailscale_authorizes_peer_via_whois():
+    api = FakeLocalAPI(status=_UP_STATUS, known_peers={"100.64.5.6"})
+    t = TailscaleTransport(api)
+    assert t.is_authorized_source("100.64.5.6") is True
+
+
+def test_tailscale_falls_back_to_cgnat_range_when_whois_empty():
+    # WhoIs returns nothing but the address is in 100.64.0.0/10.
+    t = TailscaleTransport(FakeLocalAPI(status=_UP_STATUS))
+    assert t.is_authorized_source("100.99.99.99") is True
+
+
+def test_tailscale_rejects_non_tailnet_source():
+    t = TailscaleTransport(FakeLocalAPI(status=_UP_STATUS))
+    assert t.is_authorized_source("192.168.1.50") is False
+    assert t.is_authorized_source("8.8.8.8") is False
+    assert t.is_authorized_source("garbage") is False
+
+
+def test_tailscale_status_shape():
+    s = TailscaleTransport(FakeLocalAPI(status=_UP_STATUS)).status()
+    assert s["name"] == "tailscale"
+    assert s["available"] is True
+    assert s["advertise_host"] == "my-box.tailnet-1234.ts.net"
+
+
+def test_tailscale_satisfies_protocol():
+    assert isinstance(TailscaleTransport(FakeLocalAPI()), TransportProvider)
+
+
+# --- Factory ----------------------------------------------------------------
+
+
+def test_factory_defaults_to_loopback(monkeypatch):
+    monkeypatch.delenv("VADGR_TRANSPORT", raising=False)
+    assert isinstance(create_transport(), LoopbackTransport)
+
+
+def test_factory_selects_tailscale():
+    assert isinstance(create_transport("tailscale"), TailscaleTransport)
+
+
+def test_factory_reads_env(monkeypatch):
+    monkeypatch.setenv("VADGR_TRANSPORT", "tailscale")
+    assert isinstance(create_transport(), TailscaleTransport)
+
+
+def test_factory_rejects_unknown():
+    with pytest.raises(ValueError):
+        create_transport("headscale")

--- a/api/transport/__init__.py
+++ b/api/transport/__init__.py
@@ -1,0 +1,13 @@
+"""Pluggable transport providers (loopback / tailscale)."""
+
+from .base import TransportProvider
+from .loopback import LoopbackTransport
+from .tailscale import TailscaleTransport
+from .factory import create_transport
+
+__all__ = [
+    "TransportProvider",
+    "LoopbackTransport",
+    "TailscaleTransport",
+    "create_transport",
+]

--- a/api/transport/base.py
+++ b/api/transport/base.py
@@ -1,0 +1,38 @@
+"""The transport port -- the only abstraction routes/middleware depend on."""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TransportProvider(Protocol):
+    """Pluggable network transport. Adapters honour the contract table in
+    ``design/vadgr/0.3.0/transport.md`` so callers never branch on the concrete
+    type -- they depend only on this protocol (DIP)."""
+
+    name: str
+
+    def bind_host(self) -> str:
+        """Interface uvicorn binds to. The transport's own address -- NEVER
+        0.0.0.0. (Loopback: '127.0.0.1'; Tailscale: the node's 100.x IP.)"""
+        ...
+
+    def advertise_host(self) -> Optional[str]:
+        """Address to embed in the pairing QR (reachable by the phone). The
+        tailnet MagicDNS name / 100.x IP. ``None`` when the transport can't be
+        paired to remotely (loopback, or tailscale down) -- the pair endpoint
+        then refuses instead of advertising localhost."""
+        ...
+
+    def is_available(self) -> bool:
+        """Transport up and ready (e.g. tailscaled running + logged in)."""
+        ...
+
+    def is_authorized_source(self, peer_ip: str) -> bool:
+        """Gate 1: is this connection from an allowed peer?"""
+        ...
+
+    def status(self) -> dict:
+        """Diagnostics for GET /api/health."""
+        ...

--- a/api/transport/factory.py
+++ b/api/transport/factory.py
@@ -33,8 +33,11 @@ class TailscaledLocalAPI:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
                 sock.settimeout(2.0)
                 sock.connect(self._socket_path)
+                # HTTP/1.0: tailscaled's Go server uses Transfer-Encoding: chunked
+                # on HTTP/1.1, which this minimal client does not decode. HTTP/1.0
+                # delimits the body by connection close, so the JSON arrives raw.
                 req = (
-                    f"GET {path} HTTP/1.1\r\n"
+                    f"GET {path} HTTP/1.0\r\n"
                     "Host: local-tailscaled.sock\r\n"
                     "Connection: close\r\n\r\n"
                 )

--- a/api/transport/factory.py
+++ b/api/transport/factory.py
@@ -5,58 +5,148 @@ from __future__ import annotations
 import json
 import os
 import socket
+import sys
 from typing import Optional
 
 from .base import TransportProvider
 from .loopback import LoopbackTransport
 from .tailscale import TailscaleTransport
 
-
-# Default unix socket for the Tailscale LocalAPI on Linux/macOS.
+# The tailscaled LocalAPI endpoint differs by OS:
+#   - Linux / macOS / WSL : a unix socket.
+#   - native Windows      : a named pipe whose server *impersonates* the client to
+#     authorize it, so the client must open the pipe allowing impersonation.
 _TAILSCALED_SOCKET = os.environ.get(
     "VADGR_TAILSCALED_SOCKET", "/var/run/tailscale/tailscaled.sock"
 )
+_TAILSCALED_PIPE = os.environ.get(
+    "VADGR_TAILSCALED_PIPE",
+    r"\\.\pipe\ProtectedPrefix\Administrators\Tailscale\tailscaled",
+)
+
+_IS_WINDOWS = sys.platform.startswith("win")
+
+
+def _unix_socket_roundtrip(socket_path: str, request: bytes) -> Optional[bytes]:
+    """Send ``request`` over a unix-socket HTTP server; return the raw response."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(2.0)
+            sock.connect(socket_path)
+            sock.sendall(request)
+            chunks = []
+            while True:
+                data = sock.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+        return b"".join(chunks)
+    except (OSError, socket.timeout):
+        return None
+
+
+def _windows_pipe_roundtrip(pipe_path: str, request: bytes) -> Optional[bytes]:
+    """Send ``request`` over the Windows named pipe; return the raw response.
+
+    tailscaled's Windows LocalAPI impersonates the named-pipe client to authorize
+    it, so the pipe must be opened with ``SECURITY_SQOS_PRESENT |
+    SECURITY_IMPERSONATION`` — Python's ``open()`` does not, so we ``CreateFileW``
+    via ``ctypes`` (no third-party dep). Verified non-elevated against a live
+    Windows ``tailscaled``.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except Exception:
+        return None
+
+    GENERIC_READ = 0x80000000
+    GENERIC_WRITE = 0x40000000
+    OPEN_EXISTING = 3
+    SECURITY_SQOS_PRESENT = 0x00100000
+    SECURITY_IMPERSONATION = 0x00020000  # SecurityImpersonation(2) << 16
+    INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+    try:
+        k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    except Exception:
+        return None
+    k32.CreateFileW.restype = wintypes.HANDLE
+    k32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD, ctypes.c_void_p,
+        wintypes.DWORD, wintypes.DWORD, wintypes.HANDLE,
+    ]
+    k32.WriteFile.argtypes = [
+        wintypes.HANDLE, ctypes.c_void_p, wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD), ctypes.c_void_p,
+    ]
+    k32.ReadFile.argtypes = [
+        wintypes.HANDLE, ctypes.c_void_p, wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD), ctypes.c_void_p,
+    ]
+
+    handle = k32.CreateFileW(
+        pipe_path, GENERIC_READ | GENERIC_WRITE, 0, None, OPEN_EXISTING,
+        SECURITY_SQOS_PRESENT | SECURITY_IMPERSONATION, None,
+    )
+    if not handle or handle == INVALID_HANDLE_VALUE:
+        return None
+    try:
+        written = wintypes.DWORD(0)
+        if not k32.WriteFile(handle, request, len(request), ctypes.byref(written), None):
+            return None
+        buf = ctypes.create_string_buffer(65536)
+        read = wintypes.DWORD(0)
+        chunks = []
+        while True:
+            ok = k32.ReadFile(handle, buf, 65536, ctypes.byref(read), None)
+            if not ok or read.value == 0:
+                break
+            chunks.append(buf.raw[: read.value])
+        return b"".join(chunks)
+    finally:
+        k32.CloseHandle(handle)
 
 
 class TailscaledLocalAPI:
-    """Talks to the ``tailscaled`` LocalAPI over its unix socket.
+    """Talks to the ``tailscaled`` LocalAPI.
 
-    HTTP-over-unix: the socket speaks HTTP/1.1; the Host header is a fixed
-    sentinel (``local-tailscaled.sock``) per Tailscale's convention.
+    Transport is per-OS — a **unix socket** on Linux/macOS/WSL, a **named pipe**
+    on native Windows — but the request is identical: HTTP/1.0 with the fixed Host
+    sentinel ``local-tailscaled.sock`` (HTTP/1.0 because the Go server chunks
+    HTTP/1.1 bodies, which this minimal client does not decode).
     """
 
-    def __init__(self, socket_path: str = _TAILSCALED_SOCKET):
+    def __init__(
+        self,
+        socket_path: str = _TAILSCALED_SOCKET,
+        *,
+        pipe_path: str = _TAILSCALED_PIPE,
+        use_pipe: Optional[bool] = None,
+    ):
         self._socket_path = socket_path
+        self._pipe_path = pipe_path
+        self._use_pipe = _IS_WINDOWS if use_pipe is None else use_pipe
+
+    def _roundtrip(self, request: bytes) -> Optional[bytes]:
+        if self._use_pipe:
+            return _windows_pipe_roundtrip(self._pipe_path, request)
+        return _unix_socket_roundtrip(self._socket_path, request)
 
     def _get(self, path: str) -> Optional[dict]:
-        try:
-            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-                sock.settimeout(2.0)
-                sock.connect(self._socket_path)
-                # HTTP/1.0: tailscaled's Go server uses Transfer-Encoding: chunked
-                # on HTTP/1.1, which this minimal client does not decode. HTTP/1.0
-                # delimits the body by connection close, so the JSON arrives raw.
-                req = (
-                    f"GET {path} HTTP/1.0\r\n"
-                    "Host: local-tailscaled.sock\r\n"
-                    "Connection: close\r\n\r\n"
-                )
-                sock.sendall(req.encode("ascii"))
-                chunks = []
-                while True:
-                    data = sock.recv(65536)
-                    if not data:
-                        break
-                    chunks.append(data)
-        except (OSError, socket.timeout):
+        request = (
+            f"GET {path} HTTP/1.0\r\n"
+            "Host: local-tailscaled.sock\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode("ascii")
+        raw = self._roundtrip(request)
+        if not raw:
             return None
-        raw = b"".join(chunks)
         sep = raw.find(b"\r\n\r\n")
         if sep == -1:
             return None
         head, body = raw[:sep], raw[sep + 4 :]
-        status_line = head.split(b"\r\n", 1)[0]
-        if b" 200 " not in status_line:
+        if b" 200 " not in head.split(b"\r\n", 1)[0]:
             return None
         try:
             return json.loads(body.decode("utf-8"))

--- a/api/transport/factory.py
+++ b/api/transport/factory.py
@@ -1,0 +1,79 @@
+"""Transport selection. ``VADGR_TRANSPORT`` picks the adapter (loopback default)."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from typing import Optional
+
+from .base import TransportProvider
+from .loopback import LoopbackTransport
+from .tailscale import TailscaleTransport
+
+
+# Default unix socket for the Tailscale LocalAPI on Linux/macOS.
+_TAILSCALED_SOCKET = os.environ.get(
+    "VADGR_TAILSCALED_SOCKET", "/var/run/tailscale/tailscaled.sock"
+)
+
+
+class TailscaledLocalAPI:
+    """Talks to the ``tailscaled`` LocalAPI over its unix socket.
+
+    HTTP-over-unix: the socket speaks HTTP/1.1; the Host header is a fixed
+    sentinel (``local-tailscaled.sock``) per Tailscale's convention.
+    """
+
+    def __init__(self, socket_path: str = _TAILSCALED_SOCKET):
+        self._socket_path = socket_path
+
+    def _get(self, path: str) -> Optional[dict]:
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(2.0)
+                sock.connect(self._socket_path)
+                req = (
+                    f"GET {path} HTTP/1.1\r\n"
+                    "Host: local-tailscaled.sock\r\n"
+                    "Connection: close\r\n\r\n"
+                )
+                sock.sendall(req.encode("ascii"))
+                chunks = []
+                while True:
+                    data = sock.recv(65536)
+                    if not data:
+                        break
+                    chunks.append(data)
+        except (OSError, socket.timeout):
+            return None
+        raw = b"".join(chunks)
+        sep = raw.find(b"\r\n\r\n")
+        if sep == -1:
+            return None
+        head, body = raw[:sep], raw[sep + 4 :]
+        status_line = head.split(b"\r\n", 1)[0]
+        if b" 200 " not in status_line:
+            return None
+        try:
+            return json.loads(body.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return None
+
+    def status(self) -> Optional[dict]:
+        return self._get("/localapi/v0/status")
+
+    def whois(self, peer_ip: str) -> Optional[dict]:
+        return self._get(f"/localapi/v0/whois?addr={peer_ip}")
+
+
+def create_transport(name: Optional[str] = None) -> TransportProvider:
+    """Build the configured transport. ``name`` overrides ``VADGR_TRANSPORT``."""
+    selected = (name or os.environ.get("VADGR_TRANSPORT", "loopback")).strip().lower()
+    if selected == "tailscale":
+        return TailscaleTransport(local_api=TailscaledLocalAPI())
+    if selected == "loopback":
+        return LoopbackTransport()
+    raise ValueError(
+        f"Unknown VADGR_TRANSPORT={selected!r}. Expected 'loopback' or 'tailscale'."
+    )

--- a/api/transport/loopback.py
+++ b/api/transport/loopback.py
@@ -1,0 +1,39 @@
+"""Loopback transport -- the dev / single-machine default.
+
+Binds to 127.0.0.1 and authorizes only loopback peers. It deliberately
+cannot advertise a host: there is no address a remote phone could reach,
+so ``advertise_host()`` returns ``None`` and the pair endpoint refuses
+rather than handing out a useless localhost QR.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Optional
+
+
+class LoopbackTransport:
+    name = "loopback"
+
+    def bind_host(self) -> str:
+        return "127.0.0.1"
+
+    def advertise_host(self) -> Optional[str]:
+        return None
+
+    def is_available(self) -> bool:
+        return True
+
+    def is_authorized_source(self, peer_ip: str) -> bool:
+        try:
+            return ipaddress.ip_address(peer_ip) in ipaddress.ip_network("127.0.0.0/8")
+        except ValueError:
+            return False
+
+    def status(self) -> dict:
+        return {
+            "name": self.name,
+            "available": True,
+            "advertise_host": None,
+            "bind_host": self.bind_host(),
+        }

--- a/api/transport/tailscale.py
+++ b/api/transport/tailscale.py
@@ -1,0 +1,112 @@
+"""Tailscale transport -- exposes the API over the tailnet only.
+
+Reachability + peer identity come from the Tailscale **LocalAPI** (the
+``tailscaled`` unix socket), preferred over shelling out to
+``tailscale status --json``. The LocalAPI client is injected so the adapter
+is unit-testable with a fake WhoIs / status (no live tailnet needed).
+
+Authorization is structural-and-checked: bind only to the node's 100.x
+interface (so non-tailnet peers can't even connect at the socket level),
+and additionally verify each peer is a tailnet member via WhoIs, falling
+back to the 100.64.0.0/10 CGNAT range when WhoIs is unavailable.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Optional, Protocol
+
+
+# Tailscale assigns node addresses from the CGNAT range 100.64.0.0/10.
+_TAILNET_CGNAT = ipaddress.ip_network("100.64.0.0/10")
+
+
+class LocalAPI(Protocol):
+    """The slice of the Tailscale LocalAPI this adapter needs."""
+
+    def status(self) -> Optional[dict]:
+        """Parsed ``tailscaled`` status, or None when unavailable/logged out."""
+        ...
+
+    def whois(self, peer_ip: str) -> Optional[dict]:
+        """Identity of a peer by IP, or None if not a tailnet member."""
+        ...
+
+
+class TailscaleTransport:
+    name = "tailscale"
+
+    def __init__(self, local_api: LocalAPI):
+        self._api = local_api
+
+    def _self_ip(self) -> Optional[str]:
+        status = self._api.status()
+        if not status:
+            return None
+        self_node = status.get("Self") or {}
+        ips = self_node.get("TailscaleIPs") or []
+        for ip in ips:
+            try:
+                if ipaddress.ip_address(ip).version == 4:
+                    return ip
+            except ValueError:
+                continue
+        return ips[0] if ips else None
+
+    def _magic_dns(self) -> Optional[str]:
+        status = self._api.status()
+        if not status:
+            return None
+        self_node = status.get("Self") or {}
+        dns = self_node.get("DNSName")
+        if dns:
+            return dns.rstrip(".")
+        return None
+
+    def bind_host(self) -> str:
+        """The node's 100.x address. Raises if the transport is unavailable --
+        callers must check ``is_available()`` first."""
+        ip = self._self_ip()
+        if not ip:
+            raise RuntimeError(
+                "Tailscale transport unavailable: tailscaled not running or logged out."
+            )
+        return ip
+
+    def advertise_host(self) -> Optional[str]:
+        if not self.is_available():
+            return None
+        return self._magic_dns() or self._self_ip()
+
+    def is_available(self) -> bool:
+        status = self._api.status()
+        if not status:
+            return False
+        # BackendState == "Running" means up + logged in.
+        if status.get("BackendState") not in (None, "Running"):
+            return False
+        return self._self_ip() is not None
+
+    def is_authorized_source(self, peer_ip: str) -> bool:
+        try:
+            addr = ipaddress.ip_address(peer_ip)
+        except ValueError:
+            return False
+        # Prefer an authoritative WhoIs identity check.
+        try:
+            who = self._api.whois(peer_ip)
+        except Exception:
+            who = None
+        if who is not None:
+            return True
+        # Fall back to the CGNAT range when WhoIs is unavailable.
+        return addr in _TAILNET_CGNAT
+
+    def status(self) -> dict:
+        available = self.is_available()
+        return {
+            "name": self.name,
+            "available": available,
+            "advertise_host": self.advertise_host() if available else None,
+            "bind_host": self._self_ip(),
+        }

--- a/api/websocket/manager.py
+++ b/api/websocket/manager.py
@@ -16,12 +16,16 @@ class ConnectionManager:
         self._connections: dict[str, list[WebSocket]] = {}
         # Buffer events so late-connecting clients receive the full history.
         self._buffers: dict[str, list[dict]] = {}
+        # Track which device (if any) owns each socket, for revocation.
+        self._device_sockets: dict[str, list[WebSocket]] = {}
 
-    async def connect(self, run_id: str, websocket: WebSocket):
+    async def connect(self, run_id: str, websocket: WebSocket, device_id: str | None = None):
         await websocket.accept()
         if run_id not in self._connections:
             self._connections[run_id] = []
         self._connections[run_id].append(websocket)
+        if device_id:
+            self._device_sockets.setdefault(device_id, []).append(websocket)
 
         # Replay any buffered events to the newly connected client.
         for event in self._buffers.get(run_id, []):
@@ -37,6 +41,22 @@ class ConnectionManager:
             ]
             if not self._connections[run_id]:
                 del self._connections[run_id]
+        for device_id, socks in list(self._device_sockets.items()):
+            self._device_sockets[device_id] = [ws for ws in socks if ws is not websocket]
+            if not self._device_sockets[device_id]:
+                del self._device_sockets[device_id]
+
+    async def disconnect_device(self, device_id: str):
+        """Close every live socket owned by a (revoked) device."""
+        for ws in list(self._device_sockets.get(device_id, [])):
+            try:
+                await ws.close(code=4003, reason="Device revoked")
+            except Exception:
+                pass
+            for run_id in list(self._connections.keys()):
+                if ws in self._connections.get(run_id, []):
+                    self.disconnect(run_id, ws)
+        self._device_sockets.pop(device_id, None)
 
     async def emit(self, run_id: str, event_type: str, data: dict[str, Any] | None = None):
         event = make_event(event_type, data)

--- a/cli/commands/pair_cmd.py
+++ b/cli/commands/pair_cmd.py
@@ -1,0 +1,72 @@
+"""``vadgr pair`` -- mint a pairing token and render a terminal QR.
+
+Hits the same ``POST /api/auth/pair`` endpoint the frontend card uses, builds
+the shared ``vadgr://pair`` deep link, and renders it as a Unicode QR in the
+terminal (for headless boxes with no GUI). The phone scans it; the raw token is
+also printed for manual entry.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+import click
+
+from cli.client import api_post
+from cli.output import print_error, print_kv, print_success
+
+
+def build_pair_uri(pair: dict) -> str:
+    """The cross-repo deep link. Param names MUST match vadgr-mobile's scanner
+    and the frontend's ``buildPairUri`` (host/port/token/name)."""
+    query = urlencode(
+        {
+            "host": pair["host"],
+            "port": str(pair["port"]),
+            "token": pair["pairing_token"],
+            "name": pair["machine_name"],
+        }
+    )
+    return f"vadgr://pair?{query}"
+
+
+def _render_qr(data: str) -> bool:
+    """Print a Unicode QR for *data*. Returns False if ``qrcode`` is missing."""
+    try:
+        import qrcode
+    except ImportError:
+        return False
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(data)
+    qr.make(fit=True)
+    qr.print_ascii(invert=True)
+    return True
+
+
+@click.command()
+@click.pass_context
+def pair(ctx):
+    """Pair a mobile device: mint a one-time token and show a QR to scan."""
+    data = api_post(ctx, "/api/auth/pair")
+    if not isinstance(data, dict) or "pairing_token" not in data:
+        print_error("Pairing failed: unexpected response from the API.")
+        raise SystemExit(1)
+
+    uri = build_pair_uri(data)
+    click.echo()
+    if not _render_qr(uri):
+        print_error(
+            "Install 'qrcode' to render the QR in the terminal (pip install qrcode)."
+        )
+        click.echo("Pairing URI (encode this in a QR or enter manually):")
+        click.echo(f"  {uri}")
+    click.echo()
+    print_kv(
+        [
+            ("Machine", data["machine_name"]),
+            ("Address", f"{data['host']}:{data['port']}"),
+            ("Pairing token", data["pairing_token"]),
+        ]
+    )
+    click.echo()
+    print_success("Scan with the Vadgr mobile app. This token is one-time and short-lived.")

--- a/cli/main.py
+++ b/cli/main.py
@@ -17,6 +17,7 @@ if sys.platform == "win32":
 
 from cli.commands.agents import agents_group
 from cli.commands.info import health, providers, computer_use
+from cli.commands.pair_cmd import pair
 from cli.commands.registry import registry_group
 from cli.commands.runs import runs_group
 from cli.commands.service import start, stop, restart, status, logs, update, api_only
@@ -52,6 +53,7 @@ cli.add_command(registry_group)
 cli.add_command(health)
 cli.add_command(providers)
 cli.add_command(computer_use)
+cli.add_command(pair)
 
 # Service commands
 cli.add_command(start)

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -2,6 +2,7 @@ click>=8.1.0
 colorama>=0.4.0
 pydantic>=2.10.0
 PyYAML>=6.0.0
+qrcode>=7.4.0
 rich>=13.0.0
 websockets>=12.0
 pytest>=8.0.0

--- a/cli/tests/test_pair_cmd.py
+++ b/cli/tests/test_pair_cmd.py
@@ -1,0 +1,60 @@
+"""Tests for `vadgr pair` -- URI builder + command rendering."""
+
+from unittest import mock
+
+from click.testing import CliRunner
+import pytest
+
+from cli.commands.pair_cmd import build_pair_uri, pair
+
+
+_PAIR_RESPONSE = {
+    "host": "my-box.tailnet-1234.ts.net",
+    "port": 8000,
+    "pairing_token": "abc123",
+    "machine_name": "Work Box",
+}
+
+
+def test_build_pair_uri_encodes_all_params():
+    uri = build_pair_uri(_PAIR_RESPONSE)
+    assert uri.startswith("vadgr://pair?")
+    assert "host=my-box.tailnet-1234.ts.net" in uri
+    assert "port=8000" in uri
+    assert "token=abc123" in uri
+    # machine_name is URL-encoded (space -> +).
+    assert "name=Work+Box" in uri
+
+
+def test_build_pair_uri_never_uses_loopback():
+    assert "127.0.0.1" not in build_pair_uri(_PAIR_RESPONSE)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_pair_command_prints_token_and_address(runner):
+    with mock.patch("cli.commands.pair_cmd.api_post") as m:
+        m.return_value = _PAIR_RESPONSE
+        result = runner.invoke(pair, [], obj={"api_url": "http://x"})
+    assert result.exit_code == 0
+    assert "abc123" in result.output
+    assert "my-box.tailnet-1234.ts.net:8000" in result.output
+
+
+def test_pair_command_falls_back_when_qr_lib_missing(runner):
+    with mock.patch("cli.commands.pair_cmd.api_post") as m, \
+         mock.patch("cli.commands.pair_cmd._render_qr", return_value=False):
+        m.return_value = _PAIR_RESPONSE
+        result = runner.invoke(pair, [], obj={"api_url": "http://x"})
+    assert result.exit_code == 0
+    assert "vadgr://pair?" in result.output
+
+
+def test_pair_command_errors_on_bad_response(runner):
+    with mock.patch("cli.commands.pair_cmd.api_post") as m:
+        m.return_value = {"unexpected": True}
+        result = runner.invoke(pair, [], obj={"api_url": "http://x"})
+    assert result.exit_code != 0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "agent-forge-frontend",
+  "name": "vadgr-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-forge-frontend",
+      "name": "vadgr-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.90.21",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
@@ -5442,6 +5443,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,11 +7,13 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",

--- a/frontend/src/api/__tests__/pairing.test.ts
+++ b/frontend/src/api/__tests__/pairing.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { pairingApi } from '../pairing';
+
+describe('pairingApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to /api/auth/pair and returns the PairResponse', async () => {
+    const body = {
+      host: 'box.ts.net',
+      port: 8000,
+      pairing_token: 'tok',
+      machine_name: 'Box',
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    }) as unknown as typeof fetch;
+
+    const result = await pairingApi.pair();
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/auth/pair',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result).toEqual(body);
+  });
+
+  it('throws the backend error message on failure', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({ error: { message: 'Tailscale isn\'t available' } }),
+    }) as unknown as typeof fetch;
+
+    await expect(pairingApi.pair()).rejects.toThrow('Tailscale');
+  });
+});

--- a/frontend/src/api/pairing.ts
+++ b/frontend/src/api/pairing.ts
@@ -1,0 +1,7 @@
+import { api } from './client';
+import type { PairResponse } from '../types/pairing';
+
+export const pairingApi = {
+  // BASE_URL already prefixes /api.
+  pair: () => api.post<PairResponse>('/auth/pair'),
+};

--- a/frontend/src/components/settings/PairDeviceCard.tsx
+++ b/frontend/src/components/settings/PairDeviceCard.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Card } from '../ui/Card';
+import { Button } from '../ui/Button';
+import { usePairing } from '../../hooks/usePairing';
+import { buildPairUri } from '../../lib/pairUri';
+
+// The backend refuses pairing (503) when the transport can't advertise a
+// reachable host; its message mentions Tailscale. Detect that case so we can
+// show a targeted hint rather than a generic error.
+function isTransportUnavailable(error: Error | null): boolean {
+  if (!error) return false;
+  const m = error.message.toLowerCase();
+  return m.includes('tailscale') || m.includes('transport');
+}
+
+export function PairDeviceCard() {
+  const { mint, data, error, isPending, isError } = usePairing();
+  const [copied, setCopied] = useState(false);
+
+  const copyToken = async () => {
+    if (!data) return;
+    try {
+      await navigator.clipboard.writeText(data.pairing_token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable -- the token is shown for manual copy anyway */
+    }
+  };
+
+  return (
+    <Card className="px-7 py-6">
+      <div className="flex items-center gap-2.5 mb-1">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--color-accent)" strokeWidth="1.3">
+          <rect x="3" y="1.5" width="10" height="13" rx="1.5" />
+          <line x1="6.5" y1="12.5" x2="9.5" y2="12.5" strokeLinecap="round" />
+        </svg>
+        <h2 className="font-heading text-lg font-semibold text-text-primary">Mobile Pairing</h2>
+      </div>
+      <p className="font-body text-xs text-text-muted font-light ml-[26px] mb-5">
+        Pair the Vadgr mobile app by scanning a one-time QR code.
+      </p>
+
+      {/* Idle / initial */}
+      {!data && !isError && (
+        <Button onClick={mint} disabled={isPending}>
+          {isPending ? 'Generating...' : 'Pair device'}
+        </Button>
+      )}
+
+      {/* Error */}
+      {isError && !data && (
+        <div className="flex flex-col gap-3">
+          {isTransportUnavailable(error) ? (
+            <p className="text-[13px] text-danger font-body" role="alert">
+              Tailscale isn&apos;t available &mdash; enable it to pair over your tailnet.
+            </p>
+          ) : (
+            <p className="text-[13px] text-danger font-body" role="alert">
+              {error?.message ?? 'Pairing failed.'}
+            </p>
+          )}
+          <div>
+            <Button variant="secondary" size="sm" onClick={mint} disabled={isPending}>
+              Retry
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Success */}
+      {data && (
+        <div className="flex flex-col gap-4">
+          <div className="self-start rounded-xl bg-white p-3">
+            <QRCodeSVG value={buildPairUri(data)} size={200} />
+          </div>
+
+          <div>
+            <div className="text-xs text-text-muted font-body mb-1">Pairing token (manual entry)</div>
+            <div className="flex items-center gap-2">
+              <code className="font-mono text-xs text-text-primary bg-bg-input rounded-[8px] px-2.5 py-1.5 break-all">
+                {data.pairing_token}
+              </code>
+              <Button variant="ghost" size="sm" onClick={copyToken}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+          </div>
+
+          <div className="text-xs text-text-muted font-body">
+            <span className="text-text-secondary">{data.machine_name}</span> &middot;{' '}
+            {data.host}:{data.port}
+          </div>
+
+          <p className="text-xs text-text-muted font-light">
+            This token is one-time and short-lived. Scan with the Vadgr mobile app.
+          </p>
+
+          <div>
+            <Button variant="secondary" size="sm" onClick={mint} disabled={isPending}>
+              {isPending ? 'Regenerating...' : 'Regenerate'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/__tests__/PairDeviceCard.test.tsx
+++ b/frontend/src/components/settings/__tests__/PairDeviceCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PairDeviceCard } from '../PairDeviceCard';
+import { usePairing } from '../../../hooks/usePairing';
+
+vi.mock('../../../hooks/usePairing', () => ({
+  usePairing: vi.fn(),
+}));
+
+const usePairingMock = usePairing as unknown as ReturnType<typeof vi.fn>;
+
+const idle = {
+  mint: vi.fn(),
+  data: undefined,
+  error: null,
+  isPending: false,
+  isError: false,
+  reset: vi.fn(),
+};
+
+beforeEach(() => {
+  usePairingMock.mockReset();
+});
+
+describe('PairDeviceCard', () => {
+  it('idle renders the Pair button', () => {
+    usePairingMock.mockReturnValue({ ...idle });
+    render(<PairDeviceCard />);
+    expect(screen.getByText('Mobile Pairing')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pair device' })).toBeInTheDocument();
+  });
+
+  it('clicking Pair triggers mint', () => {
+    const mint = vi.fn();
+    usePairingMock.mockReturnValue({ ...idle, mint });
+    render(<PairDeviceCard />);
+    fireEvent.click(screen.getByRole('button', { name: 'Pair device' }));
+    expect(mint).toHaveBeenCalledOnce();
+  });
+
+  it('success renders the QR with the vadgr://pair URI + raw token', () => {
+    const data = {
+      host: 'box.tailnet.ts.net',
+      port: 8000,
+      pairing_token: 'secret-token-xyz',
+      machine_name: 'Work Box',
+    };
+    usePairingMock.mockReturnValue({ ...idle, data });
+    const { container } = render(<PairDeviceCard />);
+
+    // QR encodes the deep link incl. the token.
+    const svg = container.querySelector('svg[value]') ?? container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    // Raw token shown for manual entry.
+    expect(screen.getByText('secret-token-xyz')).toBeInTheDocument();
+    expect(screen.getByText(/box.tailnet.ts.net:8000/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Regenerate' })).toBeInTheDocument();
+  });
+
+  it('transport-unavailable error renders the Tailscale hint + Retry', () => {
+    usePairingMock.mockReturnValue({
+      ...idle,
+      isError: true,
+      error: new Error("Tailscale isn't available to pair over your tailnet"),
+    });
+    render(<PairDeviceCard />);
+    expect(screen.getByRole('alert').textContent).toMatch(/Tailscale isn't available/i);
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('generic error renders the message + Retry', () => {
+    usePairingMock.mockReturnValue({
+      ...idle,
+      isError: true,
+      error: new Error('Something broke'),
+    });
+    render(<PairDeviceCard />);
+    expect(screen.getByRole('alert').textContent).toMatch(/Something broke/);
+  });
+});

--- a/frontend/src/hooks/__tests__/usePairing.test.tsx
+++ b/frontend/src/hooks/__tests__/usePairing.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { usePairing } from '../usePairing';
+import { pairingApi } from '../../api/pairing';
+
+vi.mock('../../api/pairing', () => ({
+  pairingApi: { pair: vi.fn() },
+}));
+
+const pairMock = pairingApi.pair as unknown as ReturnType<typeof vi.fn>;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('usePairing', () => {
+  beforeEach(() => {
+    pairMock.mockReset();
+  });
+
+  it('mints a token and exposes the PairResponse on success', async () => {
+    const response = { host: 'box.ts.net', port: 8000, pairing_token: 'tok', machine_name: 'Box' };
+    pairMock.mockResolvedValue(response);
+
+    const { result } = renderHook(() => usePairing(), { wrapper });
+    expect(result.current.isPending).toBe(false);
+
+    act(() => result.current.mint());
+
+    await waitFor(() => expect(result.current.data).toEqual(response));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('surfaces errors', async () => {
+    pairMock.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => usePairing(), { wrapper });
+    act(() => result.current.mint());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});

--- a/frontend/src/hooks/usePairing.ts
+++ b/frontend/src/hooks/usePairing.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import { pairingApi } from '../api/pairing';
+import type { PairResponse } from '../types/pairing';
+
+// Mints a one-time pairing token. The token is never persisted client-side --
+// it lives only in this mutation's `data` and is short-lived. Re-mint to refresh.
+export function usePairing() {
+  const mutation = useMutation<PairResponse, Error, void>({
+    mutationFn: () => pairingApi.pair(),
+  });
+
+  return {
+    mint: () => mutation.mutate(),
+    data: mutation.data,
+    error: mutation.error,
+    isPending: mutation.isPending,
+    isError: mutation.isError,
+    reset: mutation.reset,
+  };
+}

--- a/frontend/src/lib/__tests__/pairUri.test.ts
+++ b/frontend/src/lib/__tests__/pairUri.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { buildPairUri } from '../pairUri';
+
+const base = {
+  host: 'my-box.tailnet-1234.ts.net',
+  port: 8000,
+  pairing_token: 'abc-123',
+  machine_name: 'Work Box',
+};
+
+describe('buildPairUri', () => {
+  it('builds a vadgr://pair URI with all params', () => {
+    const uri = buildPairUri(base);
+    expect(uri.startsWith('vadgr://pair?')).toBe(true);
+    const q = new URLSearchParams(uri.split('?')[1]);
+    expect(q.get('host')).toBe('my-box.tailnet-1234.ts.net');
+    expect(q.get('port')).toBe('8000');
+    expect(q.get('token')).toBe('abc-123');
+    expect(q.get('name')).toBe('Work Box');
+  });
+
+  it('URL-encodes the machine name', () => {
+    const uri = buildPairUri({ ...base, machine_name: 'My Box & Co' });
+    expect(uri).toContain('name=My+Box+%26+Co');
+  });
+
+  it('never embeds loopback', () => {
+    expect(buildPairUri(base)).not.toContain('127.0.0.1');
+  });
+});

--- a/frontend/src/lib/pairUri.ts
+++ b/frontend/src/lib/pairUri.ts
@@ -1,0 +1,14 @@
+import type { PairResponse } from '../types/pairing';
+
+// Pure builder for the cross-repo `vadgr://pair` deep link. The param names
+// MUST match what vadgr-mobile's scanner reads and the CLI's build_pair_uri:
+// host / port / token / name.
+export function buildPairUri(p: PairResponse): string {
+  const q = new URLSearchParams({
+    host: p.host,
+    port: String(p.port),
+    token: p.pairing_token,
+    name: p.machine_name,
+  });
+  return `vadgr://pair?${q.toString()}`;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { runsApi } from '../api/runs';
 import { api } from '../api/client';
 import { PixelMoon, PixelSun, PixelGear, PixelClock } from '../components/ui/PixelIcon';
 import { getInflight, toggleComputerUse as toggleCu } from '../hooks/useComputerUse';
+import { PairDeviceCard } from '../components/settings/PairDeviceCard';
 
 const STORAGE_KEY = 'vadgr-settings';
 
@@ -265,6 +266,9 @@ export function Settings() {
           </div>
 
         </Card>
+
+        {/* Mobile Pairing */}
+        <PairDeviceCard />
 
         {/* Danger Zone */}
         <Card className="px-7 py-6 border-danger/30">

--- a/frontend/src/pages/__tests__/Settings.test.tsx
+++ b/frontend/src/pages/__tests__/Settings.test.tsx
@@ -33,6 +33,12 @@ vi.mock('../../api/client', () => ({
   },
 }));
 
+// Mock the pairing card -- its own behaviour is covered by PairDeviceCard.test.tsx;
+// here we only assert it mounts in the page.
+vi.mock('../../components/settings/PairDeviceCard', () => ({
+  PairDeviceCard: () => <div data-testid="pair-device-card" />,
+}));
+
 // Mock useComputerUse — delegate toggleComputerUse to mockPut so existing tests work,
 // but track inflight state for navigation tests.
 let mockInflight: { promise: Promise<unknown>; activating: boolean } | null = null;
@@ -60,6 +66,11 @@ describe('Settings - Computer Use Toggle', () => {
     await waitFor(() => {
       expect(screen.getByText('Disabled')).toBeTruthy();
     });
+  });
+
+  it('mounts the Mobile Pairing card', () => {
+    render(<Settings />);
+    expect(screen.getByTestId('pair-device-card')).toBeTruthy();
   });
 
   it('shows "Active" status with solid green dot when computer use is on', async () => {

--- a/frontend/src/types/pairing.ts
+++ b/frontend/src/types/pairing.ts
@@ -1,0 +1,7 @@
+// Mirrors the backend api/models/auth.py PairResponse contract.
+export interface PairResponse {
+  host: string; // tailnet address, never 127.0.0.1
+  port: number;
+  pairing_token: string; // one-time, short-lived
+  machine_name: string;
+}


### PR DESCRIPTION
## Mobile pairing & connection backend

Adds the backend that lets a mobile device pair with and reach this machine over the user's own network.

### What's new (user-visible)
- **Pair a device:** `vadgr pair` mints a one-time token and prints a QR; the same card appears in **Settings → Mobile Pairing**. Both encode a `vadgr://pair?...` deep link (host, port, token, machine name).
- **Connection transport (`VADGR_TRANSPORT`):**
  - `loopback` (default) — single machine.
  - `tailscale` — reach this machine from another device over your tailnet; the QR advertises the node's MagicDNS name.
- **Two-gate access control** on every request: the source must be an authorized peer (a tailnet member; loopback is trusted) **and** carry a valid per-device bearer token.
- **Endpoints:** `POST /api/auth/pair`, `POST /api/auth/claim`, `GET` / `DELETE /api/devices`, and a mobile run-event WebSocket stream.
- **Contract models** the mobile app consumes: `Device`, `Pair` / `Claim`, `RunEvent`.

### Testing
- 513 unit tests (transport adapters, token/auth, pairing store, device repo, routes, WebSocket).
- Verified live over a real tailnet: `pair → claim → device` persisted, and gate enforcement confirmed from a second machine (401 without a token, 200 with it).

### Note
Pairing requires a transport that can advertise a reachable address — on `loopback` it returns 503 by design (a localhost QR is useless to a phone); use `VADGR_TRANSPORT=tailscale`.
