### PR TITLE
Stop naming a private doc, and correct the test counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ gh repo clone MONTBRAIN/vadgr-docs      # the map: ARCHITECTURE.md, design/, MOB
 | Repo | Role | Default branch |
 |---|---|---|
 | `vadgr-docs` (private) | architecture, design docs, mockups, conventions | master |
-| `vadgr` | orchestrator brain (API + CLI + engine + forge + registry) | master |
+| `vadgr` | the machine daemon (API + CLI + engine + forge + registry) | master |
 | `vadgr-computer-use` | MCP runtime that drives the local machine | master |
 | `vadgr-mobile` (private) | Flutter phone app | main |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,8 @@ The gate, all three suites, before offering anything:
 
 ```bash
 PYTHONPATH=. python3 -m pytest engine/tests/ -q     # 122
-python3 -m pytest api/tests/ -q                     # 554
-python3 -m pytest cli/tests/ -q                     # 192
+python3 -m pytest api/tests/ -q                     # 596
+python3 -m pytest cli/tests/ -q                     # 201
 ```
 
 One test process at a time wherever anything is shared - two overlapping runs

--- a/E2E/0.4.2/e2e.md
+++ b/E2E/0.4.2/e2e.md
@@ -474,7 +474,7 @@ originated from loopback, so no packet crossed the tailnet.**
 It also means this branch's `OPTIONS` fix could not be exercised from a genuine
 non-loopback peer: recorded as **not run**, not as a pass.
 
-Assigned to `0.4.3`, which is the pairing minor - see `PROGRESS.md`.
+Assigned to `0.4.3`, the pairing minor.
 
 
 


### PR DESCRIPTION
## Changes

- `E2E/0.4.2/e2e.md` pointed a reader at a document this repo cannot see. The substance it was citing, that `0.4.3` is the pairing minor, is already in the same sentence, so the pointer is dropped rather than replaced.
- `CLAUDE.md`'s suite counts were stale. Verified by collection: `api/tests/` is **596** (was 554) and `cli/tests/` is **201** (was 192). `engine/tests/` at 122 was correct.
- The repo table called `vadgr` the orchestrator brain, which is v1's name for it.

## Tests

No code changed, so no test changes. The counts written were taken from `pytest --collect-only` rather than from memory.

## Caveat

The counts will drift again with the next suite change. They restate a fact the suite owns, and are worth deleting the next time they are wrong rather than corrected a third time.