### PR TITLE
The README sold a product this repo no longer is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,5 +114,14 @@ may overlap; that is what makes the three-agent e2e close safe.
 - Branch per minor, PR per minor. Never commit to `master`.
 - `CHANGELOG.md` is updated **in the PR**, and the version in `api/config.py`
   moves with it.
+- **`README.md` is updated in the same PR when the minor changed what it says**,
+  and it is the file most people read. A deleted surface, a renamed command, a
+  moved directory, a changed install path, a changed dependency floor, or a
+  change in what the product **is** all change it. Read the release's own diff
+  against it and either edit it or **say nothing in it changed** - the silence is
+  the defect. A claim can also rot with no diff touching it, and the one-line
+  description is the usual casualty. This repo's went three minors selling
+  "AI agents" after the re-scope replaced them, with an install command
+  pointing at the repository's former name.
 - A minor ends by updating `vadgr-docs/PROGRESS.md` and naming what is next -
   read from `PLANS.md`'s iteration table, not decided.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 
 <p align="center">
-  <i><b>Open-source AI agents that work on your computer.</b></i>
+  <i><b>An open-source loop that controls your computer, reachable from your phone.</b></i>
 </p>
 
-Describe your work in a sentence. Vadgr runs it on your machine -- writing code, controlling apps, clicking buttons, and delivering results -- while you do something else. You start it from this CLI or from the phone app, and watch it from either. Cross-platform: Linux, Windows (WSL2), and macOS (in progress).
+Describe your work in a sentence. Vadgr runs it on your machine - writing code, controlling apps, clicking buttons, and delivering results - while you do something else. You start it from this CLI or from the phone app, and watch it from either. It is not tied to one model vendor: the machine talks to whichever provider you point it at. Cross-platform: Linux, Windows (WSL2), and macOS (in progress).
 
 ## Platform
 
@@ -36,12 +36,12 @@ Works on **Linux**, **WSL**, and **Windows**. macOS support is in progress (runn
 
 ```bash
 # Linux / macOS / WSL
-curl -fsSL https://raw.githubusercontent.com/MONTBRAIN/Agent-Forge/master/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/MONTBRAIN/vadgr/master/setup.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/MONTBRAIN/Agent-Forge/master/setup.ps1 | iex
+irm https://raw.githubusercontent.com/MONTBRAIN/vadgr/master/setup.ps1 | iex
 ```
 
 The machine runs work through the provider named in `providers.yaml`. The
@@ -152,6 +152,7 @@ Vadgr/
 │   ├── transport/         # Loopback and Tailscale adapters
 │   └── persistence/       # SQLite database
 ├── engine/                # The native agent loop and its journal
+├── E2E/                   # One runbook per release, and its evidence
 # Desktop automation lives in:
 # https://github.com/MONTBRAIN/vadgr-computer-use
 # (installed via `pip install vadgr-computer-use` when enabled)
@@ -184,7 +185,7 @@ Vadgr/
 |:---:|:---:|:---:|:---|
 | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="25" /> | Pillow | 10.0 | Image processing |
 | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-plain.svg" width="25" /> | mss | 9.0 | Screenshot capture |
-| <picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/anthropic/white"><img src="https://cdn.simpleicons.org/anthropic/black" width="25" alt="Anthropic Logo"></picture> | MCP | 1.0 | Standardized tool interface |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/anthropic/white"><img src="https://cdn.simpleicons.org/anthropic/black" width="25" alt="Anthropic Logo"></picture> | MCP | 2.x | Standardized tool interface |
 
 </div>
 


### PR DESCRIPTION
Nothing in the release process reads the README, so it drifted through several minors unnoticed.

**Fixed**
- The tagline said `Open-source AI agents that work on your computer`. It now says what the product is, and the intro states it is not tied to one model vendor.
- Both install commands pointed at `MONTBRAIN/Agent-Forge`, this repository's former name. They point here now. The old URL still resolves through a redirect, which is exactly why nobody noticed.
- The technologies table listed MCP `1.0`; the computer-use side moved to the `2.x` line.
- `E2E/` was missing from the structure block.

**Added**
- `CLAUDE.md` gains the release rule: the README is updated in the same PR when a minor changed what it says, and "nothing in it changed" is a sentence to write rather than a step to skip.

No code changes, so no test changes.