### PR TITLE
feat(engine): native provider path + control-plane MVP (0.4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,49 @@ jobs:
       - name: Skip (no changes)
         if: steps.changes.outputs.changed == 'false'
         run: echo "No forge/ changes -- skipping tests."
+
+  # ----- engine module -----
+  engine:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for engine changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          if git diff --name-only "$BASE" HEAD | grep -qE '^engine/'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        if: steps.changes.outputs.changed == 'true'
+        run: pip install -r engine/requirements.txt
+
+      - name: Run tests with coverage
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PYTHONPATH: .
+        run: python -m pytest engine/tests/ -v --cov=engine --cov-report=term-missing
+
+      - name: Skip (no changes)
+        if: steps.changes.outputs.changed == 'false'
+        run: echo "No engine/ changes -- skipping tests."

--- a/E2E/0.4.0/e2e.md
+++ b/E2E/0.4.0/e2e.md
@@ -1,0 +1,510 @@
+# Native loop 0.4.0 - end to end test runbook
+
+Validation of the **native agent loop** and its **control-plane tools** (PR #169).
+The loop owns the conversation, the tool-use cycle, image pruning and the resume
+journal; the control-plane server gives the model eight in-process tools for
+progress, status and human-in-the-loop. Unit tests prove each piece in isolation;
+they do not prove that a real model, given a goal, finds the right tool, calls it
+with arguments it invented, and that the journal that comes out can actually
+resume a crashed run.
+
+> **Status: run on WSL, 2026-07-30. 107 of 110 cells executed, 6 findings,
+> 3 of them fixed on this branch and re-run green.** Automated gate
+> **engine 110** (was 101; +9 regression tests, each verified to fail without its
+> fix), api 516. Every axis below is **enumerated, not sampled**: each part states
+> its axes, their product, and the state of every cell. Three cells are open and
+> each says why. **F3, F5 and F6 are fixed**; F1, F2 and F4 are recorded and
+> deferred with their reason. Nothing is marked pass that was not executed and
+> read back from the journal.
+
+### Coverage
+
+| Part | Axes | Cells | Run | Open |
+|---|---|---|---|---|
+| L loop contract | 6 properties + pruning (4 x 3) | 18 | 18 | 0 |
+| C control-plane tools | 8 tools x every branch of their contract | 14 | 12 | 2 |
+| R crash + resume | prior work 2 x end-state 2 x side effect 2 | 8 | 7 | 1 |
+| P policy | mode 4 x risk 3 x denylist 2, + redaction 8, + ungated 1 | 33 | 33 | 0 |
+| N channels | channel 2 x importance 3, + routing 3, + OS 4 | 13 | 13 | 0 |
+| A auth | strategy x token state 14, + store x OS 4 | 18 | 18 | 0 |
+| M MCP host | 6 host contracts | 6 | 6 | 0 |
+| | | **110** | **107** | **3** |
+
+Collapsed deliberately, with the reason: `notify_user` x *message content* is not
+an axis (the string is opaque to the router); tool x *argument values* is not an
+axis for model-driven items - the rule from `ENGINEERING.md` §1a is to enumerate
+**outcomes**, not inputs, because the model chooses the inputs.
+
+## SCOPE EXCEPTION FOR THIS MINOR - read this first
+
+`ENGINEERING.md` §1a says a real e2e drives the product's own surface, and that a
+harness which imports the module under test is an **acceptance test**, not an
+e2e. **`0.4.0` cannot meet that bar**, and the exception is deliberate and
+bounded:
+
+- The engine ships as a **library that nothing calls**. `POST /api/agents/{id}/run`
+  goes through `ExecutionService` to the old `CLIAgentProvider`; nothing in `api/`
+  or `cli/` imports `engine/`. The PR states this under *Not in this slice*.
+- So this runbook drives the loop **directly** (`AnthropicOAuthProvider.run_agent`)
+  or through the CLI where a path exists. That is an **acceptance test**, and every
+  result below must be read as one.
+
+**The exception expires at `0.4.1`.** That patch puts the engine on the production
+path, and from that minor on the runbook drives **both real surfaces**:
+
+- **the API + the run WebSocket**, the way the phone does - the only way to know a
+  mobile call behaves, since the request/response shapes and the WS event stream
+  are what the mobile client codegens against;
+- **the CLI** (`vadgr run`, `vadgr stream`) - the on-box operator path, with its
+  own users and its own failure modes.
+
+**Neither substitutes for the other.** A green CLI run says the loop works and
+nothing about whether the JSON the phone parses is right; a green API run says the
+wire is right and nothing about the on-box path. `E2E/0.4.1/e2e.md` supersedes this
+file and covers both. Do not carry this exception forward: it exists because there
+is no surface to drive, not because importing is acceptable.
+
+## The approach
+
+Everything else in §1a still applies, and these are the rules that make the
+results mean anything:
+
+- **A real model drives it.** The loop *is* the agent here: give it a goal-level
+  task and let it choose its own tools. Never call a tool directly to "test" it -
+  that proves the function works, not that the tool is findable.
+- **Goal-level tasks, never op-level.** "Plan this work and check with me before
+  anything irreversible" - not "call `todo_write` then `request_approval`". A task
+  that names the tool has not tested discovery.
+- **The verdict comes from `trajectory.jsonl`, not the model's prose.** The journal
+  is written by the loop, not by the model, so it can contradict it. **A
+  self-reported success with no confirming journal line is a FAIL.**
+- One run at a time. Record the `run_id` of each so a finding is reproducible.
+
+## When a test surfaces a bug
+
+Finding one is the point. Root-cause it in the source citing `file:line` - a flaky
+environment is not a root cause until the code says so - fix it on the PR branch
+with a test that fails without the fix, re-run the part live, and record the patch
+in `vadgr-docs/general/PATCHES.md` with this runbook in the *found by* column.
+
+## Prerequisites
+
+- Anthropic credentials reachable: a Claude Code OAuth token, or `ANTHROPIC_API_KEY`.
+- A scratch runs dir, so a test run never lands in `~/.vadgr/runs/`:
+  `export RUNS=$(mktemp -d)`.
+- Nothing else. The loop needs no daemon, no tailnet and no phone at `0.4.0`.
+
+## Automated gate (necessary, not sufficient)
+
+Green on the branch before any live part:
+
+- `PYTHONPATH=. python3 -m pytest engine/tests/ -q` -> **110 passed** (http, auth
+  incl. per-OS token resolution, format, provider invariants, the eight
+  control-plane tools, policy, channels, trajectory, pruning, ports - plus the 9
+  regression tests this runbook's findings added, each verified to fail with its
+  fix reverted).
+- `python3 -m pytest api/tests/ -q` -> **516 passed**, no regressions.
+
+## Part L: the loop's own contract
+
+Seven properties; the pruning property is itself a 4x3 matrix.
+
+| # | Property | Expected | Status |
+|---|---|---|---|
+| L1 | Termination | no-tool task returns at `total_iterations == 1` | **pass** |
+| L2 | Journal ordering | `response -> in_flight(n) -> done(n)`, in_flight **before** dispatch | **pass** |
+| L3 | Tool error is fed back | `error` line on that `seq`, loop continues, model reads it | **pass** |
+| L4 | Multi-tool iteration | monotonic `seq`; `total_iterations` counts model calls, not tool calls | **pass** |
+| L5 | Usage accounting | per-response usage reconciles with the totals | **pass** |
+| L6 | Budget exhaustion | `MaxIterationsExceeded` raised - not a park, not a hang | **pass** |
+| L7 | Image pruning | last `keep_last` images survive; the rest become the placeholder | **pass 12/12** |
+
+**Measured:**
+
+- L1 `L1-terminate`: `total_iterations=1`, journal `{response: 1}`, no tool line,
+  final text `DONE`. The loop stops when the model stops asking for tools.
+- L3 `L3-toolerror`: the model sent `status: "completed"`; the tool's vocabulary is
+  `pending|in_progress|done|cancelled`, so it raised. Journal:
+  `{response: 2, in_flight: 1, error: 1}` - the `in_flight` at `seq 0` is closed by
+  an **`error`**, not a `done`, the loop continued, and the model quoted the message
+  back verbatim. **A tool error is data, not a crash.** (The off-vocabulary guess
+  itself is **F3**.)
+- L4 `partC`: 3 tool calls across 4 iterations, `seq` 0,1,2 with no gap.
+- L6 `L6-budget`: budget 1, task needs three turns -> `MaxIterationsExceeded: Agent
+  did not finish in 1 iterations`. The completed first call is journaled
+  `in_flight`+`done` before the raise, so the journal is resumable.
+- L5 `v-todo`: per-response `usage` lines `1303+1493+1623 = 4419` input and
+  `134+95+163 = 392` output, **exactly** the reported totals. The loop's own
+  accounting line was never redacted; the *copy inside the recorded response* was,
+  which is **F6** - fixed, and both now agree line by line.
+- L7 `prune_old_images`: `images {0,1,3,5}` x `keep_last {0,1,3}` = 12 cells, all
+  correct - `intact == min(images, keep_last)`, `pruned == max(0, images-keep_last)`,
+  including the boundary `keep_last=0` and images nested inside `tool_result`.
+
+## Part C: every control-plane tool x every outcome
+
+Axes: **8 tools**, and for the human-facing ones **every branch of their contract**
+(approve / reject / timeout / denylisted, options / no options, override channel).
+Model-driven, so the rule is *enumerate the outcomes*, not the arguments.
+
+| # | Tool | Outcome under test | Status |
+|---|---|---|---|
+| C1 | `todo_write` | model writes a plan unprompted by tool name | **pass** |
+| C2 | `todo_update` | status transition on a real id | **pass** |
+| C2b | `todo_update` | a synonym status (`completed`) is accepted, not an error | **pass** (F3 fix) |
+| C3 | `report_progress` | `progress` event + journal line | **pass** |
+| C4 | `get_run_status` | model **quotes the result back accurately** | **pass** |
+| C5 | `request_approval` | **approve** -> loop resumes and acts | not run* |
+| C6 | `request_approval` | **reject** -> normal tool result, loop continues | **pass** |
+| C7 | `request_approval` | **timeout** -> normal tool result, fail-closed | **pass** |
+| C8 | `request_approval` | **denylisted** -> `auto_deny` before the human | **pass** (Part P, 12 cells) |
+| C9 | `ask_user` | free answer steers what happens next | **pass** |
+| C10 | `ask_user` | **negative**: unambiguous task must NOT ask | **pass** |
+| C11 | `ask_user` | with `options` -> answer constrained to them | not run |
+| C12 | `propose_plan` | proposed **before** execution, and blocks | **pass** |
+| C13 | `notify_user` | routed to the active channel with `importance` | **pass** |
+| C14 | `notify_user` | per-call `channel` override reaches the other channel | **pass** (Part N) |
+
+\* C5's task produced `ask_user` instead - the model judged it needed information
+first. The tool worked; the *approve* branch of `request_approval` is still owed.
+
+**Measured:**
+
+- C2 `C2-todo`: `todo_write -> {"ok": true, "todos": [...]}`, then
+  `todo_update -> {"ok": true, "todo": {"id": "1", ..., "status": "done"}}`. An
+  unknown id raises `unknown todo id: <id>` (`engine/tools/todo.py:79`) - the id is
+  validated, not silently accepted.
+- C6 `{"decision": "reject", "note": "reject"}`, 1 `await_user` line, loop
+  continued, model replied `REJECTED` and stopped. **A rejection is not a crash.**
+- C7 timed out -> `{"decision": "reject"}`. **Timeout is fail-closed**, arrives as
+  an ordinary tool result, loop continued, no exception.
+- C9 `{"answer": "approve", "timed_out": false}`, 1 `await_user` line.
+- C10 `C10-noask`: "add 17 and 25" -> `total_iterations=1`, journal `{response: 1}`,
+  **no tool call at all**, final text `42`. The tools do not make it chatty.
+- C12 `C12-plan`: `propose_plan -> {"decision": "approve", "feedback": "ok"}` with
+  an `await_user` line in the journal - the plan **blocks** for the human, and it is
+  the model's first action, before any execution.
+- C13 `C13-notify`: `{"ok": true, "delivered": ["cli"]}`, CLI line
+  `[info] Nightly backup completed successfully.` - the model picked `low` for a
+  routine event, and `low` renders as `[info]`.
+
+## Part R: crash and resume - the state matrix
+
+Axes: **prior completed work (2) x journal end-state (2) x countable side effect
+(2) = 8 cells.** The failure to hunt is **silent replay**: a replayed run also ends
+`completed`, so "it finished after a restart" proves nothing. Every cell here uses
+`notify_user` as the countable effect - each call appends one line to a file, so a
+replay is visible as a duplicated line.
+
+| # | prior work | ends | side effect | Expected | Status |
+|---|---|---|---|---|---|
+| R1 | none | clean | n/a | no dangling; `find_latest` does **not** offer it | **pass** |
+| R2 | none | **dangling** | no | journal ends on an unmatched `in_flight` | **pass** |
+| R3 | none | dangling | no | `find_latest()` identifies it by the dangling record | **pass** |
+| R4 | none | dangling | no | `resume()`: `next_seq` == dangling `seq` | **pass** |
+| R5 | **yes (2 calls)** | dangling | **yes, counted** | completed work **NOT** re-executed | **pass** |
+| R6 | yes | dangling | yes | dangling call revalidated via `idem`, not re-issued | **not testable at 0.4.0 - F4** |
+| R7 | yes | clean | yes | resume of a finished run offers nothing to redo | **pass** |
+| R8 | yes | clean | yes | side effect happened **exactly once** per call | **pass** |
+
+**Measured - R5, the load-bearing cell.** Run `r5`: the model was asked to notify
+three times; the process was `SIGKILL`ed **after `in_flight` was journaled for the
+third call and before it dispatched**.
+
+```
+side-effect file : 2 lines   ["[notify] one", "[notify] two"]
+journal          : seq 0 in_flight+done, seq 1 in_flight+done, seq 2 in_flight (open)
+find_latest      : "r5"
+completed_seqs   : [0, 1]
+next_seq         : 2        (== the dangling seq, not 3)
+dangling         : control__notify_user {"message": "three"}
+dangling idem    : sha256:6671b08e...babd6ce
+```
+
+A replay would have re-notified `one` and `two` and left **4** lines. The file has
+**2**. `resume()` positions at `seq 2` - the first *uncompleted* step - so the two
+finished calls are skipped, not repeated.
+
+**R7/R8** ran the same task to completion: 3 lines, `completed_seqs=[0,1,2]`,
+`dangling=None`, `next_seq=3`, and `find_latest()` returns **`None`** - a finished
+run is never offered for resume, and each call fired exactly once.
+
+## Part P: policy - the full decision matrix (24/24 cells, RUN)
+
+Axes: **auth mode (4) x declared risk (3) x denylist hit (2) = 24 cells.** The
+policy hook is a pure function, so every cell is cheap and none is sampled.
+
+| mode | risk | denylisted | outcome | run |
+|---|---|---|---|---|
+| bypass | low / medium / high | no | `auto_allow` | pass |
+| bypass | low / medium / high | **yes** | `auto_deny` | pass |
+| default | low | no | `auto_allow` | pass |
+| default | medium | no | `auto_allow` | pass |
+| default | **high** | no | **`needs_human`** | pass |
+| default | low / medium / high | **yes** | `auto_deny` | pass |
+| autonomous | low | no | `auto_allow` | pass |
+| autonomous | medium | no | `auto_allow` | pass |
+| autonomous | **high** | no | **`needs_human`** | pass |
+| autonomous | low / medium / high | **yes** | `auto_deny` | pass |
+| paranoid | low / medium / high | no | **`needs_human`** | pass |
+| paranoid | low / medium / high | **yes** | `auto_deny` | pass |
+
+**P1 Denylist precedence** - confirmed in all 12 denylisted cells: a denylist hit
+is `auto_deny` in **every** mode, `bypass` included.
+**P2 `bypass`** auto-allows all three risks. **P3 `paranoid`** consults a human at
+all three risks - confirmed live end to end (a low-risk scratch write was gated,
+rejected, and the loop continued).
+
+**P4 Redaction - pass, live and enumerated.** Run `p4b`: the model called
+`report_progress` with a payload matching the credential pattern; the journal holds
+`{"message": "build [REDACTED] finished"}` and **zero** raw occurrences of the
+value. The key/value matrix (8 cells) behaves as specified: secret-named keys are
+redacted regardless of value (including `password: null`), `sk-`/`Bearer` values are
+redacted regardless of key, nesting through lists and dicts is covered, and a
+too-short `sk-` or an English sentence containing the word "secret" is **not**
+redacted - the pattern is not a keyword filter. Over-matching is **F6**.
+
+*A note the next runbook should inherit:* the first attempt (`p4`) failed to reach
+the tool at all - the model **refused to echo what looked like a real API key** and
+wrote an explanation instead. When a model-driven test needs a specific payload,
+the payload must not look like a live secret, or the model becomes the blocker.
+
+**P5 Ungated dispatch - pass.** Run `p5` with `policy.check()` counted and the mode
+set to `paranoid` (which asks on *every* gated call): 2 tools dispatched,
+**`policy.check` called 0 times**, 0 `await_user` lines. Confirms the gate is
+reached only through `request_approval` (`engine/tools/hitl.py:64`) and that
+ordinary tool dispatch is not policed. See **F2**.
+
+## Part N: channels - where a human is actually reached
+
+Axes: **channel (2) x importance (3) = 6**, plus **routing (3)**, plus **desktop
+command selection x OS (4)**. The desktop channel takes an injectable runner, so
+its per-OS command *selection* is assertable from any host; whether the native
+command works is per-OS and owed (see the OS table).
+
+| channel | low | normal | high |
+|---|---|---|---|
+| cli | `[info] <msg>` | `[notify] <msg>` | `[!]  <msg>` |
+| desktop (Linux) | `notify-send` | `notify-send` | **`zenity`** (modal) |
+
+All 6 pass. `high` escalates in both channels - a toast on `low`/`normal`, a modal
+on `high`.
+
+**Routing (3 cells):** no override -> the active channel (`["cli"]`, 0 desktop
+commands); `channel="desktop"` -> `["desktop"]`, the CLI untouched; an unknown
+channel -> `ValueError: unknown channel: nope` rather than a silent drop.
+
+**Command selection x OS (4 cells, injected runner):**
+
+| OS | notify | request |
+|---|---|---|
+| Linux | `notify-send` | `zenity` |
+| macOS | `osascript` | `osascript` |
+| Windows | `powershell` | `powershell` |
+| WSL | `notify-send` | `zenity` (Linux-side desktop, intended) |
+
+## Part A: auth - strategy x token state
+
+Axes: **3 strategies x their token states = 16 cells**, plus **store resolution x
+OS = 4**. All 20 run.
+
+| strategy | state | Outcome | Status |
+|---|---|---|---|
+| oauth | valid | injects the cached token, **0 refresh calls** | **pass** |
+| oauth | inside the refresh window | refreshes *pre-emptively*, injects the new token | **pass** |
+| oauth | expired | refreshes, injects the new token | **pass** |
+| oauth | expired, no `refreshToken` | `CredentialsError: No refresh token available` | **pass** |
+| oauth | no credentials file | `CredentialsMissingError` naming `claude setup-token` | **pass** |
+| oauth | empty credentials block | same error - an empty block is not a valid token | **pass** |
+| oauth | refresh endpoint returns 400 | `CredentialsError: Token refresh failed (HTTP 400)` | **pass** |
+| oauth | **401 -> refresh succeeds** | token dropped, refreshed once, **retry signalled** | **pass** |
+| oauth | 401 -> refresh fails | returns `False` - terminal, no retry storm | **pass** |
+| api_key | env var set | injected as `x-api-key` | **pass** |
+| api_key | env var unset | `RuntimeError` naming the variable | **pass** |
+| api_key | 401 | `False` - terminal, a bad key is not refreshable | **pass** |
+| none | any | injects nothing | **pass** |
+| none | 401 | `False` - terminal, a local 401 is misconfiguration | **pass** |
+
+**A1 (live):** every run in this document authenticated through the OAuth path
+against the real API - the strategy is exercised end to end on every part above.
+
+**A3 store resolution x OS (4 cells):** macOS -> `KeychainTokenStore`; Linux,
+Windows and WSL -> `FileTokenStore`. WSL resolves the **Linux-side** home, as
+intended. Selection is proven from this host; the Keychain and Windows stores are
+**owed on their own OS** and are the only genuinely per-OS thing in `0.4.0`.
+
+**A4 wire-format invariants:** `user_agent = "claude-cli/2.1.2 (external, cli)"`,
+`anthropic-beta: oauth-2025-04-20,interleaved-thinking-2025-05-14`, and the Claude
+Code system prefix - all asserted by the automated gate, and any 400 from the real
+API in the live runs above would have broken every part. None did.
+
+## Part M: the MCP host
+
+Six contracts. Stub servers are correct here: the object under test is the host's
+aggregation and routing, not a model behaviour.
+
+| # | Contract | Expected | Status |
+|---|---|---|---|
+| M1 | Aggregation | every server's tools in one list | **pass** |
+| M2 | Namespacing | `<server>__<tool>`; a name in two servers does **not** shadow | **pass** |
+| M3 | A server that fails to start | run continues, its tools simply absent | **pass** (F5 fix) |
+| M4 | Duplicate server names | startup error, never a silent shadow | **pass** |
+| M5 | A tool that raises | propagates to the loop, which journals `error` (see L3) | **pass** |
+| M6 | `aclose` | every server released | **pass** |
+
+**Measured live (`v-mcp`), after the F5 fix:** a run configured with a healthy
+external server (`notes`) and a broken one (`calendar`, refusing connections)
+**completed**. The host logged
+`MCP server 'calendar' failed to start and was dropped`, the model discovered and
+called `notes__save_note`, and the run finished. Before the fix this same
+configuration raised out of `connect()` and no run started at all.
+
+**Measured (host contracts):** two servers each exposing `ask_user` aggregate to
+`control__ask_user` and `cua__ask_user`, and each routes to its own server. An
+un-namespaced name (`ask_user`) and an unknown server both raise
+`UnknownToolError` - no fallback guessing. Two servers named `cua` raise
+`MCP server name collision` at connect. `aclose()` closed both.
+
+## Findings
+
+### F1: `default` and `autonomous` are indistinguishable
+
+The enumeration shows **identical outcomes in all 24 cells**. Two of the four
+advertised modes are the same mode. Not a defect in `0.4.0` - autonomy v2 (risk
+classes, decision tables, ordered overrides) is `vadgr 0.6.0` - but it must not be
+described as a working four-mode system before then.
+
+### F2: the gate is advisory twice over
+
+**Only 5 of 24 cells consult a human**, and reaching one requires *both*:
+
+1. the model **chooses** to call `request_approval` - dispatch itself is ungated
+   (**proven live in P5**: 0 `policy.check` calls across 2 dispatched tools in
+   `paranoid` mode), `policy.check()` is called from exactly one place
+   (`engine/tools/hitl.py:64`), and there is no allowlist; **and**
+2. the model **self-declares** `risk: "high"` - the risk is the model's own
+   assessment, not a classification of the call.
+
+Observed live: asked to email an external address with sign-off, the model called
+`request_approval` with **`risk: "low"`**, so `default` mode auto-allowed it and the
+human was never asked. Sending mail off the machine is `external` - the
+highest-consequence class in the target design - and the model rated it low.
+
+### F3 (fixed): the todo status vocabulary was not the model's vocabulary
+
+`VALID_STATUSES = (pending, in_progress, done, cancelled)`
+(`engine/tools/todo.py:11`). Given a plain goal, the model reached for
+**`completed`** and got `ValueError: invalid todo status: completed`. The status is
+declared as a JSON-Schema `enum`, but the enum is **advisory** - the invalid value
+reached the tool and came back as an error string, costing an iteration. The loop
+recovered correctly (that is L3), so this was ergonomics, not correctness.
+
+**Fixed** (`engine/tools/todo.py`): the common synonyms map to the canonical
+status (`completed`/`complete`/`finished`/`success` -> `done`, `in-progress` and
+`in progress` -> `in_progress`, `canceled` -> `cancelled`, `todo` -> `pending`),
+and both errors now name what is legal - the status error lists all four values,
+the id error lists the known ids. Re-run live (`v-todo`): the same kind of task
+now produces **2 tool calls, 2 `done` lines and zero `error` lines**, where before
+it burned an iteration.
+
+### F4 (deferred, with reason): `idem` is written but read by nothing
+
+Every `in_flight` record carries `idem: sha256:...` (`engine/trajectory.py:111`)
+and `PolicyDecision` declares an `idem` field, but **no non-test code reads
+either**. `resume()`'s docstring promises a dangling action is "re-validated live
+via its `idem` before any re-do" - there is no re-do path at all, so the promise is
+untestable rather than broken. R6 is therefore **owed at the minor that wires
+resume into `run_loop`**, not owed here. The docstring should say what is built.
+
+### F5 (defect, fixed): one broken MCP server took down the whole run
+
+`MCPHost.connect()` (`engine/mcp.py:52-69`) iterates the servers and awaits
+`list_tools()` inline with no per-server guard. A server that fails to start raises
+straight out of `connect()`, so **the run never begins** and the healthy servers'
+tools are lost with it. Measured: a host of `[control, broken]` raised
+`RuntimeError: broken: cannot start`; `control__ask_user` never became available.
+
+That is exactly backwards for a daemon whose value is the tools that *do* work, and
+it was a live risk the moment a third-party MCP server was configured.
+
+**Fixed** (`engine/mcp.py`): each server's `list_tools()` is guarded; a server that
+fails to start is dropped with a warning and recorded in **`MCPHost.failed()`**, so
+a degraded host is *visible* rather than silent, and every healthy server stays
+available. A **name collision still raises** - dropping one of two same-named
+servers would silently shadow the other's tools, which is the opposite failure.
+Proven live in `v-mcp` (see Part M) and by three regression tests.
+
+### F6 (defect, fixed): the redaction regex ate the token counts
+
+`_SECRET_KEY` (`engine/trajectory.py:24`) matches the substring `token`, so it also
+matches **`input_tokens`, `output_tokens`, `total_input_tokens`, `max_tokens`**.
+Every per-response usage record on disk reads
+`{"input_tokens": "[REDACTED]", "output_tokens": "[REDACTED]"}`.
+
+**Scope, stated precisely** (an earlier draft of this finding overstated it): the
+loop writes its own `usage` line *outside* redaction, so the totals were always
+reconcilable - run `l5` reads `1284+1475 = 2759` in and `122+6 = 128` out, matching
+the in-memory totals exactly. What was destroyed is the **copy inside the recorded
+model response**, and with it any key containing the substring `token` in any
+redacted payload. The blast radius is wider than usage: it is every field whose
+name merely *contains* a secret word.
+
+**Fixed** (`engine/trajectory.py`): the key pattern now matches **whole words** of
+the key, normalized from camelCase and kebab-case first. `accessToken`,
+`access-token`, `apiKey`, `client_secret` and `Authorization` are still redacted;
+`input_tokens`, `max_tokens`, `tokens_used` and `auth_mode` now survive. Exposed as
+`is_secret_key()` so the rule is testable directly, with a regression test over
+both sets. Re-run live (`v-todo`): the response copy and the loop's own line agree
+line by line, `4419` in and `392` out.
+
+## Per-OS results
+
+Legend: pass / fail / blocked / not run / **Not-Needed** (no OS-specific surface,
+so a run adds no signal - always with its reason).
+
+| | Linux | macOS | Windows native | WSL |
+|---|---|---|---|---|
+| Part L (loop contract) | Not-Needed | Not-Needed | Not-Needed | **run** |
+| Part C (control-plane tools) | Not-Needed | Not-Needed | Not-Needed | **run** |
+| Part R (crash + resume) | Not-Needed | Not-Needed | Not-Needed | **run** |
+| Part P (policy) | Not-Needed | Not-Needed | Not-Needed | **run** |
+| **Part N (desktop channel)** | **owed (0.4.x+)** | **owed** | **owed** | **run** (selection only) |
+| **Part A (auth store)** | **owed (0.4.x+)** | **owed** | **owed** | **run** |
+| Part M (MCP host) | Not-Needed | Not-Needed | Not-Needed | **run** |
+
+**Two parts have a real per-OS surface, not one.** Parts L, C, R, P and M are pure
+Python with no socket/pipe/path/registry/process branching and no per-OS deps, so
+the other OSes **cannot** behave differently - that is `Not-Needed`, not `not run`.
+**Parts N and A are different**: the desktop channel builds a different native
+command per OS (`notify-send`/`zenity`, `osascript`, `powershell`) and the OAuth
+store resolves per OS (Keychain vs file). This runbook proves the **selection** on
+all four - the selection logic is injectable - but not that the selected command or
+store actually works on macOS or native Windows. That is owed, and the
+cross-platform round belongs in a later minor.
+
+## What this runbook cannot prove
+
+Stated so no reader mistakes a green table for a working product:
+
+- **Nothing about the product's run path.** The engine is unwired at `0.4.0`; every
+  part above drives it directly. Trigger-over-API and watch-over-WebSocket arrive
+  with `0.4.1` and are proven in `E2E/0.4.1/e2e.md`.
+- **Nothing about resume in production.** `resume()` and `find_latest()` are called
+  from no non-test code, and `run_loop` has no resume entry point. Part R proves
+  the library resumes correctly; it does not prove the daemon does. See F4.
+- **Nothing about a real external MCP server.** `v-mcp` put an external server in
+  a live run (the model discovered and called its tool) but it is an in-process
+  stub. A real stdio/SSE server - handshake, subprocess lifetime, slow start,
+  mid-run death - is owed with the first one that ships.
+- **Nothing about the phone.** Mobile has never reached a machine; that is phase
+  0's separate handset clause and mobile `0.4.0`.
+
+## Open cells
+
+Three, each with its reason - listed so nobody has to diff two versions to find
+what is missing:
+
+- **C5** `request_approval` **approve** branch: the goal-level task produced
+  `ask_user` instead. Needs a task whose only sensible move is an approval.
+- **C11** `ask_user` with `options`: the constrained-answer path.
+- **R6** `idem` revalidation: not testable until resume is wired (F4).

--- a/api/docs/API_ARCHITECTURE.md
+++ b/api/docs/API_ARCHITECTURE.md
@@ -311,7 +311,7 @@ erDiagram
         json output_schema "Produced outputs (forge-inferred)"
         boolean computer_use "Can use desktop"
         string provider "anthropic | openai"
-        string model "claude-sonnet-4-6"
+        string model "claude-opus-5"
         datetime created_at
         datetime updated_at
     }
@@ -480,7 +480,7 @@ POST /api/agents
   ],
   "computer_use": false,
   "provider": "anthropic",
-  "model": "claude-sonnet-4-6"
+  "model": "claude-opus-5"
 }
 ```
 
@@ -489,7 +489,7 @@ Only `name` is required. All other fields are optional:
 - `samples` -- quality examples for forge to calibrate prompts
 - `computer_use` -- whether the agent uses desktop automation (default: false)
 - `provider` -- LLM provider key (default: "anthropic")
-- `model` -- model identifier (default: "claude-sonnet-4-6")
+- `model` -- model identifier (default: "claude-opus-5")
 
 The API returns immediately with the agent ID and status "creating". Forge generation runs as a background task:
 
@@ -525,7 +525,7 @@ Connect via WebSocket at `/api/ws/agents/{id}` for creation progress. When forge
     "prompts": ["01_Research_Analyst.md", "02_Outline_Architect.md", "03_Academic_Writer.md"]
   },
   "provider": "anthropic",
-  "model": "claude-sonnet-4-6"
+  "model": "claude-opus-5"
 }
 ```
 
@@ -973,7 +973,7 @@ CREATE TABLE agents (
     output_schema TEXT DEFAULT '[]',
     computer_use INTEGER DEFAULT 0,
     provider TEXT NOT NULL DEFAULT 'anthropic',
-    model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+    model TEXT NOT NULL DEFAULT 'claude-opus-5',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/api/docs/PHASE_A_AGENTS.md
+++ b/api/docs/PHASE_A_AGENTS.md
@@ -219,7 +219,7 @@ erDiagram
         json output_schema "Produced outputs (forge-inferred)"
         boolean computer_use "Can use desktop"
         string provider "anthropic | openai"
-        string model "claude-sonnet-4-6"
+        string model "claude-opus-5"
         datetime created_at
         datetime updated_at
     }
@@ -345,7 +345,7 @@ POST /api/agents
   ],
   "computer_use": false,
   "provider": "anthropic",
-  "model": "claude-sonnet-4-6"
+  "model": "claude-opus-5"
 }
 ```
 
@@ -354,7 +354,7 @@ Only `name` is required. All other fields are optional:
 - `samples` -- quality examples for forge to calibrate prompts
 - `computer_use` -- whether the agent uses desktop automation (default: false)
 - `provider` -- LLM provider key (default: "anthropic")
-- `model` -- model identifier (default: "claude-sonnet-4-6")
+- `model` -- model identifier (default: "claude-opus-5")
 
 The API returns immediately with the agent ID and status "creating". Forge generation runs as a background task:
 
@@ -390,7 +390,7 @@ Connect via WebSocket at `/api/ws/agents/{id}` for creation progress. When forge
     "prompts": ["01_Research_Analyst.md", "02_Outline_Architect.md", "03_Academic_Writer.md"]
   },
   "provider": "anthropic",
-  "model": "claude-sonnet-4-6"
+  "model": "claude-opus-5"
 }
 ```
 
@@ -680,7 +680,7 @@ CREATE TABLE agents (
     output_schema TEXT DEFAULT '[]',
     computer_use INTEGER DEFAULT 0,
     provider TEXT NOT NULL DEFAULT 'anthropic',
-    model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+    model TEXT NOT NULL DEFAULT 'claude-opus-5',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -51,7 +51,7 @@ class AgentCreate(StrictBody):
     output_schema: list[SchemaField] = []
     computer_use: bool = False
     provider: str = "claude_code"
-    model: str = "claude-sonnet-4-6"
+    model: str = "claude-opus-5"
 
     @field_validator("steps", mode="before")
     @classmethod
@@ -98,7 +98,7 @@ class Agent(BaseModel):
     computer_use: bool = False
     forge_config: dict[str, Any] = {}
     provider: str = "claude_code"
-    model: str = "claude-sonnet-4-6"
+    model: str = "claude-opus-5"
     created_at: datetime
     updated_at: datetime
 

--- a/api/persistence/database.py
+++ b/api/persistence/database.py
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS agents (
     computer_use INTEGER DEFAULT 0,
     forge_config TEXT DEFAULT '{}',
     provider TEXT NOT NULL DEFAULT 'claude_code',
-    model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+    model TEXT NOT NULL DEFAULT 'claude-opus-5',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/api/persistence/repositories.py
+++ b/api/persistence/repositories.py
@@ -115,7 +115,7 @@ class AgentRepository:
         computer_use: bool = False,
         forge_config: dict | None = None,
         provider: str = "anthropic",
-        model: str = "claude-sonnet-4-6",
+        model: str = "claude-opus-5",
     ) -> dict:
         agent_id = _uuid()
         now = _now()

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -388,7 +388,7 @@ async def import_agent(request: Request, background_tasks: BackgroundTasks, file
             output_schema=manifest.get("output_schema", []),
             computer_use=manifest.get("computer_use", False),
             provider=manifest.get("provider", "claude_code"),
-            model=manifest.get("model", "claude-sonnet-4-6"),
+            model=manifest.get("model", "claude-opus-5"),
         )
         forge_path = f"output/{agent['id']}"
         agent = await repo.update(agent["id"], forge_path=forge_path)

--- a/api/services/agent_service.py
+++ b/api/services/agent_service.py
@@ -179,7 +179,7 @@ class AgentService:
         output_schema: list | None = None,
         computer_use: bool = False,
         provider: str = "claude_code",
-        model: str = "claude-sonnet-4-6",
+        model: str = "claude-opus-5",
     ) -> dict:
         """Create an agent record with status 'creating' and trigger forge generation."""
         return await self.agent_repo.create(

--- a/api/tests/test_agents.py
+++ b/api/tests/test_agents.py
@@ -1069,8 +1069,8 @@ class TestProviders:
         assert claude is not None
         assert claude["name"] == "Claude Code"
         model_ids = [m["id"] for m in claude["models"]]
-        assert "claude-sonnet-4-6" in model_ids
-        assert "claude-opus-4-6" in model_ids
+        assert "claude-opus-5" in model_ids
+        assert "claude-sonnet-5" in model_ids
 
     @pytest.mark.asyncio
     async def test_each_model_has_id_and_name(self, client):

--- a/api/tests/test_runs.py
+++ b/api/tests/test_runs.py
@@ -41,7 +41,7 @@ class TestRunGet:
         assert resp.status_code == 200
         assert resp.json()["id"] == run_id
         assert resp.json()["provider"] == "claude_code"
-        assert resp.json()["model"] == "claude-sonnet-4-6"
+        assert resp.json()["model"] == "claude-opus-5"
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_run_returns_404(self, client):

--- a/api/tests/test_services.py
+++ b/api/tests/test_services.py
@@ -65,19 +65,26 @@ class TestProvidersYamlLoading:
         assert "{{prompt}}" in config.args
 
     def test_yaml_providers_all_have_placeholder(self):
-        """Every provider in YAML must have {{prompt}} placeholder in args."""
+        """Every CLI provider in YAML must have {{prompt}} placeholder in args.
+        Native providers (the engine loop) drive the model directly and carry no
+        command/args, so they are exempt."""
         providers = _load_providers_yaml()
         for key, prov in providers.items():
+            if prov.get("kind") == "native":
+                continue
             args_str = " ".join(prov["args"])
             assert "{{prompt}}" in args_str, (
                 f"Provider '{key}' missing {{{{prompt}}}} placeholder in args"
             )
 
     def test_yaml_providers_all_instantiate_as_provider_config(self):
-        """Every provider in YAML can be deserialized into a ProviderConfig."""
+        """Every CLI provider in YAML can be deserialized into a ProviderConfig.
+        Native providers are exempt -- they are not CLI subprocess providers."""
         providers = _load_providers_yaml()
         valid_fields = {f.name for f in ProviderConfig.__dataclass_fields__.values()}
         for key, prov in providers.items():
+            if prov.get("kind") == "native":
+                continue
             filtered = {k: v for k, v in prov.items() if k in valid_fields}
             config = ProviderConfig(**filtered)
             assert config.name, f"{key} has empty name"

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,9 @@
+"""vadgr native agent loop.
+
+A top-level package (peer of ``api``/``cli``/``forge``): the provider-agnostic
+agent loop and the abstractions every provider reuses. It owns the conversation
+history -- so it can prune old screenshots (keep-last-N) and the wire-limit
+failure class simply cannot recur. It imports nothing from ``api``.
+
+See ``design/vadgr/0.4.0/native-loop.md`` for the build spec.
+"""

--- a/engine/auth/__init__.py
+++ b/engine/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Auth strategies: how a provider proves who it is on the wire.
+
+0.4.0 ships the ``AuthStrategy`` port only; the concrete OAuth/API-key/no-auth
+strategies land in a subsequent slice.
+"""

--- a/engine/auth/__init__.py
+++ b/engine/auth/__init__.py
@@ -1,5 +1,7 @@
 """Auth strategies: how a provider proves who it is on the wire.
 
-0.4.0 ships the ``AuthStrategy`` port only; the concrete OAuth/API-key/no-auth
-strategies land in a subsequent slice.
+The ``AuthStrategy`` port (``base.py``) plus the three shipped strategies a
+provider composes by reference: ``OAuthStrategy`` (``oauth.py`` -- token cache,
+refresh, per-OS store), ``APIKeyStrategy`` (``api_key.py``), and
+``NoAuthStrategy`` (``none.py``).
 """

--- a/engine/auth/api_key.py
+++ b/engine/auth/api_key.py
@@ -1,0 +1,39 @@
+"""The API-key strategy -- an env-var lookup injected as a header.
+
+Terminal on 401: a rejected key is a bad key, not something a retry fixes. The
+production API-key providers (0.5.0) compose this; it ships now because the base
+class can compose any of the three strategies.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+class APIKeyStrategy:
+    """Reads ``env_var`` and injects it as ``header`` (optionally with a
+    ``scheme`` prefix like ``Bearer``)."""
+
+    def __init__(
+        self,
+        env_var: str,
+        *,
+        header: str = "x-api-key",
+        scheme: str | None = None,
+    ):
+        self._env_var = env_var
+        self._header = header
+        self._scheme = scheme
+
+    async def inject_headers(self, request: dict) -> None:
+        key = os.environ.get(self._env_var)
+        if not key:
+            raise RuntimeError(
+                f"API key not found: set the {self._env_var} environment variable"
+            )
+        value = f"{self._scheme} {key}" if self._scheme else key
+        request.setdefault("headers", {})[self._header] = value
+
+    async def handle_401(self, response: Any) -> bool:
+        return False

--- a/engine/auth/base.py
+++ b/engine/auth/base.py
@@ -1,0 +1,24 @@
+"""The auth port -- how a provider proves who it is on the wire.
+
+A provider composes exactly one ``AuthStrategy`` by reference; the loop never
+sees auth. Concrete strategies (OAuth / API-key / no-auth) land in a subsequent
+slice -- this slice ships the port only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AuthStrategy(Protocol):
+    """Mutates the outbound request to carry credentials, and reacts to a 401."""
+
+    async def inject_headers(self, request: dict) -> None:
+        """Mutate outbound headers -- Bearer / x-api-key / none -- before send."""
+        ...
+
+    async def handle_401(self, response: Any) -> bool:
+        """React to an auth failure. Return ``True`` if the caller should retry
+        (e.g. token refreshed), ``False`` if it is terminal."""
+        ...

--- a/engine/auth/none.py
+++ b/engine/auth/none.py
@@ -1,0 +1,16 @@
+"""The no-auth strategy -- for local models that need no credentials."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class NoAuthStrategy:
+    """Injects nothing and treats any 401 as terminal (a local endpoint that
+    401s is misconfigured, not refreshable)."""
+
+    async def inject_headers(self, request: dict) -> None:
+        return None
+
+    async def handle_401(self, response: Any) -> bool:
+        return False

--- a/engine/auth/oauth.py
+++ b/engine/auth/oauth.py
@@ -1,0 +1,248 @@
+"""The OAuth strategy -- token cache, refresh-on-expiry / on-401, per-OS store.
+
+Owns the access-token cache, the refresh-token exchange (through the shared
+``HttpClient``), and the credentials read/write. For the first provider it is
+constructed with the Claude Code credentials path, the refresh endpoint, and
+the public Claude Code client id.
+
+Per-OS credential resolution (four platforms, non-negotiable): on
+**Linux / Windows / WSL** the token store is the credentials **file**
+(``~/.claude/.credentials.json`` -- on WSL that is the *Linux-side* home, never
+``/mnt/c``); on **macOS** the token lives in the login **Keychain**, read/written
+through ``security`` (or ``keyring``). The store is resolved by OS behind one
+``inject_headers`` / refresh path -- the read is branched, never assumed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+# Refresh a token once it is within this window of expiry (ms). Claude Code
+# tokens are long-lived; this just avoids sending one about to expire mid-run.
+REFRESH_WINDOW_MS = 5 * 60 * 1000
+
+# The macOS login-Keychain coordinates Claude Code stores its token under.
+_KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+
+class CredentialsError(RuntimeError):
+    """Base for credential-store failures."""
+
+
+class CredentialsMissingError(CredentialsError):
+    """No credentials found -- the user must run ``claude setup-token``."""
+
+
+class FileTokenStore:
+    """The Linux / Windows / WSL token store: the credentials JSON file.
+
+    The file wraps the token block under ``claudeAiOauth`` (Claude Code's
+    layout); ``load`` returns that block, ``save`` writes it back, preserving
+    the wrapper."""
+
+    WRAPPER_KEY = "claudeAiOauth"
+
+    def __init__(self, path: str):
+        # Expand ``~`` against the *current* home -- on WSL that is the
+        # Linux-side home, exactly as intended.
+        self.path = str(Path(path).expanduser())
+
+    def load(self) -> dict | None:
+        p = Path(self.path)
+        if not p.is_file():
+            return None
+        data = json.loads(p.read_text())
+        return data.get(self.WRAPPER_KEY, data)
+
+    def save(self, block: dict) -> None:
+        p = Path(self.path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        existing: dict = {}
+        if p.is_file():
+            try:
+                existing = json.loads(p.read_text())
+            except json.JSONDecodeError:
+                existing = {}
+        existing[self.WRAPPER_KEY] = block
+        p.write_text(json.dumps(existing, indent=2))
+
+
+class KeychainTokenStore:
+    """The macOS token store: the login Keychain, via ``security``.
+
+    macOS is host-unreachable from a Linux/WSL dev host, so this backend is
+    proven by unit branch + the design's stated behavior, not live -- the
+    ``security`` invocation is isolated behind ``_run`` so a test can inject a
+    fake."""
+
+    def __init__(
+        self,
+        service: str = _KEYCHAIN_SERVICE,
+        account: str | None = None,
+        runner: Callable[[list[str]], str] | None = None,
+    ):
+        self._service = service
+        self._account = account or _current_user()
+        self._run = runner or _run_security
+
+    def load(self) -> dict | None:
+        try:
+            raw = self._run(
+                [
+                    "security", "find-generic-password",
+                    "-s", self._service, "-a", self._account, "-w",
+                ]
+            )
+        except CredentialsError:
+            return None
+        raw = raw.strip()
+        if not raw:
+            return None
+        data = json.loads(raw)
+        return data.get(FileTokenStore.WRAPPER_KEY, data)
+
+    def save(self, block: dict) -> None:
+        payload = json.dumps({FileTokenStore.WRAPPER_KEY: block})
+        # -U updates the item if it already exists.
+        self._run(
+            [
+                "security", "add-generic-password",
+                "-s", self._service, "-a", self._account, "-w", payload, "-U",
+            ]
+        )
+
+
+def _current_user() -> str:
+    import getpass
+
+    try:
+        return getpass.getuser()
+    except Exception:
+        return ""
+
+
+def _run_security(argv: list[str]) -> str:
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError as exc:  # no ``security`` binary -> not macOS
+        raise CredentialsError("security binary not available") from exc
+    if proc.returncode != 0:
+        raise CredentialsError(proc.stderr.strip() or "security failed")
+    return proc.stdout
+
+
+def resolve_token_store(os_name: str, credentials_path: str):
+    """Pick the token store by OS. macOS -> Keychain; everything else (Linux /
+    Windows / WSL) -> the credentials file."""
+    if os_name == "Darwin":
+        return KeychainTokenStore()
+    return FileTokenStore(credentials_path)
+
+
+class OAuthStrategy:
+    """``Authorization: Bearer <cached token>`` with refresh-on-expiry and
+    refresh-on-401. Composed into a provider by reference."""
+
+    def __init__(
+        self,
+        credentials_path: str,
+        refresh_url: str,
+        client_id: str,
+        *,
+        http=None,
+        now: Callable[[], int] | None = None,
+        os_name: str | None = None,
+        store=None,
+    ):
+        self._credentials_path = credentials_path
+        self._refresh_url = refresh_url
+        self._client_id = client_id
+        self._http = http
+        self._now_ms = now or (lambda: int(time.time() * 1000))
+        if store is not None:
+            self._store = store
+        else:
+            import platform
+
+            self._store = resolve_token_store(
+                os_name or platform.system(), credentials_path
+            )
+        self._block: dict | None = None
+
+    # -- public port ---------------------------------------------------------
+
+    async def inject_headers(self, request: dict) -> None:
+        token = await self._access_token()
+        request.setdefault("headers", {})["Authorization"] = f"Bearer {token}"
+
+    async def handle_401(self, response: Any) -> bool:
+        """Drop the cached token, refresh once, and signal the caller to retry.
+        Returns ``False`` if the refresh itself fails -- a terminal auth error."""
+        self._block = None
+        try:
+            await self._refresh()
+            return True
+        except Exception:
+            return False
+
+    async def ensure_ready(self) -> None:
+        """Fail-fast preflight for ``provider.setup()``: load the credentials
+        (raising the ``setup-token`` error if absent) and refresh if inside the
+        window, so a run never starts on a token about to expire."""
+        await self._access_token()
+
+    # -- internals -----------------------------------------------------------
+
+    def _load(self) -> dict:
+        if self._block is None:
+            block = self._store.load()
+            if not block or not block.get("accessToken"):
+                raise CredentialsMissingError(
+                    "No Claude credentials found -- run `claude setup-token` first."
+                )
+            self._block = block
+        return self._block
+
+    async def _access_token(self) -> str:
+        block = self._load()
+        expires_at = block.get("expiresAt", 0)
+        if self._now_ms() >= expires_at - REFRESH_WINDOW_MS:
+            await self._refresh()
+            block = self._block
+        return block["accessToken"]
+
+    async def _refresh(self) -> None:
+        block = self._load()
+        refresh_token = block.get("refreshToken")
+        if not refresh_token:
+            raise CredentialsError("No refresh token available")
+        if self._http is None:
+            from engine.http import HttpClient
+
+            self._http = HttpClient()
+        response = await self._http.post(
+            self._refresh_url,
+            headers={"Content-Type": "application/json"},
+            json={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": self._client_id,
+            },
+        )
+        if response.status_code != 200:
+            raise CredentialsError(
+                f"Token refresh failed (HTTP {response.status_code})"
+            )
+        payload = response.json()
+        new_block = dict(block)
+        new_block["accessToken"] = payload["access_token"]
+        new_block["refreshToken"] = payload.get("refresh_token", refresh_token)
+        expires_in = payload.get("expires_in")
+        if expires_in is not None:
+            new_block["expiresAt"] = self._now_ms() + int(expires_in) * 1000
+        self._store.save(new_block)
+        self._block = new_block

--- a/engine/base.py
+++ b/engine/base.py
@@ -1,0 +1,57 @@
+"""The provider port -- the only provider abstraction the loop depends on.
+
+The loop and the rest of vadgr depend on ``AgentProvider`` (a ``Protocol``),
+never on a concrete provider. Selecting/swapping a provider is a config entry,
+with no caller change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+
+from engine.trajectory import Trajectory
+
+
+@runtime_checkable
+class AgentProvider(Protocol):
+    """A native agent provider: auth + endpoint + format, behind one contract.
+
+    Concrete providers compose an auth strategy, a message format, and the
+    family endpoint; the loop only ever sees this protocol."""
+
+    name: str
+    auth_mode: str          # "oauth" | "api_key" | "subprocess" | "none"
+    default_model: str
+
+    async def setup(self) -> None:
+        """Fail fast -- validate creds / reachability before any run."""
+        ...
+
+    async def run_agent(
+        self,
+        task: Any,
+        mcp_servers: list,
+        on_event: Callable[[dict], Awaitable[None]],
+        **kwargs: Any,
+    ) -> "RunResult":
+        """Run one agent task to completion, streaming events via ``on_event``."""
+        ...
+
+    async def teardown(self) -> None:
+        """Release anything ``setup()`` acquired."""
+        ...
+
+
+@dataclass
+class RunResult:
+    """The outcome of one agent run.
+
+    ``trajectory`` is the append-only journal (path + records) -- the durable
+    record a resume reads -- not an in-memory transcript."""
+
+    final_text: str
+    trajectory: Trajectory
+    total_iterations: int
+    total_input_tokens: int
+    total_output_tokens: int

--- a/engine/channels/__init__.py
+++ b/engine/channels/__init__.py
@@ -1,4 +1,6 @@
 """User-facing channel routing (CLI / desktop) for HITL + notify.
 
-Home for a subsequent slice; empty in this one.
+The ``Channel`` port + ``ChannelRouter`` (``base.py``), the ``CLIChannel``
+(``cli.py``), and the ``DesktopChannel`` (``desktop.py``). The mobile channel is
+0.7.0.
 """

--- a/engine/channels/__init__.py
+++ b/engine/channels/__init__.py
@@ -1,0 +1,4 @@
+"""User-facing channel routing (CLI / desktop) for HITL + notify.
+
+Home for a subsequent slice; empty in this one.
+"""

--- a/engine/channels/base.py
+++ b/engine/channels/base.py
@@ -1,0 +1,75 @@
+"""The channel port + router -- where a HITL request or notify reaches a human.
+
+A ``Channel`` blocks for a human answer (``request``) or fires a notification
+(``notify``). ``ChannelRouter`` picks the active channel (the one that launched
+the run) and forwards; a per-call ``channel`` argument overrides for one call.
+0.4.0 ships CLI + desktop; the mobile channel (0.7.0) drops in with no loop
+change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class HumanPrompt:
+    """A prompt routed to a channel and shown to a human. ``kind`` selects the
+    interaction shape: ``approval`` (approve/reject), ``question`` (free
+    answer, optional ``options``), or ``plan`` (approve/revise/reject)."""
+
+    kind: str
+    text: str
+    options: list[str] | None = None
+    risk: str | None = None
+    preview: str | None = None
+    timeout: float | None = None
+
+
+@dataclass
+class Delivery:
+    """The outcome of a fire-and-forget ``notify``."""
+
+    delivered: list[str] = field(default_factory=list)
+
+
+@runtime_checkable
+class Channel(Protocol):
+    """One place a human can be reached."""
+
+    name: str
+
+    async def request(self, prompt: HumanPrompt) -> dict:
+        """Block for a human answer. Returns ``{choice, text, timed_out}``."""
+        ...
+
+    async def notify(self, message: str, *, importance: str) -> Delivery:
+        """Fire-and-forget notification at ``low`` | ``normal`` | ``high``."""
+        ...
+
+
+class ChannelRouter:
+    """Picks the active channel and forwards. ``request``/``notify`` accept a
+    per-call ``channel`` override for a single interaction."""
+
+    def __init__(self, channels: dict[str, Channel], active: str):
+        self._channels = dict(channels)
+        if active not in self._channels:
+            raise ValueError(f"active channel '{active}' is not configured")
+        self._active = active
+
+    def _pick(self, channel: str | None) -> Channel:
+        name = channel or self._active
+        try:
+            return self._channels[name]
+        except KeyError:
+            raise ValueError(f"unknown channel: {name}")
+
+    async def request(self, prompt: HumanPrompt, *, channel: str | None = None) -> dict:
+        return await self._pick(channel).request(prompt)
+
+    async def notify(
+        self, message: str, *, importance: str = "normal", channel: str | None = None
+    ) -> Delivery:
+        return await self._pick(channel).notify(message, importance=importance)

--- a/engine/channels/cli.py
+++ b/engine/channels/cli.py
@@ -1,0 +1,93 @@
+"""The CLI channel -- prompts on the controlling TTY, notifies to the terminal.
+
+``request`` renders the prompt, reads a line (with an optional timeout), and
+maps it to a normalized ``{choice, text, timed_out}``. ``notify`` writes to the
+terminal, with ``importance`` selecting how loud the line is. The read/write
+functions are injectable so a test never touches a real TTY.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Awaitable, Callable
+
+from engine.channels.base import Delivery, HumanPrompt
+
+_YES = {"approve", "approved", "a", "y", "yes", "ok", "allow"}
+_NO = {"reject", "rejected", "r", "n", "no", "deny"}
+_REVISE = {"revise", "edit", "change", "v"}
+
+
+def _default_writer(line: str) -> None:
+    print(line, file=sys.stderr, flush=True)
+
+
+class CLIChannel:
+    name = "cli"
+
+    def __init__(
+        self,
+        *,
+        input_fn: Callable[[str], str] = input,
+        writer: Callable[[str], None] = _default_writer,
+        reader: Callable[[str, float | None], Awaitable[str]] | None = None,
+    ):
+        self._input_fn = input_fn
+        self._writer = writer
+        self._reader = reader
+
+    async def _read(self, text: str, timeout: float | None) -> str:
+        if self._reader is not None:
+            return await self._reader(text, timeout)
+        loop = asyncio.get_event_loop()
+        fut = loop.run_in_executor(None, self._input_fn, text)
+        if timeout:
+            return await asyncio.wait_for(fut, timeout)
+        return await fut
+
+    async def request(self, prompt: HumanPrompt) -> dict:
+        rendered = self._render(prompt)
+        try:
+            raw = await self._read(rendered, prompt.timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            return {"choice": None, "text": None, "timed_out": True}
+        return self._interpret(prompt, raw)
+
+    async def notify(self, message: str, *, importance: str = "normal") -> Delivery:
+        prefix = {"low": "[info]", "normal": "[notify]", "high": "[!] "}.get(
+            importance, "[notify]"
+        )
+        self._writer(f"{prefix} {message}")
+        return Delivery(delivered=[self.name])
+
+    def _render(self, prompt: HumanPrompt) -> str:
+        parts = [prompt.text]
+        if prompt.risk:
+            parts.append(f"(risk: {prompt.risk})")
+        if prompt.preview:
+            parts.append(f"\n{prompt.preview}")
+        if prompt.kind == "approval":
+            parts.append(" [approve/reject] ")
+        elif prompt.kind == "plan":
+            parts.append(" [approve/revise/reject] ")
+        elif prompt.options:
+            parts.append(f" [{'/'.join(prompt.options)}] ")
+        return " ".join(parts)
+
+    def _interpret(self, prompt: HumanPrompt, raw: str) -> dict:
+        answer = (raw or "").strip()
+        low = answer.lower()
+        if prompt.kind == "approval":
+            choice = "approve" if low in _YES else "reject"
+            return {"choice": choice, "text": answer, "timed_out": False}
+        if prompt.kind == "plan":
+            if low in _YES:
+                choice = "approve"
+            elif low in _REVISE:
+                choice = "revise"
+            else:
+                choice = "reject"
+            return {"choice": choice, "text": answer, "timed_out": False}
+        # question: the raw answer is the value.
+        return {"choice": answer, "text": answer, "timed_out": False}

--- a/engine/channels/desktop.py
+++ b/engine/channels/desktop.py
@@ -1,0 +1,118 @@
+"""The desktop channel -- a native dialog / toast, branched across the four OSes.
+
+``notify`` raises a toast (``low``/``normal``) or a modal (``high``); ``request``
+raises a dialog with the choice buttons and returns the pressed button. The
+native command is selected by OS -- ``osascript`` (macOS), ``notify-send`` /
+``zenity`` (Linux, incl. WSL to the Linux desktop), PowerShell (Windows) -- and
+run through an injectable ``runner`` so tests assert the selection without a GUI.
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+from typing import Callable
+
+from engine.channels.base import Delivery, HumanPrompt
+
+_YES = {"approve", "approved", "yes", "y", "ok", "allow"}
+_REVISE = {"revise", "edit", "change"}
+
+
+def _default_runner(argv: list[str]) -> str:
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=300)
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout
+
+
+class DesktopChannel:
+    name = "desktop"
+
+    def __init__(
+        self,
+        *,
+        os_name: str | None = None,
+        runner: Callable[[list[str]], str] = _default_runner,
+    ):
+        self._os = os_name or platform.system()
+        self._run = runner
+
+    async def notify(self, message: str, *, importance: str = "normal") -> Delivery:
+        modal = importance == "high"
+        argv = self._notify_argv(message, modal=modal)
+        if argv:
+            self._run(argv)
+        return Delivery(delivered=[self.name])
+
+    async def request(self, prompt: HumanPrompt) -> dict:
+        argv = self._request_argv(prompt)
+        raw = self._run(argv) if argv else ""
+        return self._interpret(prompt, raw)
+
+    # -- per-OS command construction ----------------------------------------
+
+    def _notify_argv(self, message: str, *, modal: bool) -> list[str]:
+        if self._os == "Darwin":
+            script = (
+                f'display dialog "{message}" buttons {{"OK"}}'
+                if modal
+                else f'display notification "{message}" with title "vadgr"'
+            )
+            return ["osascript", "-e", script]
+        if self._os == "Windows":
+            verb = "MessageBox" if modal else "Notify"
+            return [
+                "powershell", "-NoProfile", "-Command",
+                f"[void][System.Windows.Forms.MessageBox]::Show('{message}')"
+                if modal
+                else f"Write-Output '{verb}: {message}'",
+            ]
+        # Linux / WSL desktop.
+        if modal:
+            return ["zenity", "--info", f"--text={message}"]
+        return ["notify-send", "vadgr", message]
+
+    def _request_argv(self, prompt: HumanPrompt) -> list[str]:
+        text = prompt.text
+        if self._os == "Darwin":
+            buttons = self._buttons(prompt)
+            btn = ", ".join(f'"{b}"' for b in buttons)
+            return [
+                "osascript", "-e",
+                f'button returned of (display dialog "{text}" buttons {{{btn}}})',
+            ]
+        if self._os == "Windows":
+            return [
+                "powershell", "-NoProfile", "-Command",
+                f"$r = [System.Windows.Forms.MessageBox]::Show('{text}',"
+                "'vadgr','YesNo'); Write-Output $r",
+            ]
+        # Linux / WSL.
+        return ["zenity", "--question", f"--text={text}"]
+
+    def _buttons(self, prompt: HumanPrompt) -> list[str]:
+        if prompt.kind == "plan":
+            return ["approve", "revise", "reject"]
+        if prompt.kind == "question" and prompt.options:
+            return list(prompt.options)
+        return ["approve", "reject"]
+
+    def _interpret(self, prompt: HumanPrompt, raw: str) -> dict:
+        answer = (raw or "").strip()
+        low = answer.lower()
+        if prompt.kind == "approval":
+            # zenity --question exits 0 (empty stdout) on Yes; treat explicit
+            # affirmatives and an empty (OK/Yes) reply as approve.
+            choice = "approve" if (low in _YES or answer == "") else "reject"
+            return {"choice": choice, "text": answer, "timed_out": False}
+        if prompt.kind == "plan":
+            if low in _YES:
+                choice = "approve"
+            elif low in _REVISE:
+                choice = "revise"
+            else:
+                choice = "reject"
+            return {"choice": choice, "text": answer, "timed_out": False}
+        return {"choice": answer, "text": answer, "timed_out": False}

--- a/engine/format/__init__.py
+++ b/engine/format/__init__.py
@@ -1,5 +1,5 @@
 """Message-format adapters: unified internal messages <-> provider wire shape.
 
-0.4.0 ships the ``MessageFormat`` port only; the Anthropic adapter is a
-subsequent slice.
+The ``MessageFormat`` port (``base.py``) + the Anthropic adapter
+(``anthropic.py``). The OpenAI/Google adapters slot in beside it in 0.5.0.
 """

--- a/engine/format/__init__.py
+++ b/engine/format/__init__.py
@@ -1,0 +1,5 @@
+"""Message-format adapters: unified internal messages <-> provider wire shape.
+
+0.4.0 ships the ``MessageFormat`` port only; the Anthropic adapter is a
+subsequent slice.
+"""

--- a/engine/format/anthropic.py
+++ b/engine/format/anthropic.py
@@ -1,0 +1,82 @@
+"""The Anthropic message/tool format adapter -- the only wire shape 0.4.0 needs.
+
+vadgr's internal message representation is already Anthropic-flavoured
+(role + content blocks, ``tool_use`` / ``tool_result``), so ``to_provider_*``
+is mostly normalization: tool specs get their JSON-schema under the Anthropic
+``input_schema`` key. ``from_provider_response`` reduces a wire message to the
+loop's unified ``{content, usage, stop_reason}`` view. The OpenAI/Google
+adapters (0.5.0) slot in beside this one without touching the loop.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_EMPTY_SCHEMA = {"type": "object", "properties": {}}
+
+
+class AnthropicFormat:
+    """Translate unified messages/tools to the Anthropic wire shape and back."""
+
+    def to_provider_messages(self, messages: list) -> list:
+        """The internal representation is already the Anthropic content-block
+        shape, so this is mostly an identity pass over a shallow copy. The one
+        normalization the wire demands: a ``tool_result`` block's ``content``
+        must be a **string** or a **list of content blocks**, never a bare
+        object -- but MCP dispatch returns a dict, so a dict/other scalar is
+        JSON-stringified here. (A list -- e.g. a screenshot's content blocks --
+        and a plain string pass through untouched.)"""
+        return [self._normalize_message(m) for m in messages]
+
+    def _normalize_message(self, message: dict) -> dict:
+        out = dict(message)
+        content = out.get("content")
+        if isinstance(content, list):
+            out["content"] = [self._normalize_block(b) for b in content]
+        return out
+
+    def _normalize_block(self, block: Any) -> Any:  # noqa: ANN401
+        if not isinstance(block, dict) or block.get("type") != "tool_result":
+            return block
+        inner = block.get("content")
+        if isinstance(inner, (str, list)):
+            return block
+        normalized = dict(block)
+        normalized["content"] = (
+            inner if isinstance(inner, str) else json.dumps(inner, default=str)
+        )
+        return normalized
+
+    def to_provider_tools(self, tools: list) -> list:
+        """Map each tool spec to the Anthropic ``{name, description,
+        input_schema}`` shape, accepting an ``inputSchema`` / ``parameters`` /
+        ``input_schema`` source key."""
+        provider_tools = []
+        for tool in tools:
+            schema = (
+                tool.get("input_schema")
+                or tool.get("inputSchema")
+                or tool.get("parameters")
+                or dict(_EMPTY_SCHEMA)
+            )
+            provider_tools.append(
+                {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "input_schema": schema,
+                }
+            )
+        return provider_tools
+
+    def from_provider_response(self, response: dict) -> dict:
+        """Reduce an Anthropic wire message to the loop's unified view."""
+        usage = response.get("usage") or {}
+        return {
+            "content": response.get("content", []),
+            "usage": {
+                "input_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+            },
+            "stop_reason": response.get("stop_reason"),
+        }

--- a/engine/format/base.py
+++ b/engine/format/base.py
@@ -1,0 +1,28 @@
+"""The format port -- unified internal messages <-> provider wire shape.
+
+A new model family is a new adapter satisfying ``MessageFormat``; the unified
+representation the loop passes never changes shape -- only the adapter at the
+wire edge does. This slice ships the port only.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MessageFormat(Protocol):
+    """Translates between vadgr's internal messages/tools and a provider's wire
+    representation, in both directions."""
+
+    def to_provider_messages(self, messages: list) -> list:
+        """Unified internal messages -> provider-native wire shape."""
+        ...
+
+    def to_provider_tools(self, tools: list) -> list:
+        """Unified tool specs -> provider-native tool schema."""
+        ...
+
+    def from_provider_response(self, response: dict) -> dict:
+        """Provider-native response -> unified internal representation."""
+        ...

--- a/engine/http.py
+++ b/engine/http.py
@@ -1,0 +1,102 @@
+"""The shared async HTTP client -- retries, timeouts, logging, in one place.
+
+Every native provider's model call and every OAuth token refresh goes through
+one ``HttpClient``, so the retry/timeout/back-off/logging policy is written
+once and reused. A concrete provider never touches ``httpx`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+_LOG = logging.getLogger("vadgr.engine.http")
+
+# Statuses worth a retry: rate limit + the transient 5xx family. A 4xx other
+# than 429 is the caller's fault (bad request / auth) and never retried.
+DEFAULT_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+class HttpClient:
+    """A thin async wrapper over ``httpx.AsyncClient`` that retries transient
+    failures with exponential back-off and logs each attempt.
+
+    ``transport`` lets a test inject ``httpx.MockTransport``; ``sleep`` lets it
+    inject a no-op so back-off never actually waits."""
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 60.0,
+        max_retries: int = 2,
+        backoff_base: float = 0.5,
+        retry_statuses: frozenset[int] = DEFAULT_RETRY_STATUSES,
+        transport: httpx.BaseTransport | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        logger: logging.Logger | None = None,
+    ):
+        self._max_retries = max_retries
+        self._backoff_base = backoff_base
+        self._retry_statuses = retry_statuses
+        self._sleep = sleep
+        self._log = logger or _LOG
+        self._client = httpx.AsyncClient(timeout=timeout, transport=transport)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json: Any | None = None,
+    ) -> httpx.Response:
+        """POST with retry-on-transient. Returns the final response even when it
+        is an un-retryable error status -- the caller decides what a 4xx means."""
+        return await self.request("POST", url, headers=headers, json=json)
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json: Any | None = None,
+    ) -> httpx.Response:
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = await self._client.request(
+                    method, url, headers=headers, json=json
+                )
+            except httpx.TransportError as exc:
+                last_exc = exc
+                if attempt >= self._max_retries:
+                    self._log.warning(
+                        "%s %s failed after %d attempts: %s",
+                        method, url, attempt + 1, exc,
+                    )
+                    raise
+                await self._backoff(attempt, reason=str(exc))
+                continue
+
+            if (
+                response.status_code in self._retry_statuses
+                and attempt < self._max_retries
+            ):
+                await self._backoff(attempt, reason=f"HTTP {response.status_code}")
+                continue
+            return response
+
+        # Only reachable if the loop exhausted on a transport error.
+        assert last_exc is not None
+        raise last_exc
+
+    async def _backoff(self, attempt: int, *, reason: str) -> None:
+        delay = self._backoff_base * (2 ** attempt)
+        self._log.info("retrying in %.2fs (attempt %d, %s)", delay, attempt + 1, reason)
+        await self._sleep(delay)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/engine/loop.py
+++ b/engine/loop.py
@@ -1,0 +1,172 @@
+"""The shared tool-use loop -- and the history pruning it exists to own.
+
+``run_loop`` is provider-agnostic: it takes a provider's ``llm_call`` callable,
+the collected MCP tools, and an ``on_event`` sink, and runs the standard
+tool-use cycle. It owns the conversation history -- including the keep-last-N
+screenshot pruning that keeps the request body under the wire limit (issue
+#10) -- and code-enforces the resume journal: every tool call writes
+``in_flight`` before dispatch and ``done``/``error`` after.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from engine.base import RunResult
+from engine.mcp import dispatch_to_mcp
+
+# The text a pruned screenshot is replaced with. Small and constant so an
+# arbitrarily large base64 payload collapses to a few bytes.
+PRUNED_PLACEHOLDER_TEXT = "[screenshot pruned]"
+
+
+class MaxIterationsExceeded(RuntimeError):
+    """Raised when the agent does not finish within ``max_iterations`` -- a
+    guard against an endless loop, never a silent hang."""
+
+
+@dataclass
+class Usage:
+    """Token usage for one model turn, normalized across providers."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+def _image_slots(messages: list):
+    """Yield ``(container_list, index)`` for every image block in the history,
+    in document order -- including images nested inside ``tool_result`` blocks
+    (where desktop screenshots actually live)."""
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for i, block in enumerate(content):
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "image":
+                yield content, i
+            elif block.get("type") == "tool_result" and isinstance(
+                block.get("content"), list
+            ):
+                inner = block["content"]
+                for j, sub in enumerate(inner):
+                    if isinstance(sub, dict) and sub.get("type") == "image":
+                        yield inner, j
+
+
+def prune_old_images(messages: list, keep_last: int = 3) -> None:
+    """Walk the history, keep the last ``keep_last`` image blocks intact, and
+    replace every older one with a small text placeholder -- in place.
+
+    Only the heavy image payloads are touched; tool-result *text* and the
+    message order are left exactly as they were. This is the entire reason the
+    loop owns the history instead of an external CLI."""
+    slots = list(_image_slots(messages))
+    if len(slots) <= keep_last:
+        return
+    for container, index in slots[: len(slots) - keep_last]:
+        container[index] = {"type": "text", "text": PRUNED_PLACEHOLDER_TEXT}
+
+
+def extract_usage(response: dict) -> Usage:
+    """Pull token usage from a provider-normalized response."""
+    usage = response.get("usage") or {}
+    return Usage(
+        input_tokens=usage.get("input_tokens", 0),
+        output_tokens=usage.get("output_tokens", 0),
+    )
+
+
+def extract_tool_uses(response: dict) -> list[dict]:
+    """Pull the ``tool_use`` blocks from a provider-normalized response."""
+    return [
+        block
+        for block in response.get("content", [])
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    ]
+
+
+def extract_text(response: dict) -> str:
+    """Pull the final assistant text from a provider-normalized response."""
+    return "".join(
+        block.get("text", "")
+        for block in response.get("content", [])
+        if isinstance(block, dict) and block.get("type") == "text"
+    )
+
+
+async def run_loop(
+    llm_call: Callable[..., Awaitable[dict]],
+    initial_task: Any,
+    mcp,
+    trajectory,
+    on_event: Callable[[dict], Awaitable[None]],
+    max_iterations: int = 100,
+    max_tokens: int = 8192,
+    keep_last_images: int = 3,
+) -> RunResult:
+    """Standard tool-use loop, shared across all native providers. Owns the
+    conversation history -- including screenshot pruning (issue #10) -- and
+    code-enforces the resume journal: every tool call writes ``in_flight``
+    BEFORE dispatch and ``done``/``error`` AFTER, so a mid-action crash always
+    leaves a dangling record. ``mcp`` is the MCP host; ``trajectory`` is the
+    journal."""
+    messages: list = [{"role": "user", "content": initial_task}]
+    mcp_tools = mcp.tools()
+    total_input_tokens = total_output_tokens = 0
+
+    for iteration in range(max_iterations):
+        prune_old_images(messages, keep_last=keep_last_images)
+        response = await llm_call(messages, tools=mcp_tools, max_tokens=max_tokens)
+        usage = extract_usage(response)
+        total_input_tokens += usage.input_tokens
+        total_output_tokens += usage.output_tokens
+
+        trajectory.append_response(iteration, response, usage)
+        await on_event({"type": "llm_response", "response": response, "usage": usage})
+
+        tool_uses = extract_tool_uses(response)
+        if not tool_uses:
+            return RunResult(
+                final_text=extract_text(response),
+                trajectory=trajectory,
+                total_iterations=iteration + 1,
+                total_input_tokens=total_input_tokens,
+                total_output_tokens=total_output_tokens,
+            )
+
+        tool_results = []
+        for tool_use in tool_uses:
+            seq = trajectory.append_in_flight(iteration, tool_use)   # BEFORE dispatch
+            try:
+                result = await dispatch_to_mcp(tool_use, mcp)
+                trajectory.append_done(seq, result)                  # AFTER dispatch
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use["id"],
+                        "content": result,
+                    }
+                )
+                await on_event(
+                    {"type": "tool_call_complete", "tool_use": tool_use, "result": result}
+                )
+            except Exception as exc:  # captured, not fatal -- fed back to the model
+                trajectory.append_error(seq, exc)                    # AFTER dispatch
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use["id"],
+                        "content": f"Error: {exc}",
+                        "is_error": True,
+                    }
+                )
+
+        messages.append({"role": "assistant", "content": response["content"]})
+        messages.append({"role": "user", "content": tool_results})
+
+    raise MaxIterationsExceeded(
+        f"Agent did not finish in {max_iterations} iterations"
+    )

--- a/engine/mcp.py
+++ b/engine/mcp.py
@@ -2,14 +2,17 @@
 
 The loop dispatches every tool through a single host that fronts a configured
 set of MCP servers (built-in: the cua servers + the in-process control-plane
-server; plus any the operator adds). The host aggregates every server's specs
+server; plus any the owner adds). The host aggregates every server's specs
 into the one list the agent sees, namespaces them by server, and routes each
 call back to the owning server. The boundary is invisible at call time.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
 
 # Separator between a server name and one of its tool names in the aggregated,
 # namespaced tool list the agent sees (``<server>__<tool>``).
@@ -47,26 +50,51 @@ class MCPHost:
         self._by_name: dict[str, MCPServer] = {}
         self._tools: list[dict] = []
         self._connected = False
+        self._failed: dict[str, str] = {}
 
     async def connect(self) -> None:
         """Start/handshake each server, build the ``name -> server`` map, and
-        aggregate the namespaced tool specs. A server-name collision is a
-        startup error -- two servers must never share a namespace."""
+        aggregate the namespaced tool specs.
+
+        A server that fails to start is **dropped, not fatal**: its tools are
+        absent and its failure is recorded in ``failed()``, while every healthy
+        server stays available. One unreachable third-party server must never
+        cost the run the tools that do work. A server-name collision is still a
+        startup error -- two servers must never share a namespace, and silently
+        dropping one would shadow the other's tools."""
         by_name: dict[str, MCPServer] = {}
         aggregated: list[dict] = []
+        failed: dict[str, str] = {}
         for server in self._servers:
             if server.name in by_name:
                 raise ValueError(
                     f"MCP server name collision: '{server.name}' is configured twice"
                 )
+            try:
+                specs = await server.list_tools()
+            except Exception as exc:  # a server that will not start
+                failed[server.name] = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "MCP server %r failed to start and was dropped: %s",
+                    server.name,
+                    exc,
+                )
+                continue
             by_name[server.name] = server
-            for spec in await server.list_tools():
+            for spec in specs:
                 namespaced = dict(spec)
                 namespaced["name"] = f"{server.name}{NAMESPACE_SEP}{spec['name']}"
                 aggregated.append(namespaced)
         self._by_name = by_name
         self._tools = aggregated
+        self._failed = failed
         self._connected = True
+
+    def failed(self) -> dict[str, str]:
+        """``server name -> why it was dropped`` for every server that failed to
+        start. Empty when the host came up whole; a degraded run is visible, not
+        silent."""
+        return dict(self._failed)
 
     def tools(self) -> list:
         """The aggregated, namespaced specs -- the single list fed to the model."""

--- a/engine/mcp.py
+++ b/engine/mcp.py
@@ -1,0 +1,100 @@
+"""The MCP host -- one generic client fronting every tool the agent can call.
+
+The loop dispatches every tool through a single host that fronts a configured
+set of MCP servers (built-in: the cua servers + the in-process control-plane
+server; plus any the operator adds). The host aggregates every server's specs
+into the one list the agent sees, namespaces them by server, and routes each
+call back to the owning server. The boundary is invisible at call time.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+# Separator between a server name and one of its tool names in the aggregated,
+# namespaced tool list the agent sees (``<server>__<tool>``).
+NAMESPACE_SEP = "__"
+
+
+@runtime_checkable
+class MCPServer(Protocol):
+    """Any MCP server, transport-agnostic -- stdio (subprocess), SSE, or
+    streamable-HTTP over the wire, or in-process (the control-plane server).
+    cua is one such server; a third-party server is another."""
+
+    name: str
+
+    async def list_tools(self) -> list:
+        """This server's tool specs (unmodified, un-namespaced)."""
+        ...
+
+    async def call_tool(self, name: str, args: dict) -> dict:
+        """Invoke one of this server's tools by its un-namespaced name."""
+        ...
+
+
+class UnknownToolError(KeyError):
+    """Raised when a dispatched tool name maps to no configured server."""
+
+
+class MCPHost:
+    """Fronts every tool the agent can call. Connects to the configured MCP
+    servers, aggregates their specs (namespaced by server), and routes each
+    call to the owning server."""
+
+    def __init__(self, servers: list[MCPServer]):
+        self._servers = list(servers)
+        self._by_name: dict[str, MCPServer] = {}
+        self._tools: list[dict] = []
+        self._connected = False
+
+    async def connect(self) -> None:
+        """Start/handshake each server, build the ``name -> server`` map, and
+        aggregate the namespaced tool specs. A server-name collision is a
+        startup error -- two servers must never share a namespace."""
+        by_name: dict[str, MCPServer] = {}
+        aggregated: list[dict] = []
+        for server in self._servers:
+            if server.name in by_name:
+                raise ValueError(
+                    f"MCP server name collision: '{server.name}' is configured twice"
+                )
+            by_name[server.name] = server
+            for spec in await server.list_tools():
+                namespaced = dict(spec)
+                namespaced["name"] = f"{server.name}{NAMESPACE_SEP}{spec['name']}"
+                aggregated.append(namespaced)
+        self._by_name = by_name
+        self._tools = aggregated
+        self._connected = True
+
+    def tools(self) -> list:
+        """The aggregated, namespaced specs -- the single list fed to the model."""
+        return self._tools
+
+    async def dispatch(self, tool_use: dict) -> dict:
+        """Route a ``tool_use`` to its owning server by the namespaced name.
+        Raises ``UnknownToolError`` on an unroutable name."""
+        server, tool_name = self._resolve(tool_use["name"])
+        return await server.call_tool(tool_name, tool_use.get("input", {}))
+
+    async def aclose(self) -> None:
+        """Release every server the host connected."""
+        for server in self._servers:
+            aclose = getattr(server, "aclose", None)
+            if aclose is not None:
+                await aclose()
+        self._connected = False
+
+    def _resolve(self, namespaced: str) -> tuple[MCPServer, str]:
+        server_name, sep, tool_name = namespaced.partition(NAMESPACE_SEP)
+        if not sep or server_name not in self._by_name:
+            raise UnknownToolError(namespaced)
+        return self._by_name[server_name], tool_name
+
+
+async def dispatch_to_mcp(tool_use: dict, mcp: MCPHost) -> dict:
+    """Loop-facing shim: resolve the owning server and call it. Raises on an
+    unknown tool or a tool error -- the loop turns that into an is_error
+    result."""
+    return await mcp.dispatch(tool_use)

--- a/engine/policy/__init__.py
+++ b/engine/policy/__init__.py
@@ -1,0 +1,4 @@
+"""Approval / denylist / redaction policy hooks (host-owned).
+
+Home for a subsequent slice; empty in this one.
+"""

--- a/engine/policy/__init__.py
+++ b/engine/policy/__init__.py
@@ -1,4 +1,5 @@
 """Approval / denylist / redaction policy hooks (host-owned).
 
-Home for a subsequent slice; empty in this one.
+The ``PolicyHook`` port + ``Decision`` / ``ApprovalRequest`` (``base.py``) and
+the default denylist + auth-mode hook (``default.py``).
 """

--- a/engine/policy/base.py
+++ b/engine/policy/base.py
@@ -1,0 +1,49 @@
+"""The policy port -- the approval / denylist / redaction hook the host owns.
+
+cua stays policy-free: it emits ``tier`` + ``risk`` and drives the machine. The
+*host* (vadgr) decides whether an action is auto-allowed, auto-denied
+(denylist), or needs a human -- per the active auth-mode. This is where §5's
+approval/denylist/redaction delegation lives, never in cua.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+# The three outcomes a policy check can return.
+AUTO_ALLOW = "auto_allow"
+AUTO_DENY = "auto_deny"
+NEEDS_HUMAN = "needs_human"
+
+
+@dataclass
+class ApprovalRequest:
+    """A request to perform a gated action, handed to the policy hook."""
+
+    action: str
+    risk: str                       # "low" | "medium" | "high"
+    preview: str = ""
+    idem: str | None = None
+
+
+@dataclass
+class Decision:
+    """A policy outcome plus the reason, for the journal / channel prompt."""
+
+    outcome: str                    # AUTO_ALLOW | AUTO_DENY | NEEDS_HUMAN
+    reason: str = ""
+
+
+@runtime_checkable
+class PolicyHook(Protocol):
+    """Decides gated actions and redacts payloads before they are written."""
+
+    async def check(self, req: ApprovalRequest) -> Decision:
+        """``auto_allow`` | ``auto_deny`` (denylist) | ``needs_human`` -- per the
+        active auth-mode."""
+        ...
+
+    def redact(self, payload: dict) -> dict:
+        """The redaction hook the trajectory + channels call before write/emit."""
+        ...

--- a/engine/policy/default.py
+++ b/engine/policy/default.py
@@ -1,0 +1,55 @@
+"""The default policy hook: denylist + risk + auth-mode.
+
+Precedence: a denylist match is ``auto_deny`` regardless of mode; then the
+auth-mode and the action's risk decide. ``redact`` delegates to the trajectory's
+secret redactor so one implementation strips tokens everywhere.
+"""
+
+from __future__ import annotations
+
+from engine.policy.base import (
+    AUTO_ALLOW,
+    AUTO_DENY,
+    NEEDS_HUMAN,
+    ApprovalRequest,
+    Decision,
+)
+from engine.trajectory import redact_secrets
+
+# Auth modes, from most permissive to most restrictive.
+BYPASS = "bypass"
+DEFAULT = "default"
+AUTONOMOUS = "autonomous"
+PARANOID = "paranoid"
+
+
+class DefaultPolicy:
+    """denylist -> risk -> auth-mode. Ships as the 0.4.0 host policy."""
+
+    def __init__(
+        self,
+        denylist: list[str] | None = None,
+        auth_mode: str = DEFAULT,
+        redactor=redact_secrets,
+    ):
+        self._denylist = list(denylist or [])
+        self._auth_mode = auth_mode
+        self._redactor = redactor
+
+    async def check(self, req: ApprovalRequest) -> Decision:
+        for pattern in self._denylist:
+            if pattern in (req.action or ""):
+                return Decision(AUTO_DENY, reason=f"denylisted: {pattern}")
+
+        if self._auth_mode == BYPASS:
+            return Decision(AUTO_ALLOW, reason="bypass mode")
+        if self._auth_mode == PARANOID:
+            return Decision(NEEDS_HUMAN, reason="paranoid mode")
+
+        # default / autonomous: high risk always needs a human, else allow.
+        if (req.risk or "").lower() == "high":
+            return Decision(NEEDS_HUMAN, reason="high-risk action")
+        return Decision(AUTO_ALLOW, reason=f"{self._auth_mode} mode, risk={req.risk}")
+
+    def redact(self, payload: dict) -> dict:
+        return self._redactor(payload)

--- a/engine/providers/__init__.py
+++ b/engine/providers/__init__.py
@@ -1,0 +1,4 @@
+"""Concrete agent providers (thin auth + endpoint + format compositions).
+
+Home for a subsequent slice; empty in this one.
+"""

--- a/engine/providers/__init__.py
+++ b/engine/providers/__init__.py
@@ -1,4 +1,6 @@
 """Concrete agent providers (thin auth + endpoint + format compositions).
 
-Home for a subsequent slice; empty in this one.
+0.4.0 ships the Anthropic family: ``_anthropic_base.py`` (format + endpoint +
+the validator invariants) and ``native_anthropic_oauth.py`` (the headline OAuth
+provider). The OpenAI/Google bases + providers are 0.5.0.
 """

--- a/engine/providers/_anthropic_base.py
+++ b/engine/providers/_anthropic_base.py
@@ -1,0 +1,251 @@
+"""The Anthropic-family base: format + endpoint + the validator invariants.
+
+Anthropic's OAuth validator enforces a fixed request shape server-side (the
+April 2026 enforcement); get any one wrong and the request is rejected. Pinning
+all of them in one family base means a validator change is a one-file patch:
+
+- ``Authorization: Bearer`` (never ``x-api-key``) -- from the auth strategy.
+- ``User-Agent`` matches ``claude-cli/<version> (external, cli)``.
+- ``anthropic-beta`` carries the subscription-auth flags; ``anthropic-version:
+  2023-06-01``.
+- the system prompt **starts** with the Claude Code identity block.
+- tool names prefixed ``mcp_`` on the way out, un-prefixed on the way back.
+
+``run_agent`` builds the MCP host over the cua servers **plus** the in-process
+control-plane server, opens a fresh ``Trajectory``, and drives the shared
+``run_loop``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from engine.base import RunResult
+from engine.channels.base import ChannelRouter
+from engine.channels.cli import CLIChannel
+from engine.channels.desktop import DesktopChannel
+from engine.format.anthropic import AnthropicFormat
+from engine.http import HttpClient
+from engine.loop import run_loop
+from engine.mcp import MCPHost
+from engine.policy.default import DefaultPolicy
+from engine.tools import ControlPlaneServer, RunContext
+from engine.trajectory import Trajectory
+
+# The identity block every Claude Code request opens its system prompt with.
+# The validator checks the system prompt STARTS with this; the real agent
+# prompt (if any) follows it.
+CLAUDE_CODE_SYSTEM_PREFIX = (
+    "You are Claude Code, Anthropic's official CLI for Claude."
+)
+
+
+class ProviderError(RuntimeError):
+    """A non-retryable HTTP error from the provider endpoint."""
+
+
+class ValidatorRejectedError(ProviderError):
+    """A 403 -- Anthropic's server-side validator rejected the request shape.
+
+    Almost always the invariants drifted (User-Agent / beta flags / system
+    prefix). Watch the community ``opencode-claude-code-auth`` pattern and patch
+    this one file."""
+
+
+class AnthropicBase:
+    """Composable base for the Anthropic-family native providers. Holds an auth
+    strategy and a message format; the concrete provider supplies identity
+    (name / model / headers / prefix) and its auth strategy."""
+
+    name: str = "anthropic_base"
+    auth_mode: str = "oauth"
+    default_model: str = "claude-sonnet-4-6"
+
+    auth_strategy: Any = None
+    user_agent: str = "claude-cli/2.1.2 (external, cli)"
+    extra_headers: dict = {"anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14"}
+    system_prompt_prefix: str = CLAUDE_CODE_SYSTEM_PREFIX
+
+    base_url: str = "https://api.anthropic.com/v1"
+    anthropic_version: str = "2023-06-01"
+    tool_prefix: str = "mcp_"
+
+    def __init__(
+        self,
+        *,
+        http: HttpClient | None = None,
+        message_format: AnthropicFormat | None = None,
+        auth_strategy: Any = None,
+        system_prompt: str = "",
+        policy=None,
+        channels: ChannelRouter | None = None,
+        runs_dir: str | None = None,
+    ):
+        self._http = http or HttpClient()
+        self._format = message_format or AnthropicFormat()
+        if auth_strategy is not None:
+            self.auth_strategy = auth_strategy
+        self._system_prompt = system_prompt
+        self._policy = policy or DefaultPolicy()
+        self._channels = channels or ChannelRouter(
+            {"cli": CLIChannel(), "desktop": DesktopChannel()}, active="cli"
+        )
+        self._runs_dir = runs_dir
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def setup(self) -> None:
+        """Fail fast: validate credentials / reachability before any run."""
+        ensure = getattr(self.auth_strategy, "ensure_ready", None)
+        if ensure is not None:
+            await ensure()
+
+    async def teardown(self) -> None:
+        await self._http.aclose()
+
+    # -- the model call ------------------------------------------------------
+
+    async def llm_call(self, messages: list, tools: list, max_tokens: int = 8192) -> dict:
+        """Build the request (format + prefix + invariants + auth), POST it, and
+        return the unified response with tool names un-prefixed."""
+        wire_messages = self._format.to_provider_messages(messages)
+        wire_tools = [
+            {**t, "name": self.tool_prefix + t["name"]}
+            for t in self._format.to_provider_tools(tools)
+        ]
+
+        system = [{"type": "text", "text": self.system_prompt_prefix}]
+        if self._system_prompt:
+            system.append({"type": "text", "text": self._system_prompt})
+
+        body: dict = {
+            "model": self.default_model,
+            "max_tokens": max_tokens,
+            "messages": wire_messages,
+            "system": system,
+        }
+        if wire_tools:
+            body["tools"] = wire_tools
+
+        request = {"headers": self._base_headers()}
+        await self.auth_strategy.inject_headers(request)
+        wire_response = await self._post(request, body)
+        return self._decode(wire_response)
+
+    def _base_headers(self) -> dict:
+        headers = {
+            "content-type": "application/json",
+            "anthropic-version": self.anthropic_version,
+            "User-Agent": self.user_agent,
+        }
+        headers.update(self.extra_headers)
+        return headers
+
+    async def _post(self, request: dict, body: dict) -> dict:
+        url = f"{self.base_url}/messages"
+        response = await self._http.post(url, headers=request["headers"], json=body)
+
+        if response.status_code == 401:
+            retry = await self.auth_strategy.handle_401(response)
+            if retry:
+                await self.auth_strategy.inject_headers(request)
+                response = await self._http.post(
+                    url, headers=request["headers"], json=body
+                )
+
+        if response.status_code == 401:
+            raise ProviderError(
+                "Anthropic rejected the credentials (401). Re-run `claude setup-token`."
+            )
+        if response.status_code == 403:
+            raise ValidatorRejectedError(
+                "Anthropic's validator rejected the request (403). The request "
+                "shape (User-Agent / anthropic-beta / system prefix) likely "
+                "drifted -- apply the current community pattern in "
+                "engine/providers/_anthropic_base.py and re-run."
+            )
+        if response.status_code >= 400:
+            raise ProviderError(
+                f"Anthropic request failed (HTTP {response.status_code}): {response.text}"
+            )
+        return response.json()
+
+    def _decode(self, wire_response: dict) -> dict:
+        unified = self._format.from_provider_response(wire_response)
+        for block in unified.get("content", []):
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and isinstance(block.get("name"), str)
+                and block["name"].startswith(self.tool_prefix)
+            ):
+                block["name"] = block["name"][len(self.tool_prefix):]
+        return unified
+
+    # -- the run -------------------------------------------------------------
+
+    async def run_agent(
+        self,
+        task: Any,
+        mcp_servers: list,
+        on_event: Callable[[dict], Awaitable[None]],
+        *,
+        run_id: str | None = None,
+        max_iterations: int = 100,
+        max_tokens: int = 8192,
+        keep_last_images: int = 3,
+        **kwargs: Any,
+    ) -> RunResult:
+        """Build the MCP host over the cua servers PLUS the in-process
+        control-plane server, open a fresh journal, and delegate the cycle to
+        the shared ``run_loop``."""
+        run_id = run_id or _new_run_id()
+        trajectory = Trajectory(run_id, path=_journal_path(self._runs_dir, run_id))
+
+        ctx = RunContext(run_id=run_id, trajectory=trajectory)
+        control = ControlPlaneServer(ctx, self._channels, self._policy)
+        host = MCPHost([*mcp_servers, control])
+        await host.connect()
+
+        async def _tracking_on_event(event: dict) -> None:
+            if event.get("type") == "llm_response":
+                ctx.iteration += 1
+                usage = event.get("usage")
+                if usage is not None:
+                    ctx.input_tokens += getattr(usage, "input_tokens", 0)
+                    ctx.output_tokens += getattr(usage, "output_tokens", 0)
+            await on_event(event)
+
+        # The RunContext's sink is the same tracking wrapper, so control-plane
+        # events (todos / progress) reach the watching client too.
+        ctx.emit = _tracking_on_event
+
+        try:
+            result = await run_loop(
+                self.llm_call,
+                task,
+                host,
+                trajectory,
+                _tracking_on_event,
+                max_iterations=max_iterations,
+                max_tokens=max_tokens,
+                keep_last_images=keep_last_images,
+            )
+        finally:
+            ctx.state = "done"
+            await host.aclose()
+        return result
+
+
+def _new_run_id() -> str:
+    import uuid
+
+    return "run-" + uuid.uuid4().hex[:12]
+
+
+def _journal_path(runs_dir: str | None, run_id: str) -> str | None:
+    if runs_dir is None:
+        return None
+    from pathlib import Path
+
+    return str(Path(runs_dir) / run_id / "trajectory.jsonl")

--- a/engine/providers/_anthropic_base.py
+++ b/engine/providers/_anthropic_base.py
@@ -59,7 +59,7 @@ class AnthropicBase:
 
     name: str = "anthropic_base"
     auth_mode: str = "oauth"
-    default_model: str = "claude-sonnet-4-6"
+    default_model: str = "claude-opus-5"
 
     auth_strategy: Any = None
     user_agent: str = "claude-cli/2.1.2 (external, cli)"

--- a/engine/providers/native_anthropic_oauth.py
+++ b/engine/providers/native_anthropic_oauth.py
@@ -1,0 +1,51 @@
+"""The headline provider: Anthropic via the Claude Code OAuth token.
+
+Dev runs bill against a Claude Pro/Max subscription instead of API credit -- the
+first version where you stop paying for API while debugging. It is gray-area per
+Anthropic's ToS and dev-only, so it refuses to start under
+``VADGR_MODE=production`` (the production API-key sibling,
+``native_anthropic_api``, is 0.5.0).
+"""
+
+from __future__ import annotations
+
+import os
+
+from engine.auth.oauth import OAuthStrategy
+from engine.providers._anthropic_base import CLAUDE_CODE_SYSTEM_PREFIX, AnthropicBase
+
+# The public Claude Code OAuth client id + refresh endpoint (§4.6).
+CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+CLAUDE_OAUTH_REFRESH_URL = "https://platform.claude.com/oauth/token"
+CLAUDE_CREDENTIALS_PATH = "~/.claude/.credentials.json"
+
+
+class AnthropicOAuthProvider(AnthropicBase):
+    name = "anthropic_oauth"
+    auth_mode = "oauth"
+    default_model = "claude-sonnet-4-6"
+    user_agent = "claude-cli/2.1.2 (external, cli)"
+    extra_headers = {
+        "anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14"
+    }
+    system_prompt_prefix = CLAUDE_CODE_SYSTEM_PREFIX
+
+    def __init__(self, **kwargs):
+        # Compose the OAuth strategy unless a test injected one.
+        if "auth_strategy" not in kwargs:
+            kwargs["auth_strategy"] = OAuthStrategy(
+                credentials_path=CLAUDE_CREDENTIALS_PATH,
+                refresh_url=CLAUDE_OAUTH_REFRESH_URL,
+                client_id=CLAUDE_CODE_CLIENT_ID,
+            )
+        super().__init__(**kwargs)
+
+    async def setup(self) -> None:
+        """Refuse production (subscription auth is dev-only), then fail fast on
+        the credentials."""
+        if os.environ.get("VADGR_MODE") == "production":
+            raise RuntimeError(
+                "native_anthropic_oauth is dev-only (subscription billing, "
+                "gray-area ToS). Use native_anthropic_api under VADGR_MODE=production."
+            )
+        await super().setup()

--- a/engine/providers/native_anthropic_oauth.py
+++ b/engine/providers/native_anthropic_oauth.py
@@ -23,7 +23,7 @@ CLAUDE_CREDENTIALS_PATH = "~/.claude/.credentials.json"
 class AnthropicOAuthProvider(AnthropicBase):
     name = "anthropic_oauth"
     auth_mode = "oauth"
-    default_model = "claude-sonnet-4-6"
+    default_model = "claude-opus-5"
     user_agent = "claude-cli/2.1.2 (external, cli)"
     extra_headers = {
         "anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14"

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -1,4 +1,8 @@
-# The engine package is pure standard library at this slice; only test deps.
+# Runtime deps for the native engine.
+httpx>=0.27.0    # the shared async HTTP client (provider calls + OAuth refresh)
+PyYAML>=6.0      # providers.yaml
+
+# Test deps.
 pytest>=8.0.0
 pytest-asyncio>=0.25.0
 pytest-cov>=6.0.0

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -1,0 +1,4 @@
+# The engine package is pure standard library at this slice; only test deps.
+pytest>=8.0.0
+pytest-asyncio>=0.25.0
+pytest-cov>=6.0.0

--- a/engine/tests/test_auth.py
+++ b/engine/tests/test_auth.py
@@ -1,0 +1,281 @@
+"""Auth strategies: OAuth (token cache + refresh + per-OS store), API-key, none.
+
+The OAuth path is driven with ``httpx.MockTransport`` (via ``HttpClient``) and a
+frozen clock so the refresh window is deterministic. Per-OS credential
+resolution is asserted by branch: Linux/Windows/WSL read+write the file (WSL
+uses the *Linux-side* home, never ``/mnt/c``); macOS goes through a Keychain
+backend, not a file.
+"""
+
+import json
+import os
+import time
+
+import httpx
+import pytest
+
+from engine.auth.api_key import APIKeyStrategy
+from engine.auth.none import NoAuthStrategy
+from engine.auth.oauth import (
+    CredentialsMissingError,
+    OAuthStrategy,
+    resolve_token_store,
+    FileTokenStore,
+    KeychainTokenStore,
+)
+from engine.http import HttpClient
+
+
+REFRESH_URL = "https://platform.claude.com/oauth/token"
+CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+
+def _write_creds(path, *, access="acc-old", refresh="ref-old", expires_at_ms=None):
+    if expires_at_ms is None:
+        expires_at_ms = int(time.time() * 1000) + 3_600_000
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": access,
+                    "refreshToken": refresh,
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        )
+    )
+
+
+def _refresh_transport(new_access="acc-new", new_refresh="ref-new", expires_in=3600):
+    def handler(request):
+        body = json.loads(request.content)
+        assert body["grant_type"] == "refresh_token"
+        assert body["client_id"] == CLIENT_ID
+        return httpx.Response(
+            200,
+            json={
+                "access_token": new_access,
+                "refresh_token": new_refresh,
+                "expires_in": expires_in,
+            },
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# ---- API-key + no-auth -----------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_api_key_injects_header_from_env(monkeypatch):
+    monkeypatch.setenv("MY_API_KEY", "sk-test-123")
+    strat = APIKeyStrategy(env_var="MY_API_KEY", header="x-api-key")
+    request = {"headers": {}}
+    await strat.inject_headers(request)
+    assert request["headers"]["x-api-key"] == "sk-test-123"
+
+
+@pytest.mark.asyncio
+async def test_api_key_bearer_scheme(monkeypatch):
+    monkeypatch.setenv("MY_API_KEY", "sk-test-123")
+    strat = APIKeyStrategy(env_var="MY_API_KEY", header="Authorization", scheme="Bearer")
+    request = {"headers": {}}
+    await strat.inject_headers(request)
+    assert request["headers"]["Authorization"] == "Bearer sk-test-123"
+
+
+@pytest.mark.asyncio
+async def test_api_key_missing_env_raises(monkeypatch):
+    monkeypatch.delenv("MY_API_KEY", raising=False)
+    strat = APIKeyStrategy(env_var="MY_API_KEY")
+    with pytest.raises(RuntimeError):
+        await strat.inject_headers({"headers": {}})
+
+
+@pytest.mark.asyncio
+async def test_api_key_401_is_terminal(monkeypatch):
+    monkeypatch.setenv("MY_API_KEY", "x")
+    strat = APIKeyStrategy(env_var="MY_API_KEY")
+    assert await strat.handle_401(object()) is False
+
+
+@pytest.mark.asyncio
+async def test_no_auth_is_noop_and_terminal():
+    strat = NoAuthStrategy()
+    request = {"headers": {"keep": "me"}}
+    await strat.inject_headers(request)
+    assert request["headers"] == {"keep": "me"}
+    assert await strat.handle_401(object()) is False
+
+
+# ---- OAuth: inject, refresh window, 401 ------------------------------------
+
+@pytest.mark.asyncio
+async def test_inject_headers_uses_cached_token_when_fresh(tmp_path):
+    creds = tmp_path / ".credentials.json"
+    _write_creds(creds, access="acc-fresh")
+    strat = OAuthStrategy(
+        credentials_path=str(creds),
+        refresh_url=REFRESH_URL,
+        client_id=CLIENT_ID,
+        os_name="Linux",
+        now=lambda: int(time.time() * 1000),
+    )
+    request = {"headers": {}}
+    await strat.inject_headers(request)
+    assert request["headers"]["Authorization"] == "Bearer acc-fresh"
+
+
+@pytest.mark.asyncio
+async def test_refresh_when_within_window_writes_back_to_file(tmp_path):
+    creds = tmp_path / ".credentials.json"
+    # expires in 60s -> inside the 5-minute refresh window
+    now_ms = 1_000_000_000_000
+    _write_creds(creds, access="acc-old", refresh="ref-old", expires_at_ms=now_ms + 60_000)
+
+    http = HttpClient(transport=_refresh_transport("acc-new", "ref-new", 3600))
+    strat = OAuthStrategy(
+        credentials_path=str(creds),
+        refresh_url=REFRESH_URL,
+        client_id=CLIENT_ID,
+        os_name="Linux",
+        http=http,
+        now=lambda: now_ms,
+    )
+    request = {"headers": {}}
+    await strat.inject_headers(request)
+
+    assert request["headers"]["Authorization"] == "Bearer acc-new"
+    # The new token was written back to the credentials file.
+    on_disk = json.loads(creds.read_text())["claudeAiOauth"]
+    assert on_disk["accessToken"] == "acc-new"
+    assert on_disk["refreshToken"] == "ref-new"
+    assert on_disk["expiresAt"] == now_ms + 3600 * 1000
+    await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_file_raises_setup_token_error(tmp_path):
+    strat = OAuthStrategy(
+        credentials_path=str(tmp_path / "nope.json"),
+        refresh_url=REFRESH_URL,
+        client_id=CLIENT_ID,
+        os_name="Linux",
+    )
+    with pytest.raises(CredentialsMissingError) as ei:
+        await strat.ensure_ready()
+    assert "setup-token" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_handle_401_drops_token_refreshes_and_signals_retry(tmp_path):
+    creds = tmp_path / ".credentials.json"
+    now_ms = 1_000_000_000_000
+    _write_creds(creds, access="acc-old", refresh="ref-old", expires_at_ms=now_ms + 3_600_000)
+    http = HttpClient(transport=_refresh_transport("acc-after-401", "ref-2", 3600))
+    strat = OAuthStrategy(
+        credentials_path=str(creds),
+        refresh_url=REFRESH_URL,
+        client_id=CLIENT_ID,
+        os_name="Linux",
+        http=http,
+        now=lambda: now_ms,
+    )
+    # prime the cache with the old (rejected) token
+    req = {"headers": {}}
+    await strat.inject_headers(req)
+    assert req["headers"]["Authorization"] == "Bearer acc-old"
+
+    retry = await strat.handle_401(httpx.Response(401))
+    assert retry is True
+
+    req2 = {"headers": {}}
+    await strat.inject_headers(req2)
+    assert req2["headers"]["Authorization"] == "Bearer acc-after-401"
+    await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_handle_401_terminal_when_refresh_fails(tmp_path):
+    creds = tmp_path / ".credentials.json"
+    now_ms = 1_000_000_000_000
+    _write_creds(creds, expires_at_ms=now_ms + 3_600_000)
+
+    def handler(request):
+        return httpx.Response(400, json={"error": "invalid_grant"})
+
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    strat = OAuthStrategy(
+        credentials_path=str(creds),
+        refresh_url=REFRESH_URL,
+        client_id=CLIENT_ID,
+        os_name="Linux",
+        http=http,
+        now=lambda: now_ms,
+    )
+    await strat.inject_headers({"headers": {}})
+    assert await strat.handle_401(httpx.Response(401)) is False
+    await http.aclose()
+
+
+# ---- Per-OS credential resolution ------------------------------------------
+
+def test_linux_windows_wsl_resolve_to_the_file_store(tmp_path):
+    for os_name in ("Linux", "Windows"):
+        store = resolve_token_store(os_name, str(tmp_path / ".credentials.json"))
+        assert isinstance(store, FileTokenStore)
+
+
+def test_wsl_uses_linux_side_home_not_mnt_c(monkeypatch, tmp_path):
+    # On WSL, ``~`` expands to the Linux home -- never a /mnt/c Windows path.
+    linux_home = tmp_path / "home" / "santiago"
+    linux_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(linux_home))
+    store = resolve_token_store("Linux", "~/.claude/.credentials.json")
+    assert isinstance(store, FileTokenStore)
+    assert "/mnt/c" not in store.path
+    assert str(linux_home) in store.path
+
+
+def test_macos_resolves_to_the_keychain_store():
+    store = resolve_token_store("Darwin", "~/.claude/.credentials.json")
+    assert isinstance(store, KeychainTokenStore)
+
+
+@pytest.mark.asyncio
+async def test_macos_keychain_backend_reads_and_writes_back(tmp_path):
+    # A fake Keychain: load returns a JSON blob; save records the write-back.
+    now_ms = 1_000_000_000_000
+    saved = {}
+    keychain_blob = {
+        "claudeAiOauth": {
+            "accessToken": "kc-old",
+            "refreshToken": "kc-ref",
+            "expiresAt": now_ms + 60_000,
+        }
+    }
+
+    class FakeKeychain:
+        def load(self):
+            return keychain_blob["claudeAiOauth"]
+
+        def save(self, block):
+            saved.update(block)
+
+    http = HttpClient(transport=_refresh_transport("kc-new", "kc-ref2", 3600))
+    strat = OAuthStrategy(
+        credentials_path="~/.claude/.credentials.json",
+        refresh_url=REFRESH_URL,
+        client_id=CLIENT_ID,
+        os_name="Darwin",
+        store=FakeKeychain(),
+        http=http,
+        now=lambda: now_ms,
+    )
+    request = {"headers": {}}
+    await strat.inject_headers(request)
+    # Refreshed through the Keychain backend (within window), written back there.
+    assert request["headers"]["Authorization"] == "Bearer kc-new"
+    assert saved["accessToken"] == "kc-new"
+    await http.aclose()

--- a/engine/tests/test_channels.py
+++ b/engine/tests/test_channels.py
@@ -1,0 +1,139 @@
+"""Where a HITL request or a notify reaches a human: CLI + desktop channels.
+
+``ChannelRouter`` picks the active channel and forwards; a per-call ``channel``
+override redirects one request/notify. ``CLIChannel`` prompts on the TTY (with a
+timeout) and maps ``importance`` to loudness; ``DesktopChannel`` selects the
+right native command per OS.
+"""
+
+import pytest
+
+from engine.channels.base import ChannelRouter, Delivery, HumanPrompt
+from engine.channels.cli import CLIChannel
+from engine.channels.desktop import DesktopChannel
+
+
+class FakeChannel:
+    def __init__(self, name, answer=None):
+        self.name = name
+        self._answer = answer or {"choice": "approve", "text": None, "timed_out": False}
+        self.requests = []
+        self.notes = []
+
+    async def request(self, prompt):
+        self.requests.append(prompt)
+        return self._answer
+
+    async def notify(self, message, *, importance):
+        self.notes.append((message, importance))
+        return Delivery(delivered=[self.name])
+
+
+# ---- ChannelRouter ---------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_forwards_to_active_channel():
+    cli = FakeChannel("cli")
+    desktop = FakeChannel("desktop")
+    router = ChannelRouter({"cli": cli, "desktop": desktop}, active="cli")
+
+    resp = await router.request(HumanPrompt(kind="approval", text="ok?"))
+    assert resp["choice"] == "approve"
+    assert len(cli.requests) == 1 and len(desktop.requests) == 0
+
+
+@pytest.mark.asyncio
+async def test_router_per_call_channel_override():
+    cli = FakeChannel("cli")
+    desktop = FakeChannel("desktop")
+    router = ChannelRouter({"cli": cli, "desktop": desktop}, active="cli")
+
+    d = await router.notify("hi", importance="high", channel="desktop")
+    assert d.delivered == ["desktop"]
+    assert desktop.notes == [("hi", "high")]
+    assert cli.notes == []
+
+
+# ---- CLIChannel ------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cli_approval_maps_yes_to_approve():
+    ch = CLIChannel(input_fn=lambda prompt: "y", writer=lambda s: None)
+    resp = await ch.request(HumanPrompt(kind="approval", text="run rm?", risk="high"))
+    assert resp["choice"] == "approve"
+    assert resp["timed_out"] is False
+
+
+@pytest.mark.asyncio
+async def test_cli_approval_maps_no_to_reject():
+    ch = CLIChannel(input_fn=lambda prompt: "n", writer=lambda s: None)
+    resp = await ch.request(HumanPrompt(kind="approval", text="run rm?"))
+    assert resp["choice"] == "reject"
+
+
+@pytest.mark.asyncio
+async def test_cli_question_returns_the_raw_answer():
+    ch = CLIChannel(input_fn=lambda prompt: "blue", writer=lambda s: None)
+    resp = await ch.request(HumanPrompt(kind="question", text="colour?"))
+    assert resp["choice"] == "blue"
+
+
+@pytest.mark.asyncio
+async def test_cli_timeout_returns_timed_out():
+    async def slow_reader(text, timeout):
+        import asyncio
+
+        raise asyncio.TimeoutError
+
+    ch = CLIChannel(reader=slow_reader, writer=lambda s: None)
+    resp = await ch.request(HumanPrompt(kind="approval", text="q", timeout=0.01))
+    assert resp["timed_out"] is True
+    assert resp["choice"] is None
+
+
+@pytest.mark.asyncio
+async def test_cli_notify_writes_and_maps_importance():
+    written = []
+    ch = CLIChannel(input_fn=lambda p: "", writer=written.append)
+    d = await ch.notify("build done", importance="high")
+    assert d.delivered == ["cli"]
+    assert any("build done" in w for w in written)
+
+
+# ---- DesktopChannel (per-OS command selection) -----------------------------
+
+@pytest.mark.asyncio
+async def test_desktop_notify_uses_osascript_on_macos():
+    calls = []
+
+    def runner(argv):
+        calls.append(argv)
+        return ""
+
+    ch = DesktopChannel(os_name="Darwin", runner=runner)
+    await ch.notify("hello", importance="normal")
+    assert any("osascript" in argv[0] for argv in calls)
+
+
+@pytest.mark.asyncio
+async def test_desktop_notify_uses_notify_send_on_linux():
+    calls = []
+    ch = DesktopChannel(os_name="Linux", runner=lambda a: calls.append(a) or "")
+    await ch.notify("hello", importance="normal")
+    assert calls and "notify-send" in calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_desktop_notify_uses_powershell_on_windows():
+    calls = []
+    ch = DesktopChannel(os_name="Windows", runner=lambda a: calls.append(a) or "")
+    await ch.notify("hello", importance="normal")
+    assert calls and "powershell" in calls[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_desktop_request_returns_choice_from_runner():
+    ch = DesktopChannel(os_name="Linux", runner=lambda a: "approve")
+    resp = await ch.request(HumanPrompt(kind="approval", text="run?"))
+    assert resp["choice"] == "approve"
+    assert resp["timed_out"] is False

--- a/engine/tests/test_format_anthropic.py
+++ b/engine/tests/test_format_anthropic.py
@@ -1,0 +1,121 @@
+"""The Anthropic message/tool format adapter.
+
+``to_provider_messages`` / ``to_provider_tools`` produce the Anthropic
+content-block / tool schema; ``from_provider_response`` maps the wire response
+back to the loop's unified representation. ``tool_use`` blocks survive the round
+trip.
+"""
+
+from engine.format.anthropic import AnthropicFormat
+
+
+def test_to_provider_tools_maps_input_schema_key():
+    fmt = AnthropicFormat()
+    tools = [
+        {"name": "cua__click", "description": "click", "inputSchema": {"type": "object"}},
+        {"name": "control__todo_write", "description": "todos", "input_schema": {"type": "object"}},
+    ]
+    out = fmt.to_provider_tools(tools)
+    assert out[0] == {
+        "name": "cua__click",
+        "description": "click",
+        "input_schema": {"type": "object"},
+    }
+    # already-snake input_schema is preserved
+    assert out[1]["input_schema"] == {"type": "object"}
+
+
+def test_to_provider_tools_defaults_missing_schema():
+    fmt = AnthropicFormat()
+    out = fmt.to_provider_tools([{"name": "t", "description": "d"}])
+    assert out[0]["input_schema"] == {"type": "object", "properties": {}}
+
+
+def test_to_provider_messages_passes_content_blocks_through():
+    fmt = AnthropicFormat()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "x", "input": {}}],
+        },
+    ]
+    out = fmt.to_provider_messages(messages)
+    assert out[0] == {"role": "user", "content": "hello"}
+    assert out[1]["content"][0]["type"] == "tool_use"
+
+
+def test_tool_result_dict_content_is_json_stringified():
+    # Anthropic requires tool_result.content to be a string or a list of content
+    # blocks -- never a bare object. The MCP dispatch returns a dict, so the
+    # adapter must serialize it. (Regression: the live endpoint 400'd on this.)
+    fmt = AnthropicFormat()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": {"secret_word": "rhino"},
+                }
+            ],
+        }
+    ]
+    out = fmt.to_provider_messages(messages)
+    block = out[0]["content"][0]
+    assert isinstance(block["content"], str)
+    assert "rhino" in block["content"]
+
+
+def test_tool_result_list_content_blocks_pass_through():
+    # A screenshot tool-result (list of content blocks, incl. an image) must
+    # survive untouched -- only bare-object content is stringified.
+    fmt = AnthropicFormat()
+    blocks = [
+        {"type": "text", "text": "ok"},
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "x"}},
+    ]
+    messages = [
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": blocks}]}
+    ]
+    out = fmt.to_provider_messages(messages)
+    assert out[0]["content"][0]["content"] == blocks
+
+
+def test_tool_result_string_content_is_left_alone():
+    fmt = AnthropicFormat()
+    messages = [
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "plain"}]}
+    ]
+    out = fmt.to_provider_messages(messages)
+    assert out[0]["content"][0]["content"] == "plain"
+
+
+def test_from_provider_response_extracts_content_and_usage():
+    fmt = AnthropicFormat()
+    wire = {
+        "id": "msg_1",
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "done"},
+            {"type": "tool_use", "id": "t1", "name": "cua__click", "input": {"x": 1}},
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 12, "output_tokens": 5},
+    }
+    unified = fmt.from_provider_response(wire)
+    assert unified["content"] == wire["content"]
+    assert unified["usage"] == {"input_tokens": 12, "output_tokens": 5}
+    assert unified["stop_reason"] == "tool_use"
+
+
+def test_tool_use_survives_round_trip():
+    fmt = AnthropicFormat()
+    wire = {
+        "content": [{"type": "tool_use", "id": "t1", "name": "n", "input": {"a": 2}}],
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    unified = fmt.from_provider_response(wire)
+    tool_uses = [b for b in unified["content"] if b["type"] == "tool_use"]
+    assert tool_uses[0]["input"] == {"a": 2}

--- a/engine/tests/test_http.py
+++ b/engine/tests/test_http.py
@@ -1,0 +1,136 @@
+"""The shared async HTTP client: retries, timeouts, logging.
+
+Every provider model call and every OAuth token refresh goes through one
+``HttpClient`` so retry/timeout/logging is written once. Tests drive it with
+``httpx.MockTransport`` -- no socket -- and an injected no-op sleep so a
+back-off never actually waits.
+"""
+
+import httpx
+import pytest
+
+from engine.http import HttpClient
+
+
+async def _noop_sleep(_seconds):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_post_returns_response_on_success():
+    def handler(request):
+        assert request.headers["x-test"] == "1"
+        return httpx.Response(200, json={"ok": True})
+
+    client = HttpClient(
+        transport=httpx.MockTransport(handler), sleep=_noop_sleep
+    )
+    resp = await client.post(
+        "https://example.test/v1/messages", headers={"x-test": "1"}, json={"a": 1}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_retries_on_retryable_status_then_succeeds():
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(503, text="try later")
+        return httpx.Response(200, json={"ok": True})
+
+    client = HttpClient(
+        transport=httpx.MockTransport(handler),
+        max_retries=3,
+        sleep=_noop_sleep,
+    )
+    resp = await client.post("https://example.test/x", json={})
+    assert resp.status_code == 200
+    assert calls["n"] == 3
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_retries_returning_last_response():
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(500, text="boom")
+
+    client = HttpClient(
+        transport=httpx.MockTransport(handler),
+        max_retries=2,
+        sleep=_noop_sleep,
+    )
+    resp = await client.post("https://example.test/x", json={})
+    assert resp.status_code == 500
+    # initial try + 2 retries
+    assert calls["n"] == 3
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_a_4xx():
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(403, text="nope")
+
+    client = HttpClient(
+        transport=httpx.MockTransport(handler),
+        max_retries=3,
+        sleep=_noop_sleep,
+    )
+    resp = await client.post("https://example.test/x", json={})
+    assert resp.status_code == 403
+    assert calls["n"] == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_retries_a_transport_error_then_succeeds():
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("connection refused")
+        return httpx.Response(200, json={"ok": True})
+
+    client = HttpClient(
+        transport=httpx.MockTransport(handler),
+        max_retries=2,
+        sleep=_noop_sleep,
+    )
+    resp = await client.post("https://example.test/x", json={})
+    assert resp.status_code == 200
+    assert calls["n"] == 2
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_backoff_sleeps_between_retries():
+    slept = []
+
+    async def spy_sleep(seconds):
+        slept.append(seconds)
+
+    def handler(request):
+        return httpx.Response(503)
+
+    client = HttpClient(
+        transport=httpx.MockTransport(handler),
+        max_retries=2,
+        backoff_base=0.5,
+        sleep=spy_sleep,
+    )
+    await client.post("https://example.test/x", json={})
+    # one sleep per retry (2), growing
+    assert slept == [0.5, 1.0]
+    await client.aclose()

--- a/engine/tests/test_loop.py
+++ b/engine/tests/test_loop.py
@@ -1,0 +1,183 @@
+"""The shared tool-use loop, wired against fakes.
+
+A scripted ``llm_call`` + a fake ``MCPHost`` + a spy ``Trajectory`` prove the
+loop dispatches tools, journals ``in_flight`` before dispatch and ``done``/
+``error`` after, prunes images each iteration, captures a tool error as an
+``is_error`` result, and returns a ``RunResult``.
+"""
+
+import copy
+
+import pytest
+
+from engine.loop import MaxIterationsExceeded, run_loop
+
+
+def _tool_use_response(tid="t1", name="cua__click", inp=None, in_tok=10, out_tok=5):
+    return {
+        "content": [
+            {"type": "text", "text": "working"},
+            {"type": "tool_use", "id": tid, "name": name, "input": inp or {"x": 1}},
+        ],
+        "usage": {"input_tokens": in_tok, "output_tokens": out_tok},
+    }
+
+
+def _final_response(text="all done", in_tok=3, out_tok=2):
+    return {
+        "content": [{"type": "text", "text": text}],
+        "usage": {"input_tokens": in_tok, "output_tokens": out_tok},
+    }
+
+
+class ScriptedLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def __call__(self, messages, tools, max_tokens):
+        self.calls.append({"messages": copy.deepcopy(messages), "tools": tools})
+        if len(self._responses) == 1:
+            return self._responses[0]
+        return self._responses.pop(0)
+
+
+class FakeMCP:
+    def __init__(self, log, handler=None):
+        self.log = log
+        self._handler = handler or (lambda tu: {"content": "ok"})
+        self.dispatched = []
+
+    def tools(self):
+        return [{"name": "cua__click"}]
+
+    async def dispatch(self, tool_use):
+        self.log.append(("dispatch", tool_use["id"]))
+        self.dispatched.append(tool_use)
+        return self._handler(tool_use)
+
+
+class SpyTrajectory:
+    def __init__(self, log):
+        self.log = log
+        self._seq = -1
+
+    def append_response(self, iteration, response, usage):
+        self.log.append(("response", iteration))
+
+    def append_in_flight(self, iteration, tool_use):
+        self._seq += 1
+        self.log.append(("in_flight", self._seq))
+        return self._seq
+
+    def append_done(self, seq, result):
+        self.log.append(("done", seq))
+
+    def append_error(self, seq, err):
+        self.log.append(("error", seq))
+
+
+class EventSink:
+    def __init__(self):
+        self.events = []
+
+    async def __call__(self, event):
+        self.events.append(event)
+
+
+@pytest.mark.asyncio
+async def test_dispatches_tool_and_returns_run_result():
+    log = []
+    llm = ScriptedLLM([_tool_use_response(), _final_response()])
+    mcp = FakeMCP(log)
+    traj = SpyTrajectory(log)
+
+    result = await run_loop(llm, "do it", mcp, traj, EventSink())
+
+    assert len(mcp.dispatched) == 1
+    assert mcp.dispatched[0]["name"] == "cua__click"
+    assert result.final_text == "all done"
+    assert result.total_iterations == 2
+    assert result.total_input_tokens == 13   # 10 + 3
+    assert result.total_output_tokens == 7   # 5 + 2
+    assert result.trajectory is traj
+
+
+@pytest.mark.asyncio
+async def test_journals_in_flight_before_dispatch_and_done_after():
+    log = []
+    llm = ScriptedLLM([_tool_use_response(), _final_response()])
+    mcp = FakeMCP(log)
+
+    await run_loop(llm, "do it", mcp, SpyTrajectory(log), EventSink())
+
+    phases = [entry[0] for entry in log]
+    i_in_flight = phases.index("in_flight")
+    i_dispatch = phases.index("dispatch")
+    i_done = phases.index("done")
+    assert i_in_flight < i_dispatch < i_done
+
+
+@pytest.mark.asyncio
+async def test_prunes_images_every_iteration(monkeypatch):
+    calls = {"n": 0}
+    import engine.loop as loop_mod
+
+    real = loop_mod.prune_old_images
+
+    def counting_prune(messages, keep_last=3):
+        calls["n"] += 1
+        return real(messages, keep_last=keep_last)
+
+    monkeypatch.setattr(loop_mod, "prune_old_images", counting_prune)
+
+    llm = ScriptedLLM([_tool_use_response(), _final_response()])
+    result = await run_loop(llm, "do it", FakeMCP([]), SpyTrajectory([]), EventSink())
+
+    assert calls["n"] == result.total_iterations == 2
+
+
+@pytest.mark.asyncio
+async def test_tool_error_captured_as_is_error_not_a_crash():
+    log = []
+
+    def boom(tool_use):
+        raise RuntimeError("nope")
+
+    llm = ScriptedLLM([_tool_use_response(), _final_response()])
+    mcp = FakeMCP(log, handler=boom)
+
+    result = await run_loop(llm, "do it", mcp, SpyTrajectory(log), EventSink())
+
+    # The error was journaled as an error close, not swallowed.
+    assert any(entry[0] == "error" for entry in log)
+    # The failed tool came back to the model as an is_error tool_result.
+    fed_back = llm.calls[1]["messages"][-1]["content"][0]
+    assert fed_back["type"] == "tool_result"
+    assert fed_back["is_error"] is True
+    assert "nope" in fed_back["content"]
+    # The run still completed normally.
+    assert result.final_text == "all done"
+
+
+@pytest.mark.asyncio
+async def test_emits_llm_response_and_tool_call_complete_events():
+    sink = EventSink()
+    llm = ScriptedLLM([_tool_use_response(), _final_response()])
+
+    await run_loop(llm, "do it", FakeMCP([]), SpyTrajectory([]), sink)
+
+    types = [e["type"] for e in sink.events]
+    assert types.count("llm_response") == 2
+    assert types.count("tool_call_complete") == 1
+
+
+@pytest.mark.asyncio
+async def test_raises_max_iterations_exceeded_when_agent_never_finishes():
+    llm = ScriptedLLM([_tool_use_response()])  # single element -> always tool_use
+
+    with pytest.raises(MaxIterationsExceeded):
+        await run_loop(
+            llm, "loop forever", FakeMCP([]), SpyTrajectory([]), EventSink(),
+            max_iterations=3,
+        )

--- a/engine/tests/test_mcp.py
+++ b/engine/tests/test_mcp.py
@@ -70,3 +70,49 @@ async def test_server_name_collision_is_a_startup_error():
     host = MCPHost([FakeServer("cua", ["click"]), FakeServer("cua", ["type"])])
     with pytest.raises(ValueError):
         await host.connect()
+
+
+class BrokenServer:
+    """A server that will not start -- a misconfigured or unreachable one."""
+
+    def __init__(self, name):
+        self.name = name
+
+    async def list_tools(self):
+        raise RuntimeError(f"{self.name}: cannot start")
+
+    async def call_tool(self, name, args):  # pragma: no cover - never reached
+        raise AssertionError("a dropped server must never be dispatched to")
+
+
+@pytest.mark.asyncio
+async def test_a_broken_server_is_dropped_not_fatal():
+    """Regression (E2E/0.4.0 F5): one unreachable server raised straight out of
+    connect(), so the run never started and every healthy server's tools were
+    lost with it."""
+    host = MCPHost([FakeServer("control", ["ask_user"]), BrokenServer("broken")])
+
+    await host.connect()
+
+    assert [t["name"] for t in host.tools()] == ["control__ask_user"]
+    assert "broken" in host.failed()
+    assert "cannot start" in host.failed()["broken"]
+    # The healthy server still routes.
+    assert await host.dispatch({"name": "control__ask_user", "input": {}})
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_server_is_unroutable():
+    host = MCPHost([FakeServer("control", ["ask_user"]), BrokenServer("broken")])
+    await host.connect()
+
+    with pytest.raises(UnknownToolError):
+        await host.dispatch({"name": "broken__anything", "input": {}})
+
+
+@pytest.mark.asyncio
+async def test_failed_is_empty_when_every_server_starts():
+    host = MCPHost([FakeServer("control", ["ask_user"]), FakeServer("cua", ["click"])])
+    await host.connect()
+
+    assert host.failed() == {}

--- a/engine/tests/test_mcp.py
+++ b/engine/tests/test_mcp.py
@@ -1,0 +1,72 @@
+"""The generic MCP host: aggregate + namespace + route.
+
+The host fronts a configured set of MCP servers, aggregates their specs into
+one namespaced list the agent sees, and routes each call to the owning server.
+A control-plane tool and a cua tool sit in the same list; a name collision
+across servers is a startup error.
+"""
+
+import pytest
+
+from engine.mcp import MCPHost, MCPServer, UnknownToolError, dispatch_to_mcp
+
+
+class FakeServer:
+    def __init__(self, name, tools):
+        self.name = name
+        self._tools = tools
+        self.calls = []
+
+    async def list_tools(self):
+        return [{"name": t, "description": f"{t} tool"} for t in self._tools]
+
+    async def call_tool(self, name, args):
+        self.calls.append((name, args))
+        return {"server": self.name, "tool": name, "args": args}
+
+
+def test_fake_server_satisfies_the_protocol():
+    assert isinstance(FakeServer("cua", ["click"]), MCPServer)
+
+
+@pytest.mark.asyncio
+async def test_tools_is_the_namespaced_union_across_servers():
+    cua = FakeServer("cua", ["click", "type"])
+    control = FakeServer("control", ["request_approval"])
+    host = MCPHost([cua, control])
+    await host.connect()
+
+    names = {spec["name"] for spec in host.tools()}
+    # cua capability tools AND the control-plane tool are all reachable.
+    assert names == {"cua__click", "cua__type", "control__request_approval"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_the_owning_server():
+    cua = FakeServer("cua", ["click"])
+    control = FakeServer("control", ["request_approval"])
+    host = MCPHost([cua, control])
+    await host.connect()
+
+    result = await dispatch_to_mcp(
+        {"id": "t1", "name": "control__request_approval", "input": {"risk": "high"}}, host
+    )
+
+    assert result["server"] == "control"
+    assert control.calls == [("request_approval", {"risk": "high"})]
+    assert cua.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_raises():
+    host = MCPHost([FakeServer("cua", ["click"])])
+    await host.connect()
+    with pytest.raises(UnknownToolError):
+        await host.dispatch({"id": "t1", "name": "nope__missing", "input": {}})
+
+
+@pytest.mark.asyncio
+async def test_server_name_collision_is_a_startup_error():
+    host = MCPHost([FakeServer("cua", ["click"]), FakeServer("cua", ["type"])])
+    with pytest.raises(ValueError):
+        await host.connect()

--- a/engine/tests/test_policy.py
+++ b/engine/tests/test_policy.py
@@ -1,0 +1,72 @@
+"""The host-owned policy hook: denylist, risk, auth-mode -> a decision.
+
+cua emits ``tier`` + ``risk`` and no policy; the host decides. A denylisted
+action is auto-denied without ever reaching a human; ``risk == "high"`` needs a
+human; otherwise the auth-mode (bypass / default / autonomous / paranoid)
+decides. ``redact`` strips secrets before any write / emit.
+"""
+
+import pytest
+
+from engine.policy.base import AUTO_ALLOW, AUTO_DENY, NEEDS_HUMAN, ApprovalRequest
+from engine.policy.default import DefaultPolicy
+
+
+def _req(action="shell.run rm -rf /tmp/x", risk="medium"):
+    return ApprovalRequest(action=action, risk=risk, preview="preview", idem="sha256:x")
+
+
+@pytest.mark.asyncio
+async def test_denylist_match_is_auto_deny_without_a_human():
+    policy = DefaultPolicy(denylist=["rm -rf /"], auth_mode="default")
+    d = await policy.check(_req(action="shell.run rm -rf / now", risk="low"))
+    assert d.outcome == AUTO_DENY
+
+
+@pytest.mark.asyncio
+async def test_high_risk_needs_human_in_default_mode():
+    policy = DefaultPolicy(auth_mode="default")
+    d = await policy.check(_req(risk="high"))
+    assert d.outcome == NEEDS_HUMAN
+
+
+@pytest.mark.asyncio
+async def test_medium_risk_auto_allows_in_default_mode():
+    policy = DefaultPolicy(auth_mode="default")
+    d = await policy.check(_req(risk="medium"))
+    assert d.outcome == AUTO_ALLOW
+
+
+@pytest.mark.asyncio
+async def test_bypass_mode_allows_even_high_risk():
+    policy = DefaultPolicy(auth_mode="bypass")
+    d = await policy.check(_req(risk="high"))
+    assert d.outcome == AUTO_ALLOW
+
+
+@pytest.mark.asyncio
+async def test_paranoid_mode_needs_human_even_for_low_risk():
+    policy = DefaultPolicy(auth_mode="paranoid")
+    d = await policy.check(_req(risk="low"))
+    assert d.outcome == NEEDS_HUMAN
+
+
+@pytest.mark.asyncio
+async def test_paranoid_still_denies_denylisted():
+    policy = DefaultPolicy(denylist=["curl evil"], auth_mode="paranoid")
+    d = await policy.check(_req(action="shell.run curl evil.com", risk="low"))
+    assert d.outcome == AUTO_DENY
+
+
+@pytest.mark.asyncio
+async def test_autonomous_allows_medium_but_gates_high():
+    policy = DefaultPolicy(auth_mode="autonomous")
+    assert (await policy.check(_req(risk="medium"))).outcome == AUTO_ALLOW
+    assert (await policy.check(_req(risk="high"))).outcome == NEEDS_HUMAN
+
+
+def test_redact_strips_secrets():
+    policy = DefaultPolicy()
+    out = policy.redact({"api_key": "sk-ant-oat01-SECRET", "keep": "ok"})
+    assert out["api_key"] == "[REDACTED]"
+    assert out["keep"] == "ok"

--- a/engine/tests/test_ports.py
+++ b/engine/tests/test_ports.py
@@ -1,0 +1,69 @@
+"""The core ports are runtime-checkable protocols a concrete can satisfy.
+
+These lock the signatures the rest of vadgr depends on -- the loop and callers
+depend on the protocol, never a concrete class.
+"""
+
+from engine.auth.base import AuthStrategy
+from engine.base import AgentProvider, RunResult
+from engine.format.base import MessageFormat
+from engine.trajectory import Trajectory
+
+
+class _Provider:
+    name = "fake"
+    auth_mode = "none"
+    default_model = "m"
+
+    async def setup(self):
+        ...
+
+    async def run_agent(self, task, mcp_servers, on_event, **kwargs):
+        ...
+
+    async def teardown(self):
+        ...
+
+
+class _Auth:
+    async def inject_headers(self, request):
+        ...
+
+    async def handle_401(self, response):
+        return False
+
+
+class _Format:
+    def to_provider_messages(self, messages):
+        return messages
+
+    def to_provider_tools(self, tools):
+        return tools
+
+    def from_provider_response(self, response):
+        return response
+
+
+def test_provider_protocol_is_satisfiable():
+    assert isinstance(_Provider(), AgentProvider)
+
+
+def test_auth_protocol_is_satisfiable():
+    assert isinstance(_Auth(), AuthStrategy)
+
+
+def test_format_protocol_is_satisfiable():
+    assert isinstance(_Format(), MessageFormat)
+
+
+def test_run_result_carries_the_journal(tmp_path):
+    traj = Trajectory("run-x", path=str(tmp_path / "t.jsonl"))
+    result = RunResult(
+        final_text="done",
+        trajectory=traj,
+        total_iterations=1,
+        total_input_tokens=5,
+        total_output_tokens=2,
+    )
+    assert result.trajectory is traj
+    assert result.final_text == "done"

--- a/engine/tests/test_provider.py
+++ b/engine/tests/test_provider.py
@@ -1,0 +1,265 @@
+"""The Anthropic-family base + the native_anthropic_oauth provider.
+
+Against a mock transport, the outbound request must carry every validator
+invariant Anthropic enforces server-side: ``Authorization: Bearer`` (never
+``x-api-key``), the ``claude-cli/<ver> (external, cli)`` User-Agent, the
+``anthropic-beta`` flags, ``anthropic-version``, the Claude Code system prefix as
+the first system block, and ``mcp_``-prefixed tool names -- un-prefixed on the
+way back. A 403 maps to the validator-update error; a 401 refreshes and retries.
+``run_agent`` wires the control-plane server in beside cua and drives the loop.
+"""
+
+import json
+import re
+import time
+
+import httpx
+import pytest
+
+from engine.auth.none import NoAuthStrategy
+from engine.auth.oauth import OAuthStrategy
+from engine.http import HttpClient
+from engine.providers._anthropic_base import (
+    CLAUDE_CODE_SYSTEM_PREFIX,
+    AnthropicBase,
+    ValidatorRejectedError,
+)
+from engine.providers.native_anthropic_oauth import AnthropicOAuthProvider
+
+
+REFRESH_URL = "https://platform.claude.com/oauth/token"
+CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+
+def _final(text="done"):
+    return {
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 2},
+    }
+
+
+def _with_tool(name="mcp_cua__click"):
+    return {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "clicking"},
+            {"type": "tool_use", "id": "t1", "name": name, "input": {"x": 1}},
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 10, "output_tokens": 4},
+    }
+
+
+class _NoAuthBase(AnthropicBase):
+    name = "test_anthropic"
+    auth_mode = "none"
+    default_model = "claude-sonnet-4-6"
+    user_agent = "claude-cli/2.1.2 (external, cli)"
+    extra_headers = {"anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14"}
+
+
+class FakeCua:
+    name = "cua"
+
+    async def list_tools(self):
+        return [{"name": "click", "description": "click"}]
+
+    async def call_tool(self, name, args):
+        return {"clicked": True, "name": name, "args": args}
+
+
+class Sink:
+    def __init__(self):
+        self.events = []
+
+    async def __call__(self, event):
+        self.events.append(event)
+
+
+# ---- validator invariants on the outbound request --------------------------
+
+@pytest.mark.asyncio
+async def test_outbound_request_carries_the_validator_invariants(tmp_path):
+    captured = {}
+
+    def handler(request):
+        captured["headers"] = request.headers
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json=_final())
+
+    creds = tmp_path / ".credentials.json"
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "acc-123",
+                    "refreshToken": "ref",
+                    "expiresAt": int(time.time() * 1000) + 3_600_000,
+                }
+            }
+        )
+    )
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    oauth = OAuthStrategy(
+        credentials_path=str(creds), refresh_url=REFRESH_URL, client_id=CLIENT_ID,
+        os_name="Linux", http=http,
+    )
+    provider = _NoAuthBase(http=http, auth_strategy=oauth)
+
+    tools = [{"name": "cua__click", "description": "click", "inputSchema": {"type": "object"}}]
+    await provider.llm_call([{"role": "user", "content": "hi"}], tools=tools, max_tokens=64)
+
+    headers = captured["headers"]
+    body = captured["body"]
+    assert headers["authorization"] == "Bearer acc-123"
+    assert "x-api-key" not in headers
+    assert re.match(r"claude-cli/[\d.]+ \(external, cli\)", headers["user-agent"])
+    assert "oauth-2025-04-20" in headers["anthropic-beta"]
+    assert headers["anthropic-version"] == "2023-06-01"
+    # System starts with the Claude Code identity block.
+    assert body["system"][0]["text"] == CLAUDE_CODE_SYSTEM_PREFIX
+    # Tool names go out mcp_-prefixed.
+    assert body["tools"][0]["name"] == "mcp_cua__click"
+    await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_response_tool_names_are_un_prefixed_on_the_way_back():
+    def handler(request):
+        return httpx.Response(200, json=_with_tool("mcp_cua__click"))
+
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    provider = _NoAuthBase(http=http, auth_strategy=NoAuthStrategy())
+    unified = await provider.llm_call([{"role": "user", "content": "x"}], tools=[], max_tokens=64)
+    tool_uses = [b for b in unified["content"] if b["type"] == "tool_use"]
+    assert tool_uses[0]["name"] == "cua__click"
+    await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_403_maps_to_validator_update_error():
+    def handler(request):
+        return httpx.Response(403, json={"error": "forbidden"})
+
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    provider = _NoAuthBase(http=http, auth_strategy=NoAuthStrategy())
+    with pytest.raises(ValidatorRejectedError):
+        await provider.llm_call([{"role": "user", "content": "x"}], tools=[], max_tokens=64)
+    await http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_401_refreshes_then_retries_once(tmp_path):
+    creds = tmp_path / ".credentials.json"
+    now_ms = 1_000_000_000_000
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "acc-old",
+                    "refreshToken": "ref-old",
+                    "expiresAt": now_ms + 3_600_000,
+                }
+            }
+        )
+    )
+    seen_tokens = []
+    state = {"messages_calls": 0}
+
+    def handler(request):
+        if request.url.path.endswith("/oauth/token"):
+            return httpx.Response(
+                200,
+                json={"access_token": "acc-new", "refresh_token": "ref-new", "expires_in": 3600},
+            )
+        # /v1/messages
+        state["messages_calls"] += 1
+        seen_tokens.append(request.headers["authorization"])
+        if state["messages_calls"] == 1:
+            return httpx.Response(401, json={"error": "expired"})
+        return httpx.Response(200, json=_final("recovered"))
+
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    oauth = OAuthStrategy(
+        credentials_path=str(creds), refresh_url=REFRESH_URL, client_id=CLIENT_ID,
+        os_name="Linux", http=http, now=lambda: now_ms,
+    )
+    provider = _NoAuthBase(http=http, auth_strategy=oauth)
+    unified = await provider.llm_call([{"role": "user", "content": "x"}], tools=[], max_tokens=64)
+
+    assert state["messages_calls"] == 2
+    assert seen_tokens == ["Bearer acc-old", "Bearer acc-new"]
+    assert "recovered" in unified["content"][0]["text"]
+    await http.aclose()
+
+
+# ---- run_agent wiring ------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_agent_wires_control_plane_and_drives_loop(tmp_path):
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(200, json=_with_tool("mcp_cua__click"))
+        return httpx.Response(200, json=_final("all done"))
+
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    provider = _NoAuthBase(http=http, auth_strategy=NoAuthStrategy(), runs_dir=str(tmp_path))
+    sink = Sink()
+
+    result = await provider.run_agent(
+        "do the thing", [FakeCua()], sink, run_id="run-xyz"
+    )
+
+    assert result.final_text == "all done"
+    assert result.total_iterations == 2
+    assert result.total_input_tokens == 15  # 10 + 5
+    # The cua tool was actually dispatched (mcp_ stripped, routed to cua).
+    assert any(e["type"] == "tool_call_complete" for e in sink.events)
+    # The journal was written for this run.
+    import os
+
+    assert os.path.exists(result.trajectory.path)
+    await provider.teardown()
+
+
+@pytest.mark.asyncio
+async def test_run_agent_control_tools_reach_the_agent(tmp_path):
+    seen_tools = {}
+
+    def handler(request):
+        body = json.loads(request.content)
+        for t in body.get("tools", []):
+            seen_tools[t["name"]] = True
+        return httpx.Response(200, json=_final("ok"))
+
+    http = HttpClient(transport=httpx.MockTransport(handler))
+    provider = _NoAuthBase(http=http, auth_strategy=NoAuthStrategy(), runs_dir=str(tmp_path))
+    await provider.run_agent("go", [FakeCua()], Sink(), run_id="run-tools")
+
+    # Control-plane tools are in the list the agent sees (mcp_-prefixed).
+    assert "mcp_control__request_approval" in seen_tools
+    assert "mcp_cua__click" in seen_tools
+    await provider.teardown()
+
+
+# ---- the concrete OAuth provider -------------------------------------------
+
+def test_oauth_provider_identity():
+    provider = AnthropicOAuthProvider()
+    assert provider.name == "anthropic_oauth"
+    assert provider.auth_mode == "oauth"
+    assert provider.user_agent.startswith("claude-cli/")
+    assert "oauth-2025-04-20" in provider.extra_headers["anthropic-beta"]
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_refuses_production_mode(monkeypatch):
+    monkeypatch.setenv("VADGR_MODE", "production")
+    provider = AnthropicOAuthProvider()
+    with pytest.raises(RuntimeError):
+        await provider.setup()

--- a/engine/tests/test_prune_images.py
+++ b/engine/tests/test_prune_images.py
@@ -1,0 +1,130 @@
+"""The issue #10 regression guard: keep-last-N screenshot pruning.
+
+A long desktop loop accumulates screenshots in the request body until it
+crosses the provider's wire limit and the session dies. Because the native loop
+owns the message history, it can prune old screenshots -- keep the last N,
+replace the rest with a small text placeholder -- so the body never creeps
+toward the limit.
+"""
+
+import copy
+import json
+
+from engine.loop import PRUNED_PLACEHOLDER_TEXT, prune_old_images
+
+
+def _image_block(tag: str) -> dict:
+    # A heavy base64 image payload -- the only thing that grows the body.
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": tag + ("A" * 5000),
+        },
+    }
+
+
+def _history_with_images(count: int) -> list:
+    """A realistic history: a user task, then `count` assistant/tool-result
+    turns each carrying one screenshot plus tool-result text."""
+    messages = [{"role": "user", "content": "do the thing"}]
+    for i in range(count):
+        messages.append(
+            {"role": "assistant", "content": [{"type": "text", "text": f"step {i}"}]}
+        )
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": f"t{i}",
+                        "content": [
+                            {"type": "text", "text": f"result text {i}"},
+                            _image_block(f"img{i}-"),
+                        ],
+                    }
+                ],
+            }
+        )
+    return messages
+
+
+def _collect_image_data(messages: list) -> list:
+    found = []
+    for msg in messages:
+        content = msg["content"]
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if block.get("type") == "image":
+                found.append(block["source"]["data"])
+            elif block.get("type") == "tool_result" and isinstance(
+                block.get("content"), list
+            ):
+                for inner in block["content"]:
+                    if inner.get("type") == "image":
+                        found.append(inner["source"]["data"])
+    return found
+
+
+def test_keeps_last_n_images_intact_and_prunes_the_rest():
+    messages = _history_with_images(6)
+    keep = 3
+
+    prune_old_images(messages, keep_last=keep)
+
+    remaining = _collect_image_data(messages)
+    assert len(remaining) == keep
+    # The intact images are the last N (imgs 3, 4, 5).
+    assert [d[:6] for d in remaining] == ["img3-A", "img4-A", "img5-A"]
+
+
+def test_pruned_images_become_the_text_placeholder():
+    messages = _history_with_images(5)
+
+    prune_old_images(messages, keep_last=2)
+
+    # The two oldest tool-result turns now carry a placeholder text block in
+    # place of the image, not an image block.
+    tool_result_0 = messages[2]["content"][0]
+    blocks = tool_result_0["content"]
+    assert not any(b.get("type") == "image" for b in blocks)
+    assert {"type": "text", "text": PRUNED_PLACEHOLDER_TEXT} in blocks
+
+
+def test_tool_result_text_and_message_order_untouched():
+    messages = _history_with_images(4)
+    original = copy.deepcopy(messages)
+
+    prune_old_images(messages, keep_last=1)
+
+    # Same number of messages, same roles, same order.
+    assert len(messages) == len(original)
+    assert [m["role"] for m in messages] == [m["role"] for m in original]
+    # Every tool-result text block survives verbatim.
+    for i in range(4):
+        blocks = messages[2 + i * 2]["content"][0]["content"]
+        assert {"type": "text", "text": f"result text {i}"} in blocks
+
+
+def test_serialized_body_shrinks_below_the_pre_prune_size():
+    messages = _history_with_images(10)
+    before = len(json.dumps(messages))
+
+    prune_old_images(messages, keep_last=3)
+
+    after = len(json.dumps(messages))
+    assert after < before
+    # Only 3 heavy payloads remain, not 10.
+    assert len(_collect_image_data(messages)) == 3
+
+
+def test_fewer_images_than_keep_last_is_a_no_op():
+    messages = _history_with_images(2)
+    original = copy.deepcopy(messages)
+
+    prune_old_images(messages, keep_last=5)
+
+    assert messages == original

--- a/engine/tests/test_tools.py
+++ b/engine/tests/test_tools.py
@@ -290,3 +290,59 @@ async def test_notify_user_routes_to_channel_and_maps_importance():
     assert res["ok"] is True
     assert res["delivered"] == ["cli"]
     assert channel.notes == [("done", "high")]
+
+
+@pytest.mark.asyncio
+async def test_todo_status_accepts_the_synonyms_a_model_reaches_for():
+    """Regression (E2E/0.4.0 F3): given a plain goal the model wrote
+    ``completed``; the vocabulary is ``done``, the schema enum is advisory, and
+    the mismatch cost an iteration on an error."""
+    server, _, _ = _server()
+    await server.call_tool("todo_write", {"items": [{"id": "1", "content": "step one"}]})
+
+    result = await server.call_tool("todo_update", {"id": "1", "status": "completed"})
+
+    assert result["todo"]["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_todo_status_synonyms_across_the_vocabulary():
+    server, _, _ = _server()
+    for given, expected in (
+        ("complete", "done"),
+        ("Finished", "done"),
+        ("in-progress", "in_progress"),
+        ("in progress", "in_progress"),
+        ("canceled", "cancelled"),
+        ("todo", "pending"),
+    ):
+        result = await server.call_tool(
+            "todo_write", {"items": [{"content": "x", "status": given}]}
+        )
+        assert result["todos"][0]["status"] == expected, given
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_todo_status_names_every_legal_value():
+    server, _, _ = _server()
+    with pytest.raises(ValueError) as excinfo:
+        await server.call_tool(
+            "todo_write", {"items": [{"content": "x", "status": "nope"}]}
+        )
+
+    message = str(excinfo.value)
+    for status in ("pending", "in_progress", "done", "cancelled"):
+        assert status in message
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_todo_id_names_the_known_ids():
+    server, _, _ = _server()
+    await server.call_tool(
+        "todo_write", {"items": [{"content": "a"}, {"content": "b"}]}
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await server.call_tool("todo_update", {"id": "99", "status": "done"})
+
+    assert "known ids: 1, 2" in str(excinfo.value)

--- a/engine/tests/test_tools.py
+++ b/engine/tests/test_tools.py
@@ -1,0 +1,292 @@
+"""The in-process control-plane MCP server + its 7 tools.
+
+Driven against a fake run context, a fake channel, and the default policy. The
+server satisfies ``MCPServer`` (so the ``MCPHost`` wires it in beside cua); its
+tools cover todo/progress/HITL/notify. The HITL gate is spec-critical:
+``request_approval`` **blocks then resolves** on approve / reject / timeout, and
+an auto-decision from policy never touches the channel.
+"""
+
+import asyncio
+
+import pytest
+
+from engine.channels.base import Delivery, HumanPrompt
+from engine.mcp import MCPHost, MCPServer
+from engine.policy.default import DefaultPolicy
+from engine.tools import ControlPlaneServer, RunContext
+
+
+class FakeChannel:
+    def __init__(self, name="cli", answer=None, gate=None):
+        self.name = name
+        self._answer = answer or {"choice": "approve", "text": None, "timed_out": False}
+        self._gate = gate            # optional asyncio.Event to block on
+        self.requests = []
+        self.notes = []
+
+    async def request(self, prompt):
+        self.requests.append(prompt)
+        if self._gate is not None:
+            await self._gate.wait()
+        return self._answer
+
+    async def notify(self, message, *, importance):
+        self.notes.append((message, importance))
+        return Delivery(delivered=[self.name])
+
+
+class Router:
+    """Minimal ChannelRouter stand-in exposing request/notify."""
+
+    def __init__(self, channel):
+        self.channel = channel
+
+    async def request(self, prompt, *, channel=None):
+        return await self.channel.request(prompt)
+
+    async def notify(self, message, *, importance="normal", channel=None):
+        return await self.channel.notify(message, importance=importance)
+
+
+class RecordingCtx(RunContext):
+    pass
+
+
+def _server(channel=None, policy=None, ctx=None):
+    channel = channel or FakeChannel()
+    events = []
+
+    async def emit(event):
+        events.append(event)
+
+    ctx = ctx or RunContext(run_id="run-1", emit=emit)
+    ctx._events = events  # type: ignore[attr-defined]
+    return ControlPlaneServer(ctx, Router(channel), policy or DefaultPolicy()), ctx, channel
+
+
+# ---- server plumbing -------------------------------------------------------
+
+def test_server_satisfies_mcp_server_protocol():
+    server, _, _ = _server()
+    assert isinstance(server, MCPServer)
+    assert server.name == "control"
+
+
+@pytest.mark.asyncio
+async def test_list_tools_exposes_the_seven_control_plane_tools():
+    server, _, _ = _server()
+    names = {spec["name"] for spec in await server.list_tools()}
+    assert names == {
+        "todo_write",
+        "todo_update",
+        "report_progress",
+        "get_run_status",
+        "request_approval",
+        "ask_user",
+        "propose_plan",
+        "notify_user",
+    }
+
+
+@pytest.mark.asyncio
+async def test_host_aggregates_control_tools_beside_cua():
+    server, _, _ = _server()
+
+    class Cua:
+        name = "cua"
+
+        async def list_tools(self):
+            return [{"name": "click", "description": "c"}]
+
+        async def call_tool(self, name, args):
+            return {"ok": True}
+
+    host = MCPHost([Cua(), server])
+    await host.connect()
+    names = {s["name"] for s in host.tools()}
+    assert "cua__click" in names
+    assert "control__request_approval" in names
+
+
+# ---- todo / progress -------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_todo_write_replaces_list_and_streams_event():
+    server, ctx, _ = _server()
+    res = await server.call_tool(
+        "todo_write", {"items": [{"id": "1", "content": "step one"}]}
+    )
+    assert res["ok"] is True
+    assert ctx.todos[0]["content"] == "step one"
+    assert ctx.todos[0]["status"] == "pending"
+    assert any(e["type"] == "todos" for e in ctx._events)
+
+
+@pytest.mark.asyncio
+async def test_todo_update_walks_status_and_rejects_bad_status():
+    server, ctx, _ = _server()
+    await server.call_tool("todo_write", {"items": [{"id": "1", "content": "x"}]})
+    res = await server.call_tool("todo_update", {"id": "1", "status": "in_progress"})
+    assert res["todo"]["status"] == "in_progress"
+
+    with pytest.raises(ValueError):
+        await server.call_tool("todo_update", {"id": "1", "status": "bogus"})
+    with pytest.raises(ValueError):
+        await server.call_tool("todo_update", {"id": "nope", "status": "done"})
+
+
+@pytest.mark.asyncio
+async def test_report_progress_emits_event():
+    server, ctx, _ = _server()
+    res = await server.call_tool("report_progress", {"message": "halfway"})
+    assert res == {"ok": True}
+    assert any(
+        e["type"] == "progress" and e["message"] == "halfway" for e in ctx._events
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_run_status_reports_shape():
+    server, ctx, _ = _server()
+    ctx.iteration = 4
+    ctx.input_tokens = 100
+    ctx.output_tokens = 20
+    await server.call_tool("todo_write", {"items": [{"id": "1", "content": "x"}]})
+    status = await server.call_tool("get_run_status", {})
+    assert status["run_id"] == "run-1"
+    assert status["state"] == "running"
+    assert status["iteration"] == 4
+    assert status["tokens"] == {"input": 100, "output": 20}
+    assert len(status["todos"]) == 1
+
+
+# ---- HITL gate -------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_request_approval_auto_allow_never_touches_channel():
+    channel = FakeChannel()
+    server, _, _ = _server(channel=channel, policy=DefaultPolicy(auth_mode="bypass"))
+    res = await server.call_tool(
+        "request_approval",
+        {"action": "shell.run ls", "risk": "high", "preview": "ls"},
+    )
+    assert res["decision"] == "approve"
+    assert channel.requests == []
+
+
+@pytest.mark.asyncio
+async def test_request_approval_denylist_auto_denies_without_channel():
+    channel = FakeChannel()
+    policy = DefaultPolicy(denylist=["rm -rf /"], auth_mode="default")
+    server, _, _ = _server(channel=channel, policy=policy)
+    res = await server.call_tool(
+        "request_approval",
+        {"action": "shell.run rm -rf / now", "risk": "low", "preview": "danger"},
+    )
+    assert res["decision"] == "reject"
+    assert channel.requests == []
+
+
+@pytest.mark.asyncio
+async def test_request_approval_high_risk_routes_to_channel_and_approves():
+    channel = FakeChannel(answer={"choice": "approve", "text": "go", "timed_out": False})
+    server, _, _ = _server(channel=channel, policy=DefaultPolicy(auth_mode="default"))
+    res = await server.call_tool(
+        "request_approval",
+        {"action": "shell.run deploy", "risk": "high", "preview": "deploy"},
+    )
+    assert res["decision"] == "approve"
+    assert len(channel.requests) == 1
+    assert channel.requests[0].kind == "approval"
+
+
+@pytest.mark.asyncio
+async def test_request_approval_reject_is_a_normal_result_not_a_crash():
+    channel = FakeChannel(answer={"choice": "reject", "text": None, "timed_out": False})
+    server, _, _ = _server(channel=channel, policy=DefaultPolicy(auth_mode="default"))
+    res = await server.call_tool(
+        "request_approval", {"action": "x", "risk": "high", "preview": "p"}
+    )
+    assert res["decision"] == "reject"
+
+
+@pytest.mark.asyncio
+async def test_request_approval_timeout_maps_to_timeout_decision():
+    channel = FakeChannel(answer={"choice": None, "text": None, "timed_out": True})
+    server, _, _ = _server(channel=channel, policy=DefaultPolicy(auth_mode="paranoid"))
+    res = await server.call_tool(
+        "request_approval", {"action": "x", "risk": "low", "preview": "p", "timeout": 1}
+    )
+    assert res["decision"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_request_approval_blocks_until_channel_responds():
+    gate = asyncio.Event()
+    channel = FakeChannel(
+        answer={"choice": "approve", "text": None, "timed_out": False}, gate=gate
+    )
+    server, _, _ = _server(channel=channel, policy=DefaultPolicy(auth_mode="paranoid"))
+
+    task = asyncio.create_task(
+        server.call_tool("request_approval", {"action": "x", "risk": "low"})
+    )
+    await asyncio.sleep(0.02)
+    # Still blocked -- no decision yet, loop iteration is suspended on the await.
+    assert not task.done()
+    gate.set()
+    res = await task
+    assert res["decision"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_request_approval_journals_await_user_on_the_open_seq(tmp_path):
+    from engine.trajectory import Trajectory
+
+    traj = Trajectory("run-await", path=str(tmp_path / "t.jsonl"))
+    # The loop opens the in_flight action just before dispatch.
+    seq = traj.append_in_flight(0, {"id": "t1", "name": "control__request_approval", "input": {}})
+
+    channel = FakeChannel(answer={"choice": "approve", "text": None, "timed_out": False})
+    ctx = RunContext(run_id="run-await", trajectory=traj)
+    server = ControlPlaneServer(ctx, Router(channel), DefaultPolicy(auth_mode="paranoid"))
+    await server.call_tool("request_approval", {"action": "x", "risk": "low"})
+    traj.append_done(seq, {"decision": "approve"})
+
+    import json
+
+    lines = [json.loads(l) for l in open(traj.path) if l.strip()]
+    await_lines = [l for l in lines if l["phase"] == "await_user"]
+    assert await_lines and await_lines[0]["seq"] == seq
+
+
+@pytest.mark.asyncio
+async def test_ask_user_returns_answer():
+    channel = FakeChannel(answer={"choice": "green", "text": "green", "timed_out": False})
+    server, _, _ = _server(channel=channel)
+    res = await server.call_tool("ask_user", {"question": "colour?"})
+    assert res == {"answer": "green", "timed_out": False}
+
+
+@pytest.mark.asyncio
+async def test_propose_plan_returns_decision():
+    channel = FakeChannel(answer={"choice": "revise", "text": "tweak step 2", "timed_out": False})
+    server, _, _ = _server(channel=channel)
+    res = await server.call_tool("propose_plan", {"plan": "do a, b, c"})
+    assert res["decision"] == "revise"
+    assert res["feedback"] == "tweak step 2"
+
+
+# ---- notify ----------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_notify_user_routes_to_channel_and_maps_importance():
+    channel = FakeChannel()
+    server, _, _ = _server(channel=channel)
+    res = await server.call_tool(
+        "notify_user", {"message": "done", "importance": "high"}
+    )
+    assert res["ok"] is True
+    assert res["delivered"] == ["cli"]
+    assert channel.notes == [("done", "high")]

--- a/engine/tests/test_trajectory.py
+++ b/engine/tests/test_trajectory.py
@@ -10,7 +10,13 @@ import json
 
 import pytest
 
-from engine.trajectory import Trajectory, find_latest, resume
+from engine.loop import Usage
+from engine.trajectory import (
+    Trajectory,
+    find_latest,
+    is_secret_key,
+    resume,
+)
 
 
 def _read_lines(path) -> list[dict]:
@@ -156,3 +162,60 @@ def test_find_latest_returns_none_when_all_finished(tmp_path):
     s = t.append_in_flight(0, _tool_use())
     t.append_done(s, {"ok": True})
     assert find_latest(runs_dir=str(runs)) is None
+
+
+def test_usage_counts_survive_redaction(tmp_path):
+    """Regression (E2E/0.4.0 F6): the key pattern matched the substring
+    ``token``, so ``input_tokens`` / ``output_tokens`` were redacted and usage
+    could not be reconstructed from the journal -- the durable record."""
+    journal = tmp_path / "t.jsonl"
+    traj = Trajectory("run-1", path=str(journal))
+
+    traj.append_response(
+        0,
+        {
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {"input_tokens": 2759, "output_tokens": 128},
+        },
+        Usage(input_tokens=2759, output_tokens=128),
+    )
+
+    record = json.loads(journal.read_text().strip())
+    # The loop's own accounting line was never routed through redaction...
+    assert record["usage"] == {"input_tokens": 2759, "output_tokens": 128}
+    # ...but the provider's response, which IS redacted, carries the same counts
+    # and used to arrive as "[REDACTED]".
+    assert record["response"]["usage"] == {
+        "input_tokens": 2759,
+        "output_tokens": 128,
+    }
+
+
+def test_secret_keys_are_matched_as_whole_words():
+    """Credentials are redacted whichever way the key is spelled; counts and
+    limits that merely contain the word are not."""
+    for key in (
+        "token",
+        "access_token",
+        "accessToken",
+        "refresh-token",
+        "api_key",
+        "apiKey",
+        "client_secret",
+        "Authorization",
+        "password",
+        "session_key",
+    ):
+        assert is_secret_key(key), key
+
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "total_input_tokens",
+        "max_tokens",
+        "tokens_used",
+        "stop_reason",
+        "message",
+        "auth_mode",
+    ):
+        assert not is_secret_key(key), key

--- a/engine/tests/test_trajectory.py
+++ b/engine/tests/test_trajectory.py
@@ -1,0 +1,158 @@
+"""The append-only JSONL resume journal.
+
+One monotonic ``seq``, code-enforced by the loop: every tool call writes
+``in_flight`` before dispatch and ``done``/``error`` after, so a mid-action
+crash always leaves a dangling record -- the signal resume keys on. Secrets are
+redacted on write, so the one file is both audit trail and resume source.
+"""
+
+import json
+
+import pytest
+
+from engine.trajectory import Trajectory, find_latest, resume
+
+
+def _read_lines(path) -> list[dict]:
+    with open(path) as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def _tool_use(name="browser__click", params=None, tid="t1", step="book-flight"):
+    return {"id": tid, "name": name, "input": params or {"x": 1}, "step": step}
+
+
+def test_in_flight_then_done_share_one_seq_in_order(tmp_path):
+    journal = tmp_path / "trajectory.jsonl"
+    traj = Trajectory("run-1", path=str(journal))
+
+    seq = traj.append_in_flight(0, _tool_use())
+    traj.append_done(seq, {"ok": True})
+
+    lines = _read_lines(journal)
+    assert len(lines) == 2
+    assert lines[0]["phase"] == "in_flight"
+    assert lines[1]["phase"] == "done"
+    assert lines[0]["seq"] == lines[1]["seq"] == seq
+    assert lines[1]["status"] == "ok"
+    # The in_flight line carries the durable-action metadata.
+    assert lines[0]["tool"] == "browser__click"
+    assert lines[0]["step"] == "book-flight"
+    assert lines[0]["idem"].startswith("sha256:")
+
+
+def test_seq_is_monotonic_across_tool_calls(tmp_path):
+    traj = Trajectory("run-1", path=str(tmp_path / "t.jsonl"))
+    s0 = traj.append_in_flight(0, _tool_use(tid="a"))
+    traj.append_done(s0, {"ok": True})
+    s1 = traj.append_in_flight(1, _tool_use(tid="b"))
+    traj.append_done(s1, {"ok": True})
+    assert s1 == s0 + 1
+
+
+def test_append_error_writes_error_close(tmp_path):
+    journal = tmp_path / "t.jsonl"
+    traj = Trajectory("run-1", path=str(journal))
+    seq = traj.append_in_flight(0, _tool_use())
+    traj.append_error(seq, RuntimeError("boom"))
+
+    close = _read_lines(journal)[1]
+    assert close["seq"] == seq
+    assert close["phase"] == "error"
+    assert close["status"] == "error"
+    assert "boom" in close["error"]
+
+
+def test_secrets_are_redacted_on_write(tmp_path):
+    journal = tmp_path / "t.jsonl"
+    traj = Trajectory("run-1", path=str(journal))
+
+    secret = "sk-ant-oat01-VERYSECRETTOKEN"
+    seq = traj.append_in_flight(
+        0, _tool_use(params={"api_key": secret, "note": "hello"})
+    )
+    traj.append_done(seq, {"access_token": secret, "value": "kept"})
+
+    raw = journal.read_text()
+    assert secret not in raw
+    # Non-secret fields survive.
+    assert "hello" in raw
+    assert "kept" in raw
+
+
+def test_append_response_is_an_audit_line_not_a_checkpoint(tmp_path):
+    journal = tmp_path / "t.jsonl"
+    traj = Trajectory("run-1", path=str(journal))
+
+    class _Usage:
+        input_tokens = 10
+        output_tokens = 4
+
+    traj.append_response(0, {"content": [{"type": "text", "text": "hi"}]}, _Usage())
+    line = _read_lines(journal)[0]
+    assert line["phase"] == "response"
+    assert line["iteration"] == 0
+
+
+@pytest.mark.asyncio
+async def test_resume_detects_dangling_in_flight_and_positions_at_it(tmp_path):
+    journal = tmp_path / "t.jsonl"
+    traj = Trajectory("run-danger", path=str(journal))
+    # Two completed steps...
+    s0 = traj.append_in_flight(0, _tool_use(tid="a"))
+    traj.append_done(s0, {"ok": 1})
+    s1 = traj.append_in_flight(1, _tool_use(tid="b"))
+    traj.append_done(s1, {"ok": 2})
+    # ...then a crash mid-action: an unclosed in_flight is the last line.
+    s2 = traj.append_in_flight(2, _tool_use(tid="c", step="charge-card"))
+
+    state = await resume("run-danger", runs_dir=str(tmp_path.parent), path=str(journal))
+
+    assert state.last_seq == s2
+    assert state.dangling is not None
+    assert state.dangling["seq"] == s2
+    assert state.dangling["step"] == "charge-card"
+    # Positioned AT the dangling step -- completed steps are not re-run.
+    assert state.next_seq == s2
+    assert state.completed_seqs == [s0, s1]
+
+
+@pytest.mark.asyncio
+async def test_resume_after_clean_close_positions_after_last(tmp_path):
+    journal = tmp_path / "t.jsonl"
+    traj = Trajectory("run-clean", path=str(journal))
+    s0 = traj.append_in_flight(0, _tool_use())
+    traj.append_done(s0, {"ok": True})
+
+    state = await resume("run-clean", path=str(journal))
+    assert state.dangling is None
+    assert state.next_seq == s0 + 1
+    assert state.completed_seqs == [s0]
+
+
+def test_find_latest_picks_newest_unfinished_run(tmp_path):
+    runs = tmp_path / "runs"
+    # A finished run (all closed).
+    done_dir = runs / "run-done"
+    done_dir.mkdir(parents=True)
+    dt = Trajectory("run-done", path=str(done_dir / "trajectory.jsonl"))
+    s = dt.append_in_flight(0, _tool_use())
+    dt.append_done(s, {"ok": True})
+
+    # An unfinished run (dangling in_flight).
+    open_dir = runs / "run-open"
+    open_dir.mkdir(parents=True)
+    ot = Trajectory("run-open", path=str(open_dir / "trajectory.jsonl"))
+    ot.append_in_flight(0, _tool_use())
+
+    assert find_latest(runs_dir=str(runs)) == "run-open"
+
+
+def test_find_latest_returns_none_when_all_finished(tmp_path):
+    runs = tmp_path / "runs"
+    d = runs / "run-done"
+    d.mkdir(parents=True)
+    t = Trajectory("run-done", path=str(d / "trajectory.jsonl"))
+    s = t.append_in_flight(0, _tool_use())
+    t.append_done(s, {"ok": True})
+    assert find_latest(runs_dir=str(runs)) is None

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -1,4 +1,92 @@
-"""In-process control-plane MCP server (todo/progress/HITL/notify).
+"""vadgr's in-process control-plane MCP server (§4.9) + the @control_tool registry.
 
-Home for a subsequent slice; empty in this one.
+The server satisfies ``MCPServer`` so the ``MCPHost`` wires it in beside the cua
+servers -- no wire hop. Handlers register via ``@control_tool``; ``list_tools()``
+returns their specs, ``call_tool()`` invokes one. Adding a control-plane tool is
+a new ``@control_tool`` in ``engine/tools/`` -- never a cua or loop change.
+
+The seven 0.4.0 tools live one group per file (``todo``/``progress``/``hitl``/
+``notify``); importing this package registers them all.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+# name -> {"handler": fn, "spec": {...}}
+_REGISTRY: dict[str, dict] = {}
+
+
+def control_tool(
+    fn: Callable | None = None,
+    *,
+    description: str = "",
+    input_schema: dict | None = None,
+):
+    """Register one handler + its MCP spec. Usable bare (``@control_tool``) or
+    with metadata (``@control_tool(description=..., input_schema=...)``)."""
+
+    def wrap(f: Callable) -> Callable:
+        desc = description or (f.__doc__ or "").strip().split("\n")[0]
+        _REGISTRY[f.__name__] = {
+            "handler": f,
+            "spec": {
+                "name": f.__name__,
+                "description": desc,
+                "input_schema": input_schema or {"type": "object", "properties": {}},
+            },
+        }
+        return f
+
+    return wrap(fn) if fn is not None else wrap
+
+
+@dataclass
+class RunContext:
+    """The live run state the control-plane tools read and mutate: the run id,
+    the resume journal, the event sink, and the working-memory todo list.
+
+    The provider's ``on_event`` wrapper keeps ``iteration`` / token counters
+    current, so ``get_run_status`` reports the real run, not a stub."""
+
+    run_id: str
+    trajectory: Any = None
+    emit: Callable[[dict], Awaitable[None]] | None = None
+    state: str = "running"
+    iteration: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    todos: list = field(default_factory=list)
+
+
+class ControlPlaneServer:
+    """vadgr's own in-process MCP server. One per run; holds the run context,
+    the channel router (for HITL / notify), and the policy hook."""
+
+    name = "control"
+
+    def __init__(self, run_ctx: RunContext, channels, policy):
+        self.ctx = run_ctx
+        self.channels = channels
+        self.policy = policy
+
+    async def list_tools(self) -> list:
+        return [dict(entry["spec"]) for entry in _REGISTRY.values()]
+
+    async def call_tool(self, name: str, args: dict) -> dict:
+        entry = _REGISTRY.get(name)
+        if entry is None:
+            raise KeyError(f"unknown control-plane tool: {name}")
+        return await entry["handler"](args or {}, self)
+
+
+async def emit_event(server: "ControlPlaneServer", event: dict) -> None:
+    """Stream a RunEvent to the watching client, if a sink is wired."""
+    if server.ctx.emit is not None:
+        await server.ctx.emit(event)
+
+
+# Importing the handler modules registers every @control_tool. Kept at the
+# bottom so the registry + RunContext + ControlPlaneServer exist first.
+from engine.tools import hitl, notify, progress, todo  # noqa: E402,F401

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -1,0 +1,4 @@
+"""In-process control-plane MCP server (todo/progress/HITL/notify).
+
+Home for a subsequent slice; empty in this one.
+"""

--- a/engine/tools/hitl.py
+++ b/engine/tools/hitl.py
@@ -1,0 +1,111 @@
+"""Human-in-the-loop gate v1: request_approval / ask_user / propose_plan.
+
+These are the one place a tool call *blocks a loop iteration*. Because control-
+plane tools dispatch exactly like any other tool, the pause happens inside
+``call_tool`` here, so the loop's ``for`` iteration is already suspended at the
+``await``. ``request_approval`` first asks the policy hook (auto_allow /
+auto_deny / needs_human); only ``needs_human`` routes to the channel. The pause
+is journaled as ``await_user`` on the still-open ``seq`` so a crash while waiting
+resumes into the same pending request.
+"""
+
+from __future__ import annotations
+
+from engine.channels.base import HumanPrompt
+from engine.policy.base import AUTO_ALLOW, AUTO_DENY, ApprovalRequest
+from engine.tools import control_tool
+
+_APPROVAL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "action": {"type": "string"},
+        "risk": {"type": "string", "enum": ["low", "medium", "high"]},
+        "preview": {"type": "string"},
+        "timeout": {"type": "number"},
+    },
+    "required": ["action", "risk", "preview"],
+}
+
+_ASK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "question": {"type": "string"},
+        "options": {"type": "array", "items": {"type": "string"}},
+        "timeout": {"type": "number"},
+    },
+    "required": ["question"],
+}
+
+_PLAN_SCHEMA = {
+    "type": "object",
+    "properties": {"plan": {"type": "string"}},
+    "required": ["plan"],
+}
+
+
+def _journal_await(server, request: dict) -> None:
+    traj = server.ctx.trajectory
+    if traj is not None and hasattr(traj, "append_await_user"):
+        traj.append_await_user(request)
+
+
+@control_tool(
+    description="Ask a human to approve a gated action. Blocks the loop until "
+    "answered; a reject/timeout is a normal result, not a crash.",
+    input_schema=_APPROVAL_SCHEMA,
+)
+async def request_approval(args: dict, server) -> dict:
+    action = args["action"]
+    risk = args.get("risk", "medium")
+    preview = args.get("preview", "")
+    timeout = args.get("timeout")
+
+    req = ApprovalRequest(action=action, risk=risk, preview=preview)
+    decision = await server.policy.check(req)
+    if decision.outcome == AUTO_DENY:
+        return {"decision": "reject", "note": decision.reason}
+    if decision.outcome == AUTO_ALLOW:
+        return {"decision": "approve", "note": None}
+
+    # needs_human -> journal the pause, then block on the channel.
+    _journal_await(server, {"kind": "approval", "action": action, "risk": risk})
+    prompt = HumanPrompt(
+        kind="approval", text=action, risk=risk, preview=preview, timeout=timeout
+    )
+    resp = await server.channels.request(prompt)
+    if resp.get("timed_out"):
+        return {"decision": "timeout", "note": None}
+    choice = "approve" if resp.get("choice") == "approve" else "reject"
+    return {"decision": choice, "note": resp.get("text") or None}
+
+
+@control_tool(
+    description="Ask a human a question, optionally with choices. Blocks the loop.",
+    input_schema=_ASK_SCHEMA,
+)
+async def ask_user(args: dict, server) -> dict:
+    question = args["question"]
+    options = args.get("options")
+    timeout = args.get("timeout")
+
+    _journal_await(server, {"kind": "question", "question": question})
+    prompt = HumanPrompt(
+        kind="question", text=question, options=options, timeout=timeout
+    )
+    resp = await server.channels.request(prompt)
+    if resp.get("timed_out"):
+        return {"answer": None, "timed_out": True}
+    return {"answer": resp.get("choice"), "timed_out": False}
+
+
+@control_tool(
+    description="Propose a plan for a human to approve / revise / reject. Blocks.",
+    input_schema=_PLAN_SCHEMA,
+)
+async def propose_plan(args: dict, server) -> dict:
+    plan = args["plan"]
+    _journal_await(server, {"kind": "plan"})
+    resp = await server.channels.request(HumanPrompt(kind="plan", text=plan))
+    if resp.get("timed_out"):
+        return {"decision": "reject", "feedback": "timed out"}
+    return {"decision": resp.get("choice") or "reject", "feedback": resp.get("text") or None}

--- a/engine/tools/notify.py
+++ b/engine/tools/notify.py
@@ -1,0 +1,34 @@
+"""Notify: notify_user (CLI / desktop).
+
+Fire-and-forget -- routes a message to the active channel (or a per-call
+override) and returns immediately with the delivery targets. ``importance``
+selects how loud: low -> log, normal -> toast, high -> modal/alert.
+"""
+
+from __future__ import annotations
+
+from engine.tools import control_tool
+
+_NOTIFY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "message": {"type": "string"},
+        "channel": {"type": "string"},
+        "importance": {"type": "string", "enum": ["low", "normal", "high"]},
+    },
+    "required": ["message"],
+}
+
+
+@control_tool(
+    description="Notify the user on the active channel. Fire-and-forget.",
+    input_schema=_NOTIFY_SCHEMA,
+)
+async def notify_user(args: dict, server) -> dict:
+    message = args["message"]
+    channel = args.get("channel")
+    importance = args.get("importance", "normal")
+    delivery = await server.channels.notify(
+        message, importance=importance, channel=channel
+    )
+    return {"ok": True, "delivered": delivery.delivered}

--- a/engine/tools/progress.py
+++ b/engine/tools/progress.py
@@ -1,0 +1,45 @@
+"""Self / progress: report_progress / get_run_status.
+
+``report_progress`` surfaces a human-readable line to the client stream;
+``get_run_status`` introspects the live run (state / iteration / todos / tokens).
+"""
+
+from __future__ import annotations
+
+from engine.tools import control_tool, emit_event
+
+_PROGRESS_SCHEMA = {
+    "type": "object",
+    "properties": {"message": {"type": "string"}},
+    "required": ["message"],
+}
+
+_STATUS_SCHEMA = {
+    "type": "object",
+    "properties": {"run_id": {"type": "string"}},
+}
+
+
+@control_tool(
+    description="Surface a progress message to the watching client.",
+    input_schema=_PROGRESS_SCHEMA,
+)
+async def report_progress(args: dict, server) -> dict:
+    message = args.get("message", "")
+    await emit_event(server, {"type": "progress", "message": message})
+    return {"ok": True}
+
+
+@control_tool(
+    description="Introspect the current run: state, iteration, todos, tokens.",
+    input_schema=_STATUS_SCHEMA,
+)
+async def get_run_status(args: dict, server) -> dict:
+    ctx = server.ctx
+    return {
+        "run_id": args.get("run_id") or ctx.run_id,
+        "state": ctx.state,
+        "iteration": ctx.iteration,
+        "todos": ctx.todos,
+        "tokens": {"input": ctx.input_tokens, "output": ctx.output_tokens},
+    }

--- a/engine/tools/todo.py
+++ b/engine/tools/todo.py
@@ -10,6 +10,41 @@ from engine.tools import control_tool, emit_event
 
 VALID_STATUSES = ("pending", "in_progress", "done", "cancelled")
 
+# The vocabulary a model actually reaches for. The schema declares an ``enum``,
+# but a JSON-Schema enum is advisory -- an off-vocabulary value reaches the tool
+# anyway -- and a model given a plain goal writes "completed", not "done". These
+# map to the canonical status instead of costing an iteration on an error.
+_STATUS_ALIASES = {
+    "complete": "done",
+    "completed": "done",
+    "finished": "done",
+    "success": "done",
+    "todo": "pending",
+    "not_started": "pending",
+    "in-progress": "in_progress",
+    "inprogress": "in_progress",
+    "active": "in_progress",
+    "running": "in_progress",
+    "canceled": "cancelled",
+    "cancel": "cancelled",
+    "skipped": "cancelled",
+}
+
+
+def _canonical_status(status: str) -> str:
+    """The canonical status, accepting the common synonyms. Raises naming every
+    legal value -- an error a model can act on without guessing again."""
+    if not isinstance(status, str):
+        raise ValueError(f"invalid todo status: {status!r}")
+    key = status.strip().lower().replace(" ", "_")
+    resolved = _STATUS_ALIASES.get(key, key)
+    if resolved not in VALID_STATUSES:
+        raise ValueError(
+            f"invalid todo status: {status!r} -- expected one of "
+            + ", ".join(VALID_STATUSES)
+        )
+    return resolved
+
 _ITEMS_SCHEMA = {
     "type": "object",
     "properties": {
@@ -41,9 +76,7 @@ _UPDATE_SCHEMA = {
 
 def _normalize(item: dict, index: int) -> dict:
     content = item.get("content") or item.get("title") or item.get("text") or ""
-    status = item.get("status", "pending")
-    if status not in VALID_STATUSES:
-        raise ValueError(f"invalid todo status: {status}")
+    status = _canonical_status(item.get("status", "pending"))
     return {
         "id": str(item.get("id") or index + 1),
         "content": content,
@@ -68,12 +101,11 @@ async def todo_write(args: dict, server) -> dict:
 )
 async def todo_update(args: dict, server) -> dict:
     todo_id = str(args["id"])
-    status = args["status"]
-    if status not in VALID_STATUSES:
-        raise ValueError(f"invalid todo status: {status}")
+    status = _canonical_status(args["status"])
     for todo in server.ctx.todos:
         if str(todo.get("id")) == todo_id:
             todo["status"] = status
             await emit_event(server, {"type": "todos", "todos": server.ctx.todos})
             return {"ok": True, "todo": todo}
-    raise ValueError(f"unknown todo id: {todo_id}")
+    known = ", ".join(str(t.get("id")) for t in server.ctx.todos) or "none"
+    raise ValueError(f"unknown todo id: {todo_id} -- known ids: {known}")

--- a/engine/tools/todo.py
+++ b/engine/tools/todo.py
@@ -1,0 +1,79 @@
+"""Planning / working memory: todo_write / todo_update.
+
+The step list the agent maintains, streamed to the watching client on every
+write/update via a ``todos`` RunEvent.
+"""
+
+from __future__ import annotations
+
+from engine.tools import control_tool, emit_event
+
+VALID_STATUSES = ("pending", "in_progress", "done", "cancelled")
+
+_ITEMS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "content": {"type": "string"},
+                    "status": {"type": "string", "enum": list(VALID_STATUSES)},
+                },
+                "required": ["content"],
+            },
+        }
+    },
+    "required": ["items"],
+}
+
+_UPDATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "status": {"type": "string", "enum": list(VALID_STATUSES)},
+    },
+    "required": ["id", "status"],
+}
+
+
+def _normalize(item: dict, index: int) -> dict:
+    content = item.get("content") or item.get("title") or item.get("text") or ""
+    status = item.get("status", "pending")
+    if status not in VALID_STATUSES:
+        raise ValueError(f"invalid todo status: {status}")
+    return {
+        "id": str(item.get("id") or index + 1),
+        "content": content,
+        "status": status,
+    }
+
+
+@control_tool(
+    description="Replace the agent's todo list (the step plan it maintains).",
+    input_schema=_ITEMS_SCHEMA,
+)
+async def todo_write(args: dict, server) -> dict:
+    items = [_normalize(it, i) for i, it in enumerate(args.get("items", []))]
+    server.ctx.todos = items
+    await emit_event(server, {"type": "todos", "todos": items})
+    return {"ok": True, "todos": items}
+
+
+@control_tool(
+    description="Update one todo's status (pending|in_progress|done|cancelled).",
+    input_schema=_UPDATE_SCHEMA,
+)
+async def todo_update(args: dict, server) -> dict:
+    todo_id = str(args["id"])
+    status = args["status"]
+    if status not in VALID_STATUSES:
+        raise ValueError(f"invalid todo status: {status}")
+    for todo in server.ctx.todos:
+        if str(todo.get("id")) == todo_id:
+            todo["status"] = status
+            await emit_event(server, {"type": "todos", "todos": server.ctx.todos})
+            return {"ok": True, "todo": todo}
+    raise ValueError(f"unknown todo id: {todo_id}")

--- a/engine/trajectory.py
+++ b/engine/trajectory.py
@@ -20,16 +20,38 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-# Keys whose values are secrets regardless of content.
+# Keys whose values are secrets regardless of content. Matched on WHOLE words of
+# the normalized key, never as a bare substring: an unanchored ``token`` also
+# matches ``input_tokens`` / ``max_tokens``, which would redact the usage counts
+# and make cost unauditable from the journal.
 _SECRET_KEY = re.compile(
-    r"(token|secret|password|passwd|api[_-]?key|authorization|bearer|"
-    r"credential|client[_-]?secret|access[_-]?token|refresh[_-]?token)",
-    re.IGNORECASE,
+    r"(?:^|_)(?:"
+    r"token|secret|password|passwd|passphrase|authorization|bearer|cookie|"
+    r"credential|credentials|signature|"
+    r"api_key|apikey|access_key|secret_key|private_key|session_key"
+    r")(?:$|_)"
 )
 # Values that look like credentials regardless of their key.
 _SECRET_VALUE = re.compile(r"(sk-[A-Za-z0-9-]{8,}|Bearer\s+[A-Za-z0-9._-]{8,})")
 
+# camelCase / kebab-case / PascalCase -> snake_case, so ``accessToken``,
+# ``access-token`` and ``AccessToken`` all normalize to ``access_token``.
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
 _REDACTED = "[REDACTED]"
+
+
+def _normalize_key(key: str) -> str:
+    """The key as underscore-separated lowercase words."""
+    return _CAMEL_BOUNDARY.sub("_", key).replace("-", "_").lower()
+
+
+def is_secret_key(key: str) -> bool:
+    """True when ``key`` names a credential and its value must never reach disk.
+
+    Whole-word: ``access_token`` and ``apiKey`` are secrets; ``input_tokens``
+    and ``max_tokens`` are counts and survive."""
+    return bool(_SECRET_KEY.search(_normalize_key(key)))
 
 
 def redact_secrets(payload: Any) -> Any:
@@ -38,7 +60,7 @@ def redact_secrets(payload: Any) -> Any:
     if isinstance(payload, dict):
         out: dict = {}
         for key, value in payload.items():
-            if isinstance(key, str) and _SECRET_KEY.search(key):
+            if isinstance(key, str) and is_secret_key(key):
                 out[key] = _REDACTED
             else:
                 out[key] = redact_secrets(value)

--- a/engine/trajectory.py
+++ b/engine/trajectory.py
@@ -123,6 +123,20 @@ class Trajectory:
         """Write the ``error`` close, flush. Called AFTER dispatch."""
         self._write({"seq": seq, "phase": "error", "status": "error", "error": str(err)})
 
+    def append_await_user(self, request: dict) -> None:
+        """Write an ``await_user`` line on the *current* (still-open) ``seq``,
+        flush. A HITL tool pauses inside its dispatch -- the loop wrote the
+        ``in_flight`` line just before -- so this line shares that action's
+        ``seq``, and a crash while waiting resumes into the same pending
+        request. Redacted on write like every other line."""
+        self._write(
+            {
+                "seq": self._seq,
+                "phase": "await_user",
+                "request": redact_secrets(request),
+            }
+        )
+
 
 @dataclass
 class ResumeState:

--- a/engine/trajectory.py
+++ b/engine/trajectory.py
@@ -1,0 +1,227 @@
+"""The append-only JSONL resume journal (and find-latest-and-continue resume).
+
+One monotonic ``seq``, code-enforced by the loop, secret-redacted on write. It
+is the durable record a resume reads -- not the LLM transcript. Every tool call
+writes ``in_flight`` before dispatch and ``done``/``error`` after; a crash
+between them leaves a dangling ``in_flight`` line, the exact signal resume keys
+on. Full durable execution (snapshots, cross-process recovery, the enforced
+idempotency contract) is a later minor -- this slice ships the journal + a
+tail-read resume.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Keys whose values are secrets regardless of content.
+_SECRET_KEY = re.compile(
+    r"(token|secret|password|passwd|api[_-]?key|authorization|bearer|"
+    r"credential|client[_-]?secret|access[_-]?token|refresh[_-]?token)",
+    re.IGNORECASE,
+)
+# Values that look like credentials regardless of their key.
+_SECRET_VALUE = re.compile(r"(sk-[A-Za-z0-9-]{8,}|Bearer\s+[A-Za-z0-9._-]{8,})")
+
+_REDACTED = "[REDACTED]"
+
+
+def redact_secrets(payload: Any) -> Any:
+    """Deep-copy ``payload`` with tokens/keys stripped. Applied by ``Trajectory``
+    on every write, so no credential ever reaches disk."""
+    if isinstance(payload, dict):
+        out: dict = {}
+        for key, value in payload.items():
+            if isinstance(key, str) and _SECRET_KEY.search(key):
+                out[key] = _REDACTED
+            else:
+                out[key] = redact_secrets(value)
+        return out
+    if isinstance(payload, list):
+        return [redact_secrets(v) for v in payload]
+    if isinstance(payload, str):
+        return _SECRET_VALUE.sub(_REDACTED, payload)
+    return payload
+
+
+def _idem(tool: str, params: dict) -> str:
+    canonical = json.dumps({"tool": tool, "params": params}, sort_keys=True, default=str)
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _default_runs_dir() -> Path:
+    return Path.home() / ".vadgr" / "runs"
+
+
+class Trajectory:
+    """Append-only JSONL resume journal. Single monotonic ``seq``; every tool
+    call writes ``in_flight`` before dispatch and ``done``/``error`` after.
+    Secrets redacted on write. Path: ``~/.vadgr/runs/<run_id>/trajectory.jsonl``."""
+
+    def __init__(self, run_id: str, path: str | None = None):
+        self.run_id = run_id
+        if path is None:
+            path = str(_default_runs_dir() / run_id / "trajectory.jsonl")
+        self.path = path
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._seq = -1
+
+    def _write(self, record: dict) -> None:
+        record = {"ts": datetime.now(timezone.utc).isoformat(), "run_id": self.run_id, **record}
+        with open(self.path, "a") as fh:
+            fh.write(json.dumps(record, default=str) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    def append_response(self, iteration: int, response: dict, usage: Any) -> None:
+        """Audit line for the model turn (redacted); not a resume checkpoint."""
+        self._write(
+            {
+                "phase": "response",
+                "iteration": iteration,
+                "response": redact_secrets(response),
+                "usage": {
+                    "input_tokens": getattr(usage, "input_tokens", 0),
+                    "output_tokens": getattr(usage, "output_tokens", 0),
+                },
+            }
+        )
+
+    def append_in_flight(self, iteration: int, tool_use: dict) -> int:
+        """Write the ``in_flight`` line, flush, and return the ``seq`` the
+        matching close will reuse. Called BEFORE dispatch."""
+        self._seq += 1
+        seq = self._seq
+        tool = tool_use.get("name", "")
+        params = tool_use.get("input", {}) or {}
+        self._write(
+            {
+                "seq": seq,
+                "phase": "in_flight",
+                "iteration": iteration,
+                "step": tool_use.get("step"),
+                "tool": tool,
+                "params": redact_secrets(params),
+                "idem": _idem(tool, params),
+            }
+        )
+        return seq
+
+    def append_done(self, seq: int, result: dict) -> None:
+        """Write the ``done`` close (redacted), flush. Called AFTER dispatch."""
+        self._write(
+            {"seq": seq, "phase": "done", "status": "ok", "result": redact_secrets(result)}
+        )
+
+    def append_error(self, seq: int, err: Exception) -> None:
+        """Write the ``error`` close, flush. Called AFTER dispatch."""
+        self._write({"seq": seq, "phase": "error", "status": "error", "error": str(err)})
+
+
+@dataclass
+class ResumeState:
+    """The purified view a resume continues from -- goal-relevant records, not
+    the whole transcript. ``next_seq`` is the first uncompleted step."""
+
+    run_id: str
+    last_seq: int
+    next_seq: int
+    dangling: dict | None
+    completed_seqs: list[int] = field(default_factory=list)
+    recent_results: list[dict] = field(default_factory=list)
+
+
+def _read_records(path: str) -> list[dict]:
+    records: list[dict] = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def _dangling_in_flight(records: list[dict]) -> dict | None:
+    """The unclosed ``in_flight`` record (a crash mid-action), or ``None``.
+    A ``seq`` is closed once a ``done``/``error`` line reuses it."""
+    in_flight: dict[int, dict] = {}
+    for rec in records:
+        if "seq" not in rec:
+            continue
+        phase = rec.get("phase")
+        if phase == "in_flight":
+            in_flight[rec["seq"]] = rec
+        elif phase in ("done", "error"):
+            in_flight.pop(rec["seq"], None)
+    if not in_flight:
+        return None
+    # The latest still-open action.
+    return in_flight[max(in_flight)]
+
+
+def find_latest(runs_dir: str | None = None) -> str | None:
+    """Newest run dir whose journal is unfinished (has a dangling
+    ``in_flight``), or ``None``."""
+    base = Path(runs_dir) if runs_dir else _default_runs_dir()
+    if not base.is_dir():
+        return None
+    candidates: list[tuple[float, str]] = []
+    for run_dir in base.iterdir():
+        journal = run_dir / "trajectory.jsonl"
+        if not journal.is_file():
+            continue
+        if _dangling_in_flight(_read_records(str(journal))) is not None:
+            candidates.append((journal.stat().st_mtime, run_dir.name))
+    if not candidates:
+        return None
+    return max(candidates)[1]
+
+
+async def resume(
+    run_id: str, runs_dir: str | None = None, path: str | None = None
+) -> ResumeState:
+    """Read the journal TAIL, classify the last ``seq`` (closed or dangling
+    ``in_flight``), reconstruct a purified context, and return a ``ResumeState``
+    positioned at the first uncompleted step. The giant transcript is never
+    read; completed steps are never re-run. A dangling action is re-validated
+    live via its ``idem`` before any re-do -- never blindly replayed."""
+    if path is None:
+        base = Path(runs_dir) if runs_dir else _default_runs_dir()
+        path = str(base / run_id / "trajectory.jsonl")
+
+    records = _read_records(path)
+    seqs = [r["seq"] for r in records if "seq" in r]
+    last_seq = max(seqs) if seqs else -1
+
+    dangling = _dangling_in_flight(records)
+    closed = {
+        r["seq"]
+        for r in records
+        if r.get("phase") in ("done", "error") and "seq" in r
+    }
+    completed_seqs = sorted(closed)
+    recent_results = [
+        r.get("result", {})
+        for r in records
+        if r.get("phase") == "done"
+    ][-3:]
+
+    if dangling is not None:
+        next_seq = dangling["seq"]
+    else:
+        next_seq = last_seq + 1
+
+    return ResumeState(
+        run_id=run_id,
+        last_seq=last_seq,
+        next_seq=next_seq,
+        dangling=dangling,
+        completed_seqs=completed_seqs,
+        recent_results=recent_results,
+    )

--- a/providers.yaml
+++ b/providers.yaml
@@ -21,10 +21,14 @@ providers:
     kind: native
     module: "engine.providers.native_anthropic_oauth:AnthropicOAuthProvider"
     auth_mode: oauth
-    default_model: "claude-sonnet-4-6"
+    default_model: "claude-opus-5"
     models:
+      - { id: "claude-opus-5", name: "Claude Opus 5" }
+      - { id: "claude-sonnet-5", name: "Claude Sonnet 5" }
+      - { id: "claude-fable-5", name: "Claude Fable 5" }
+      - { id: "claude-opus-4-8", name: "Claude Opus 4.8" }
       - { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
-      - { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
+      - { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" }
 
   # -- legacy CLI providers (subprocess bridge; deprecated 0.5.0, removed 0.6.0)
   claude_code:
@@ -42,8 +46,12 @@ providers:
       to: "stream-json"
       extra_args: ["--verbose"]
     models:
+      - { id: "claude-opus-5", name: "Claude Opus 5" }
+      - { id: "claude-sonnet-5", name: "Claude Sonnet 5" }
+      - { id: "claude-fable-5", name: "Claude Fable 5" }
+      - { id: "claude-opus-4-8", name: "Claude Opus 4.8" }
       - { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
-      - { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
+      - { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" }
 
   codex:
     name: "OpenAI Codex CLI"

--- a/providers.yaml
+++ b/providers.yaml
@@ -1,13 +1,35 @@
-# CLI agent provider configurations.
+# Agent provider configurations.
 # Adding a new provider = adding a new entry here. Zero code changes.
 #
-# Placeholders:
+# Two kinds of provider live here:
+#   - native  (engine/): the native agent loop owns the conversation history and
+#     drives the model directly via `module`. anthropic_oauth is the first one.
+#   - cli     (api/engine/providers.py): the legacy subprocess bridge that shells
+#     out to an external CLI. Kept through the transition, tagged `deprecated`.
+#
+# Placeholders (cli providers only):
 #   {{prompt}}    -- replaced with the agent prompt at runtime
 #   {{workspace}} -- replaced with the agent's working directory (if set)
 
+# Dev default: bill against a Claude subscription via OAuth, not API credit.
+default_provider: anthropic_oauth
+
 providers:
+  # -- native providers (engine/ native loop) --------------------------------
+  anthropic_oauth:
+    name: "Anthropic (OAuth, subscription)"
+    kind: native
+    module: "engine.providers.native_anthropic_oauth:AnthropicOAuthProvider"
+    auth_mode: oauth
+    default_model: "claude-sonnet-4-6"
+    models:
+      - { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" }
+      - { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
+
+  # -- legacy CLI providers (subprocess bridge; deprecated 0.5.0, removed 0.6.0)
   claude_code:
     name: "Claude Code"
+    deprecated: true
     command: claude
     args: ["-p", "{{prompt}}", "--dangerously-skip-permissions", "--output-format", "json"]
     available_check: ["claude", "--version"]
@@ -25,6 +47,7 @@ providers:
 
   codex:
     name: "OpenAI Codex CLI"
+    deprecated: true
     command: codex
     args: ["exec", "{{prompt}}", "--dangerously-bypass-approvals-and-sandbox", "--json"]
     available_check: ["codex", "--version"]
@@ -35,6 +58,7 @@ providers:
 
   gemini:
     name: "Gemini CLI"
+    deprecated: true
     command: gemini
     args: ["--prompt", "{{prompt}}", "--approval-mode", "yolo", "--output-format", "json"]
     available_check: ["gemini", "--version"]

--- a/registry/manifest.py
+++ b/registry/manifest.py
@@ -36,7 +36,7 @@ class Manifest(BaseModel):
     author: str = ""
     license: str = ""
     provider: str = "claude_code"
-    model: str = "claude-sonnet-4-6"
+    model: str = "claude-opus-5"
     computer_use: bool = False
     steps: list[StepEntry] = Field(default_factory=list)
     samples: list[str] = Field(default_factory=list)

--- a/registry/tests/test_manifest.py
+++ b/registry/tests/test_manifest.py
@@ -38,7 +38,7 @@ class TestManifestValidation:
         })
         assert m.samples == ["example"]
         assert m.input_schema == [{"name": "x"}]
-        assert m.model == "claude-sonnet-4-6"
+        assert m.model == "claude-opus-5"
 
     def test_missing_name_raises(self):
         with pytest.raises(ValueError, match="Invalid manifest"):


### PR DESCRIPTION
Builds the native provider path and the in-process control-plane server on top of the existing native-loop foundation (shared loop + ports + pruning + resume journal). Adds the first native provider so dev runs can bill against a Claude subscription over OAuth instead of API credit.

## What's new

**Provider path**
- `engine/http.py` - shared async HTTP client: retry-on-transient (429/5xx + transport errors) with exponential back-off, timeout, logging. Every model call and token refresh goes through it.
- `engine/auth/{oauth,api_key,none}.py` - three auth strategies. `OAuthStrategy` caches the access token, refreshes on expiry and on 401, and resolves the token store per OS: the credentials file on Linux/Windows/WSL (WSL reads the Linux-side home, not `/mnt/c`) and the login Keychain on macOS.
- `engine/format/anthropic.py` - Anthropic content-block / tool-schema adapter. Normalizes `tool_result` content to a string or list of content blocks (the wire requires it; a raw dict is rejected).
- `engine/providers/_anthropic_base.py` + `native_anthropic_oauth.py` - the OAuth provider. Sends the exact request shape Anthropic enforces: `Authorization: Bearer`, the `claude-cli/<ver> (external, cli)` User-Agent, the `anthropic-beta` flags, `anthropic-version`, the Claude Code system prefix as the first system block, and `mcp_`-prefixed tool names (un-prefixed on the way back). Refreshes and retries once on 401; raises a clear validator-update error on 403. `run_agent` builds the MCP host over the cua servers plus the control-plane server, opens a run journal, and drives the loop. Refuses to start under `VADGR_MODE=production`.

**Control-plane MVP** (in-process MCP server, wired beside cua)
- `engine/tools/` - `ControlPlaneServer` + a `@control_tool` registry and the eight tools: `todo_write` / `todo_update`, `report_progress` / `get_run_status`, `request_approval` / `ask_user` / `propose_plan`, `notify_user`.
- `engine/policy/` - a policy hook with a default denylist + risk + auth-mode rule (bypass / default / autonomous / paranoid).
- `engine/channels/` - `ChannelRouter` + a CLI channel (TTY prompt, timeout, importance-to-loudness) and a desktop channel (native dialog/toast, per-OS command selection).
- `request_approval` pauses the loop, asks the policy hook, and only then routes to the active channel; it resumes when the human (or a timeout) answers. A reject/timeout is a normal tool result, not a crash. The pause is written to the journal as an `await_user` line on the same step.

**Wire-up**
- `providers.yaml` - new `anthropic_oauth` native block + `default_provider: anthropic_oauth`; the legacy CLI providers are tagged `deprecated`.
- `providers` discovery route and its YAML tests now treat native providers as a distinct kind (they carry no command/args).

## Fixes from the acceptance run

Three defects the runbook below surfaced, fixed in this PR with nine regression tests, each verified to fail with its fix reverted.

- **A broken MCP server no longer takes the run down.** `MCPHost.connect()` awaited `list_tools()` inline with no guard, so one unreachable third-party server raised straight out and the run never started - taking every healthy server's tools with it. Each server's start is now guarded: the failure is logged, that server is dropped, and the reason is recorded in `MCPHost.failed()`, so a degraded host is visible rather than silent. A server-name collision still raises, since silently dropping one of two same-named servers would shadow the other's tools.
- **Journal redaction no longer eats the token counts.** The key pattern matched the bare substring `token`, so `input_tokens`, `output_tokens` and `max_tokens` were written as `[REDACTED]` - along with every other field whose name merely contains a secret word. Keys are now matched as whole words after normalizing camelCase and kebab-case: `accessToken`, `apiKey`, `client_secret` and `Authorization` are still redacted, `input_tokens` and `max_tokens` survive. Exposed as `is_secret_key()`.
- **`todo_update` accepts the vocabulary a model actually reaches for.** Given a plain goal the model wrote status `completed`; the enum is `done`, and a JSON-Schema enum is advisory, so the value reached the tool and came back as an error that cost an iteration. The common synonyms now map to the canonical status, the status error names all four legal values, and the unknown-id error names the ids that do exist.

## Default model -> Claude Opus 5

The default was `claude-sonnet-4-6`, two generations behind. Verified against `GET /v1/models` on the live endpoint, which lists `claude-opus-5`, `claude-sonnet-5` and `claude-fable-5`.

Bumped in every place the default is defined - the native provider and its base, the agent model field, the repository and agent-service defaults, the `agents` table `DEFAULT`, the manifest default and the import fallback - and the advertised catalogue in `providers.yaml` refreshed to the current family (Sonnet 4.6 kept, Haiku 4.5 added).

The table `DEFAULT` applies to newly created databases; existing rows keep the model they were written with, and an agent that names its model is unaffected.

Verified live: a run on the new default completed with a tool call and real usage, and an unknown model id comes back `404 not_found_error: model: ...`, so the name is genuinely sent and validated rather than defaulted server-side.

## Tests

- `PYTHONPATH=. python3 -m pytest engine/tests/` -> **110 passed** (http, auth incl. per-OS resolution, format, provider invariants, the eight control-plane tools, policy, channels, trajectory, pruning, ports).
- `PYTHONPATH=. python3 -m pytest api/tests/ registry/tests/ cli/tests/` -> **850 passed**, 1 skipped, no regressions.

## Acceptance runbook - `E2E/0.4.0/e2e.md`

Run live against the real Anthropic endpoint on subscription OAuth. A real model drives every part with goal-level tasks; the verdict comes from `trajectory.jsonl`, which the loop writes, not from the model's prose.

Each part states its axes, their product, and the state of every cell - **110 cells, 107 run, 3 open**, with the reason for each open one.

| Part | Axes | Cells | Run |
|---|---|---|---|
| L loop contract | 6 properties + pruning (4 x 3) | 18 | 18 |
| C control-plane tools | 8 tools x every branch of their contract | 14 | 12 |
| R crash + resume | prior work 2 x end-state 2 x side effect 2 | 8 | 7 |
| P policy | mode 4 x risk 3 x denylist 2, + redaction 8, + ungated 1 | 33 | 33 |
| N channels | channel 2 x importance 3, + routing 3, + OS 4 | 13 | 13 |
| A auth | strategy x token state 14, + store x OS 4 | 18 | 18 |
| M MCP host | 6 host contracts | 6 | 6 |

Highlights:

- **Crash and resume, with a countable side effect.** The process is `SIGKILL`ed after `in_flight` is journaled for the third tool call and before it dispatches. Two calls had already completed, each appending one line to a file. After the kill the file holds **2** lines - a replay would leave 4 - and `resume()` returns `completed_seqs=[0,1]`, `next_seq=2`, positioned on the dangling step. A finished run is never offered for resume.
- **The policy matrix in full**, 24 of 24 cells. A denylist hit is `auto_deny` in every mode including `bypass`; `paranoid` consults a human at all three risk levels; a rejection and a timeout both arrive as ordinary tool results and the loop continues.
- **Redaction proven on the live path**: a payload matching the credential pattern reaches the journal as `[REDACTED]` with zero raw occurrences.
- **A run with one MCP server down completes**: the healthy external server's tool was discovered and called by the model, the broken one was dropped with a warning.

Three findings are recorded rather than fixed here, each with its reason:

- `default` and `autonomous` produce identical outcomes in all 24 cells - two of the four advertised modes are the same mode today. Risk classes and decision tables are `0.6.0`; the mode set should not be described as four working modes before then.
- Only 5 of the 24 cells consult a human, and reaching one needs the model to both *choose* `request_approval` and *self-declare* `risk: "high"`. Dispatch itself is ungated - measured at 0 policy evaluations across 2 dispatched tools in `paranoid` mode. Observed live: asked to email an external address, the model declared the risk `low`.
- Every `in_flight` record carries an `idem` hash and `PolicyDecision` declares the field, but no non-test code reads either, and there is no re-do path yet. Owed at the minor that wires resume into `run_loop`.

## Scope of the runbook

`0.4.0` ships the engine as a library nothing calls, so there is no product surface to drive: the runbook drives the loop directly and is an acceptance test, stated at the top of the file. The exception expires at `0.4.1`, which puts the engine on the production path and is validated through **both** the API + run WebSocket (the way the phone calls it) and the CLI.

## Not in this slice

- [ ] Wiring the API run endpoints to the native loop (they still use the CLI executor); the native path runs via the provider directly for now.
- [ ] macOS Keychain and the native Windows desktop channel: command and store *selection* is proven for all four OSes through injected runners, but not that the selected command works on macOS or native Windows.
- [ ] A real stdio/SSE MCP server (handshake, subprocess lifetime, mid-run death) - the external server in the live run is in-process.
- [ ] Other native providers and the OpenAI/Google format adapters (0.5.0).
