### PR TITLE
docs(e2e): the on-box path belongs to the owner, not an operator

### DIFF
--- a/E2E/0.4.0/e2e.md
+++ b/E2E/0.4.0/e2e.md
@@ -55,7 +55,7 @@ path, and from that minor on the runbook drives **both real surfaces**:
 - **the API + the run WebSocket**, the way the phone does - the only way to know a
   mobile call behaves, since the request/response shapes and the WS event stream
   are what the mobile client codegens against;
-- **the CLI** (`vadgr run`, `vadgr stream`) - the on-box operator path, with its
+- **the CLI** (`vadgr run`, `vadgr stream`) - the on-box owner path, with its
   own users and its own failure modes.
 
 **Neither substitutes for the other.** A green CLI run says the loop works and


### PR DESCRIPTION
One word. The reshape deleted the `operator` entity, and the same word was still the role word for the person at the machine in the 0.4.0 runbook. The person is the owner throughout the docs now, so nothing reads as a reference to an entity that does not exist.

No behaviour change, no code touched.