### PR TITLE
Point the CLI test fixtures at a route the product serves

### DIFF
--- a/cli/tests/test_client.py
+++ b/cli/tests/test_client.py
@@ -129,9 +129,9 @@ def test_a_post_with_a_body_still_sends_it(monkeypatch):
     seen = _capture_request(monkeypatch)
     ctx = click.Context(click.Command("x"))
     ctx.obj = {"api_url": "http://127.0.0.1:8000"}
-    api_post(ctx, "/api/agents", {"name": "a"})
+    api_post(ctx, "/api/runs", {"task": "a"})
 
-    assert seen["req"].data == b'{"name": "a"}'
+    assert seen["req"].data == b'{"task": "a"}'
     assert seen["req"].get_header("Content-type") == "application/json"
 
 

--- a/cli/tests/test_http.py
+++ b/cli/tests/test_http.py
@@ -26,7 +26,7 @@ class _TestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/api/health":
             self._json(200, {"status": "healthy"})
-        elif self.path == "/api/agents":
+        elif self.path == "/api/runs":
             self._json(200, [{"id": "1", "name": "test"}])
         elif self.path == "/api/missing":
             self._json(404, {"detail": "Not found"})
@@ -72,7 +72,7 @@ class TestApiGet:
         assert result["status"] == "healthy"
 
     def test_returns_list(self, ctx, test_server):
-        result = api_get(ctx, "/api/agents")
+        result = api_get(ctx, "/api/runs")
         assert isinstance(result, list)
         assert result[0]["name"] == "test"
 
@@ -88,17 +88,17 @@ class TestApiGet:
 
 class TestApiPost:
     def test_sends_json_body(self, ctx, test_server):
-        result = api_post(ctx, "/api/agents", {"name": "new-agent"})
-        assert result["received"]["name"] == "new-agent"
+        result = api_post(ctx, "/api/runs", {"task": "a new run"})
+        assert result["received"]["task"] == "a new run"
 
     def test_empty_body(self, ctx, test_server):
-        result = api_post(ctx, "/api/agents")
+        result = api_post(ctx, "/api/runs")
         assert result["received"] == {}
 
 
 class TestApiDelete:
     def test_returns_response(self, ctx, test_server):
-        result = api_delete(ctx, "/api/agents/1")
+        result = api_delete(ctx, "/api/runs/1")
         assert result["deleted"] is True
 
 

--- a/cli/tests/test_wait_spinner.py
+++ b/cli/tests/test_wait_spinner.py
@@ -29,7 +29,7 @@ class TestWaitWithSpinner:
             return {"status": "creating", "name": "my-agent"}
 
         with mock.patch("cli.output.api_get", mock_get):
-            result = wait_with_spinner(ctx, "/api/agents/1",
+            result = wait_with_spinner(ctx, "/api/runs/1",
                                        lambda r: r["status"] not in ("creating", "updating", "importing"),
                                        "Working...", interval=0.01, timeout=5)
         assert result["status"] == "ready"
@@ -44,6 +44,6 @@ class TestWaitWithSpinner:
 
         with mock.patch("cli.output.api_get", return_value={"status": "creating"}):
             with pytest.raises(click.ClickException, match="timed out"):
-                wait_with_spinner(ctx, "/api/agents/1",
+                wait_with_spinner(ctx, "/api/runs/1",
                                   lambda r: r["status"] == "ready",
                                   "Working...", interval=0.01, timeout=0.05)


### PR DESCRIPTION
The CLI test fixtures used `/api/agents` and `/api/agents/1` as their example URLs.

The tests exercise the HTTP client generically and passed either way, so nothing was broken. But the agents surface left the product at `0.4.4`, and a reader learning the client from these tests learned a route that does not exist.

## Code

`cli/tests/test_http.py`, `cli/tests/test_client.py`, `cli/tests/test_wait_spinner.py` now use `/api/runs`, which the product serves, and a run-shaped body.

## Tests

`cli` suite: 152 passed.

## User-visible changes

None. Test fixtures only.