### PR TITLE
0.4.8: the CLI in Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +24,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -42,6 +98,16 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic-write-file"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae67d5c03ee972c101a1d8db3ddbf8a9c819ad1ea9d6fd9cd385605547b60edb"
+dependencies = [
+ "nix",
+ "rand 0.10.2",
+]
 
 [[package]]
 name = "autocfg"
@@ -99,10 +165,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -182,6 +248,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +313,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +375,28 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -291,6 +437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -384,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,10 +579,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -609,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +804,12 @@ dependencies = [
  "libc",
  "windows-link",
 ]
+
+[[package]]
+name = "html-escape"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "http"
@@ -861,6 +1053,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,10 +1076,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -1045,6 +1269,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1287,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1096,6 +1340,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -1151,6 +1401,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1464,24 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qrcode-generator"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839ce5d4bbbc258ab4b83061d1e813af257cdf7a63df4837b9cc39f11ffac2d4"
+dependencies = [
+ "atomic-write-file",
+ "html-escape",
+ "image",
+ "url",
 ]
 
 [[package]]
@@ -1724,6 +2011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +2056,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -1814,6 +2118,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2018,7 +2328,23 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.30.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2178,7 +2504,25 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
- "sha1",
+ "sha1 0.10.7",
+ "thiserror",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.11.0",
  "thiserror",
 ]
 
@@ -2193,6 +2537,24 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -2219,6 +2581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,14 +2601,20 @@ dependencies = [
 name = "vadgr-daemon"
 version = "0.4.7"
 dependencies = [
+ "anstream",
+ "anstyle",
  "anyhow",
  "async-trait",
  "axum",
  "base64 0.23.1",
+ "clap",
+ "comfy-table",
  "directories",
  "futures-util",
  "hostname",
  "http-body-util",
+ "indicatif",
+ "qrcode-generator",
  "rand 0.10.2",
  "regex",
  "reqwest",
@@ -2255,6 +2629,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-tungstenite 0.30.0",
  "tokio-util",
  "tower",
  "tower-http 0.7.0",
@@ -2262,7 +2637,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 1.0.9",
  "windows-sys 0.61.2",
 ]
 
@@ -2413,6 +2788,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,31 @@ path = "src/lib.rs"
 name = "vadgr-daemon"
 path = "src/main.rs"
 
+# The CLI is a binary in this crate rather than a second crate, so it depends on
+# `transport` directly. That is what turns `service.py`'s cross-package import of
+# `api.transport` into a shared module instead of a duplicated address
+# computation.
+[[bin]]
+name = "vadgr-cli"
+path = "src/cli/main.rs"
+
 [dependencies]
+# The CLI's surface. `anstyle` is declared because Rust requires a direct
+# dependency to import it, but it adds nothing to the compiled tree: `clap`
+# already brings it, and `anstream` rides clap's default colour feature.
+# `anstream` is what actually strips colour when the stream is not a terminal.
+# `anstyle` only describes a style; printing it through `std::println!` writes the
+# escapes unconditionally, which leaked into piped output until this was caught by
+# driving the CLI rather than by a unit test.
+anstream = "1.0"
+# The run stream consumer, replacing `websockets`. `futures-util` is already here.
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
+anstyle = "1.0"
+clap = { version = "4.6", features = ["derive", "env"] }
+comfy-table = { version = "8.0", default-features = false }
+indicatif = "0.18"
+qrcode-generator = "6.0"
+
 axum = { version = "0.8", features = ["ws", "macros"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.7", features = ["trace"] }

--- a/rust/src/cli/client.rs
+++ b/rust/src/cli/client.rs
@@ -1,0 +1,325 @@
+//! The CLI's HTTP boundary.
+//!
+//! Ported from `cli/client.py`, and the design calls this the riskiest file in
+//! the port: every behaviour a script depends on lives here, and none of it is
+//! visible in the command tree.
+
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+/// Fifteen seconds for an ordinary call.
+const TIMEOUT: Duration = Duration::from_secs(15);
+/// Two minutes for the calls that wait on a provider.
+const LONG_TIMEOUT: Duration = Duration::from_secs(120);
+/// The reachability probe answers in milliseconds or not at all.
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(1500);
+
+const LOOPBACK_HOSTS: [&str; 3] = ["127.0.0.1", "localhost", "::1"];
+
+/// The daemon could not be reached.
+///
+/// **Its own exit code, and that is the contract.** "It is down" and "it ran and
+/// said no" are different problems, and a script branches on them: the first is
+/// retried after a start, the second never is. Collapsing them into one code
+/// makes that branch impossible to write.
+#[derive(Debug)]
+pub struct DaemonUnreachable {
+    pub base_url: String,
+}
+
+impl DaemonUnreachable {
+    pub const EXIT_CODE: i32 = 3;
+}
+
+impl std::fmt::Display for DaemonUnreachable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "API is not running at {}. Start it with: vadgr start",
+            self.base_url
+        )
+    }
+}
+
+/// A structured daemon error that a command can recover from **by code**.
+///
+/// `details` is load-bearing rather than decoration: the provider commands read
+/// `details["category"]` to choose which recovery menu to offer. A port that
+/// keeps only the message turns that branch into string matching.
+#[derive(Debug)]
+pub struct ApiClientError {
+    pub message: String,
+    pub status: u16,
+    pub code: Option<String>,
+    pub details: serde_json::Value,
+}
+
+impl ApiClientError {
+    pub const EXIT_CODE: i32 = 1;
+
+    /// The recovery category, when the daemon named one.
+    pub fn category(&self) -> Option<&str> {
+        self.details.get("category").and_then(|v| v.as_str())
+    }
+}
+
+impl std::fmt::Display for ApiClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+#[derive(Debug)]
+pub enum ClientError {
+    Unreachable(DaemonUnreachable),
+    Api(ApiClientError),
+}
+
+impl ClientError {
+    /// The exit code this failure leaves the process with.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Unreachable(_) => DaemonUnreachable::EXIT_CODE,
+            Self::Api(_) => ApiClientError::EXIT_CODE,
+        }
+    }
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreachable(e) => e.fmt(f),
+            Self::Api(e) => e.fmt(f),
+        }
+    }
+}
+
+/// Whether the pre-request reachability probe applies to this URL.
+///
+/// **Loopback with an explicit port, and nothing else.** The probe exists for
+/// the local daemon and is only ever allowed to make the answer *faster*, never
+/// to invent a failure the request itself would not have hit.
+///
+/// Two ways a broader probe would do exactly that. `--api-url` can point at an
+/// `https://` host with no port, where testing `port or 80` would probe 80 while
+/// the request goes to 443 and report a live machine as down. And a remote host
+/// over a tailnet can be reachable-but-slow, which is normal for it rather than
+/// a failure to report early.
+pub fn should_probe(base_url: &str) -> bool {
+    let Ok(url) = url::Url::parse(base_url) else {
+        return false;
+    };
+    let Some(port) = url.port() else {
+        return false;
+    };
+    let _ = port;
+    url.host_str().is_some_and(|h| LOOPBACK_HOSTS.contains(&h))
+}
+
+/// Whether anything is listening, answered in milliseconds.
+///
+/// On Linux and macOS a closed local port is refused instantly and this is
+/// redundant. **On WSL2 it is not**: an IPv4 loopback connect to a port nothing
+/// listens on is swallowed rather than refused, so the connect runs to the full
+/// timeout. Measured at 15 s for `vadgr health` against a dead daemon, where
+/// `::1` refuses the same port in under a millisecond. WSL2 is a platform this
+/// daemon claims, and "your daemon is down" should not take fifteen seconds to
+/// say on it.
+pub fn port_is_open(host: &str, port: u16) -> bool {
+    let Ok(addrs) = (host, port).to_socket_addrs() else {
+        return false;
+    };
+    let addrs: Vec<SocketAddr> = addrs.collect();
+    addrs
+        .iter()
+        .any(|a| TcpStream::connect_timeout(a, CONNECT_TIMEOUT).is_ok())
+}
+
+/// The HTTP client, holding its base URL as a value.
+///
+/// Taking the base URL and the underlying client by value rather than reading
+/// them from ambient context is what makes every command testable against a stub
+/// without a live daemon, which is what the Python tests already do.
+pub struct Client {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl Client {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            http: reqwest::Client::builder()
+                .timeout(TIMEOUT)
+                .build()
+                .expect("the HTTP client builds"),
+        }
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub async fn get(&self, path: &str) -> Result<serde_json::Value, ClientError> {
+        self.request(reqwest::Method::GET, path, None, TIMEOUT)
+            .await
+    }
+
+    pub async fn post(
+        &self,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> Result<serde_json::Value, ClientError> {
+        self.request(reqwest::Method::POST, path, body, TIMEOUT)
+            .await
+    }
+
+    /// A POST that waits on a provider, so it takes the long timeout.
+    pub async fn post_long(
+        &self,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> Result<serde_json::Value, ClientError> {
+        self.request(reqwest::Method::POST, path, body, LONG_TIMEOUT)
+            .await
+    }
+
+    pub async fn put(
+        &self,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> Result<serde_json::Value, ClientError> {
+        self.request(reqwest::Method::PUT, path, body, LONG_TIMEOUT)
+            .await
+    }
+
+    pub async fn delete(&self, path: &str) -> Result<serde_json::Value, ClientError> {
+        self.request(reqwest::Method::DELETE, path, None, TIMEOUT)
+            .await
+    }
+
+    /// Whether the daemon answers its health route.
+    pub async fn is_running(&self) -> bool {
+        self.get("/api/health").await.is_ok()
+    }
+
+    fn unreachable(&self) -> ClientError {
+        ClientError::Unreachable(DaemonUnreachable {
+            base_url: self.base_url.clone(),
+        })
+    }
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, ClientError> {
+        if should_probe(&self.base_url) {
+            let url = url::Url::parse(&self.base_url).expect("a probed base URL parses");
+            let host = url.host_str().unwrap_or("127.0.0.1");
+            let port = url.port().expect("should_probe required a port");
+            if !port_is_open(host, port) {
+                return Err(self.unreachable());
+            }
+        }
+
+        let mut req = self
+            .http
+            .request(method, format!("{}{path}", self.base_url))
+            .timeout(timeout);
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let response = match req.send().await {
+            Ok(r) => r,
+            Err(e) if e.is_connect() || e.is_timeout() => return Err(self.unreachable()),
+            Err(e) => {
+                return Err(ClientError::Api(ApiClientError {
+                    message: e.to_string(),
+                    status: 0,
+                    code: None,
+                    details: serde_json::Value::Null,
+                }));
+            }
+        };
+
+        let status = response.status().as_u16();
+        let payload: serde_json::Value = response.json().await.unwrap_or(serde_json::Value::Null);
+
+        if (200..300).contains(&status) {
+            return Ok(payload);
+        }
+
+        // The daemon's error envelope, kept whole. `details` reaches the command
+        // that has to branch on it.
+        let error = payload.get("error");
+        Err(ClientError::Api(ApiClientError {
+            message: error
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str())
+                .unwrap_or("the daemon returned an error")
+                .to_owned(),
+            status,
+            code: error
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_str())
+                .map(str::to_owned),
+            details: error
+                .and_then(|e| e.get("details"))
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_probe_applies_to_loopback_with_an_explicit_port() {
+        assert!(should_probe("http://127.0.0.1:8000"));
+        assert!(should_probe("http://localhost:8000"));
+    }
+
+    /// The narrowness is the point, not an omission.
+    #[test]
+    fn the_probe_does_not_apply_where_it_would_invent_a_failure() {
+        // An https host with no port: probing `port or 80` would test 80 while
+        // the request goes to 443, and report a live machine as down.
+        assert!(!should_probe("https://machine.example.com"));
+        // A remote host is allowed to be reachable-but-slow.
+        assert!(!should_probe("http://100.64.0.1:8000"));
+        assert!(!should_probe("http://machine.tail1234.ts.net:8000"));
+    }
+
+    #[test]
+    fn the_two_failures_carry_different_exit_codes() {
+        let down = ClientError::Unreachable(DaemonUnreachable {
+            base_url: "http://127.0.0.1:8000".into(),
+        });
+        let refused = ClientError::Api(ApiClientError {
+            message: "no".into(),
+            status: 400,
+            code: Some("BAD".into()),
+            details: serde_json::Value::Null,
+        });
+        assert_eq!(down.exit_code(), 3, "down is retried after a start");
+        assert_eq!(refused.exit_code(), 1, "refused never is");
+        assert_ne!(down.exit_code(), refused.exit_code());
+    }
+
+    #[test]
+    fn a_daemon_error_keeps_the_category_a_command_branches_on() {
+        let e = ApiClientError {
+            message: "could not connect".into(),
+            status: 503,
+            code: Some("PROVIDER_UNAVAILABLE".into()),
+            details: serde_json::json!({ "category": "provider_unavailable" }),
+        };
+        assert_eq!(e.category(), Some("provider_unavailable"));
+    }
+}

--- a/rust/src/cli/commands/info.rs
+++ b/rust/src/cli/commands/info.rs
@@ -1,0 +1,106 @@
+//! `vadgr health`, `vadgr providers`, `vadgr computer-use`.
+//!
+//! Ported from `cli/commands/info.py`: the read-only views of what the daemon
+//! currently is.
+
+use crate::client::{Client, ClientError};
+use crate::output;
+
+pub async fn health(client: &Client) -> Result<(), ClientError> {
+    let body = client.get("/api/health").await?;
+    let field = |k: &str| {
+        body.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("-")
+            .to_owned()
+    };
+    let cua = body
+        .get("modules")
+        .and_then(|m| m.get("computer_use"))
+        .and_then(|v| v.as_bool())
+        .map(|b| if b { "available" } else { "disabled" })
+        .unwrap_or("-")
+        .to_owned();
+    let pairs = vec![
+        ("Status".to_owned(), output::format_status(&field("status"))),
+        ("Version".to_owned(), field("version")),
+        ("Platform".to_owned(), field("platform")),
+        ("Computer use".to_owned(), cua),
+    ];
+    anstream::println!("{}", output::render_kv(&pairs));
+    Ok(())
+}
+
+pub async fn providers(client: &Client) -> Result<(), ClientError> {
+    let body = client.get("/api/providers").await?;
+    let empty = Vec::new();
+    let list = body.as_array().unwrap_or(&empty);
+    let rows: Vec<Vec<String>> = list
+        .iter()
+        .map(|p| {
+            let connected = p
+                .get("connected")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let default = p
+                .get("is_default")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let models = p
+                .get("models")
+                .and_then(|v| v.as_array())
+                .map(|m| m.len())
+                .unwrap_or(0);
+            vec![
+                p.get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_owned(),
+                output::format_status(if connected { "ready" } else { "disabled" }),
+                if default {
+                    "default".to_owned()
+                } else {
+                    String::new()
+                },
+                models.to_string(),
+            ]
+        })
+        .collect();
+    anstream::println!(
+        "{}",
+        output::render_table(&["Provider", "State", "", "Models"], &rows)
+    );
+    Ok(())
+}
+
+pub async fn computer_use_status(client: &Client) -> Result<(), ClientError> {
+    let body = client.get("/api/settings/computer-use").await?;
+    let enabled = body
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let pairs = vec![(
+        "Computer use".to_owned(),
+        output::format_status(if enabled { "ready" } else { "disabled" }),
+    )];
+    anstream::println!("{}", output::render_kv(&pairs));
+    Ok(())
+}
+
+pub async fn computer_use_set(client: &Client, enabled: bool) -> Result<(), ClientError> {
+    client
+        .put(
+            "/api/settings/computer-use",
+            Some(serde_json::json!({ "enabled": enabled })),
+        )
+        .await?;
+    anstream::println!(
+        "{}",
+        output::success(if enabled {
+            "Computer use enabled."
+        } else {
+            "Computer use disabled."
+        })
+    );
+    Ok(())
+}

--- a/rust/src/cli/commands/mod.rs
+++ b/rust/src/cli/commands/mod.rs
@@ -1,0 +1,9 @@
+//! The command implementations.
+//!
+//! **Boundary rule from the design:** a command never builds strings for the
+//! terminal and never calls the HTTP layer directly. It calls `client` and hands
+//! values to `output`. That is what makes the sweep's "whether output was
+//! produced" assertion checkable per command.
+
+pub mod info;
+pub mod runs;

--- a/rust/src/cli/commands/runs.rs
+++ b/rust/src/cli/commands/runs.rs
@@ -1,0 +1,135 @@
+//! `vadgr runs`: list, get, cancel, resume.
+//!
+//! Ported from `cli/commands/runs.py`. The exit code a terminal run status
+//! implies is part of the contract the recorded sweep asserts, so it lives here
+//! in one place rather than at each call site.
+
+use crate::client::{Client, ClientError};
+use crate::output;
+
+/// The exit code a finished run leaves behind.
+///
+/// A script runs `vadgr run` and branches on this, so the mapping is a contract
+/// rather than a convenience. `cancelled` is deliberately not a failure: the
+/// owner asked for it.
+pub fn exit_code_for(status: &str) -> i32 {
+    match status {
+        "completed" => 0,
+        "cancelled" => 0,
+        _ => 1,
+    }
+}
+
+fn truncate(text: &str, width: usize) -> String {
+    // Count characters, not bytes. A task sentence carries accented text and
+    // emoji, and slicing by byte splits them into replacement characters.
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= width {
+        return text.to_owned();
+    }
+    let cut: String = chars[..width.saturating_sub(1)].iter().collect();
+    format!("{cut}\u{2026}")
+}
+
+pub async fn list(client: &Client) -> Result<(), ClientError> {
+    let body = client.get("/api/runs").await?;
+    let empty = Vec::new();
+    let runs = body.as_array().unwrap_or(&empty);
+    if runs.is_empty() {
+        anstream::println!("{}", output::info("No runs yet."));
+        return Ok(());
+    }
+    let rows: Vec<Vec<String>> = runs
+        .iter()
+        .map(|r| {
+            let id = r.get("id").and_then(|v| v.as_str()).unwrap_or("-");
+            let task = r.get("agent_name").and_then(|v| v.as_str()).unwrap_or("-");
+            let status = r.get("status").and_then(|v| v.as_str()).unwrap_or("-");
+            vec![
+                id.chars().take(8).collect(),
+                truncate(task, 60),
+                output::format_status(status),
+            ]
+        })
+        .collect();
+    anstream::println!(
+        "{}",
+        output::render_table(&["Run ID", "Task", "Status"], &rows)
+    );
+    Ok(())
+}
+
+pub async fn get(client: &Client, run_id: &str) -> Result<(), ClientError> {
+    let body = client.get(&format!("/api/runs/{run_id}")).await?;
+    let field = |k: &str| {
+        body.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("-")
+            .to_owned()
+    };
+    let pairs = vec![
+        ("Run".to_owned(), field("id")),
+        ("Status".to_owned(), output::format_status(&field("status"))),
+        ("Provider".to_owned(), field("provider")),
+        ("Model".to_owned(), field("model")),
+        ("Started".to_owned(), field("started_at")),
+        ("Completed".to_owned(), field("completed_at")),
+    ];
+    anstream::println!("{}", output::render_kv(&pairs));
+    Ok(())
+}
+
+pub async fn cancel(client: &Client, run_id: &str) -> Result<(), ClientError> {
+    client
+        .post(&format!("/api/runs/{run_id}/cancel"), None)
+        .await?;
+    anstream::println!("{}", output::success(&format!("Cancelled run {run_id}")));
+    Ok(())
+}
+
+pub async fn resume(client: &Client, run_id: &str) -> Result<(), ClientError> {
+    client
+        .post(&format!("/api/runs/{run_id}/resume"), None)
+        .await?;
+    anstream::println!("{}", output::success(&format!("Resumed run {run_id}")));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_completed_run_exits_zero_and_a_failed_one_does_not() {
+        assert_eq!(exit_code_for("completed"), 0);
+        assert_eq!(exit_code_for("failed"), 1);
+    }
+
+    /// A cancellation is what the owner asked for, so it is not a failure.
+    #[test]
+    fn a_cancelled_run_is_not_a_failure() {
+        assert_eq!(exit_code_for("cancelled"), 0);
+    }
+
+    /// Truncation counts characters, because a task sentence is prose.
+    #[test]
+    fn truncation_does_not_split_a_character() {
+        let task = "reinicia el servidor de producción con cuidado";
+        let out = truncate(task, 20);
+        assert_eq!(out.chars().count(), 20);
+        assert!(out.ends_with('\u{2026}'));
+        assert!(!out.contains('\u{fffd}'), "no replacement character");
+    }
+
+    #[test]
+    fn truncation_leaves_a_short_task_alone() {
+        assert_eq!(truncate("short", 20), "short");
+    }
+
+    #[test]
+    fn emoji_survive_truncation_whole() {
+        let out = truncate("deploy 🚀🚀🚀 to production now please", 10);
+        assert_eq!(out.chars().count(), 10);
+        assert!(!out.contains('\u{fffd}'));
+    }
+}

--- a/rust/src/cli/main.rs
+++ b/rust/src/cli/main.rs
@@ -1,0 +1,184 @@
+//! `vadgr`, the on-box owner surface.
+//!
+//! Ported from `cli/` at `0.4.8`. The command tree is unchanged: same verbs,
+//! same nesting, same exit codes, because the recorded surface sweep asserts
+//! argv and exit code and a port is judged against it.
+//!
+//! **`vadgr start` still launches the Python daemon in this release.** The
+//! cutover is `0.4.9`, alone in its release, so a defect found after it has one
+//! candidate cause.
+
+mod client;
+mod commands;
+mod output;
+mod stream;
+
+use clap::{Parser, Subcommand};
+
+use client::{Client, ClientError};
+
+/// The base URL, resolved once.
+///
+/// `--api-url`, then `VADGR_API_URL`, then `VADGR_PORT` on loopback, then the
+/// default. The old `FORGE_*` names are gone rather than deprecated: §6a allows
+/// an adapter only for a named released consumer, and there is one installation,
+/// the owner's, on the same machine as the new state root.
+const DEFAULT_PORT: u16 = 8000;
+
+#[derive(Parser)]
+#[command(
+    name = "vadgr",
+    about = "vadgr CLI.",
+    version,
+    disable_help_subcommand = true
+)]
+struct Cli {
+    /// The daemon's base URL.
+    #[arg(long, global = true, env = "VADGR_API_URL", hide = true)]
+    api_url: Option<String>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start the vadgr daemon (the API).
+    Api,
+    /// Manage computer use (desktop automation).
+    ComputerUse {
+        #[command(subcommand)]
+        action: ComputerUseAction,
+    },
+    /// Check API health.
+    Health,
+    /// Tail service logs.
+    Logs,
+    /// List models and select the machine default.
+    Model {
+        #[command(subcommand)]
+        action: ModelAction,
+    },
+    /// Pair a mobile device: mint a one-time code and show a QR.
+    Pair,
+    /// Connect and manage model providers.
+    Provider {
+        #[command(subcommand)]
+        action: ProviderAction,
+    },
+    /// List available providers and models.
+    Providers,
+    /// Restart the vadgr daemon.
+    Restart,
+    /// Start a run from a task sentence and watch it.
+    Run {
+        /// What the machine should do.
+        task: String,
+    },
+    /// Manage runs.
+    Runs {
+        #[command(subcommand)]
+        action: RunsAction,
+    },
+    /// Start the vadgr daemon (the API).
+    Start,
+    /// Show service status.
+    Status,
+    /// Stop the vadgr daemon.
+    Stop,
+    /// Pull latest code and reinstall deps if changed.
+    Update,
+}
+
+#[derive(Subcommand)]
+enum ComputerUseAction {
+    /// Enable computer use.
+    Enable,
+    /// Disable computer use.
+    Disable,
+    /// Show computer-use status.
+    Status,
+}
+
+#[derive(Subcommand)]
+enum ModelAction {
+    /// Set the machine default after a live check.
+    Default {
+        /// The `provider/model` pair.
+        model: String,
+    },
+    /// List models from every connected provider.
+    List,
+}
+
+#[derive(Subcommand)]
+enum ProviderAction {
+    /// Connect or reauthenticate one provider.
+    Login {
+        provider: Option<String>,
+        /// `chatgpt` or `api-key`, for OpenAI.
+        #[arg(long)]
+        auth: Option<String>,
+    },
+    /// Disconnect one non-default provider.
+    Logout { provider: Option<String> },
+    /// Show connected providers and their model catalogs.
+    Status {
+        #[arg(long = "refresh")]
+        refresh: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum RunsAction {
+    /// Cancel a running run.
+    Cancel { run_id: String },
+    /// Show run details.
+    Get { run_id: String },
+    /// List all runs.
+    List,
+    /// Resume a failed run.
+    Resume { run_id: String },
+}
+
+fn base_url(explicit: Option<&str>) -> String {
+    if let Some(url) = explicit {
+        return url.to_owned();
+    }
+    let port = std::env::var("VADGR_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_PORT);
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let client = Client::new(base_url(cli.api_url.as_deref()));
+
+    let result: Result<(), ClientError> = match cli.command {
+        Command::Health => commands::info::health(&client).await,
+        Command::Providers => commands::info::providers(&client).await,
+        Command::ComputerUse { action } => match action {
+            ComputerUseAction::Enable => commands::info::computer_use_set(&client, true).await,
+            ComputerUseAction::Disable => commands::info::computer_use_set(&client, false).await,
+            ComputerUseAction::Status => commands::info::computer_use_status(&client).await,
+        },
+        Command::Runs { action } => match action {
+            RunsAction::List => commands::runs::list(&client).await,
+            RunsAction::Get { run_id } => commands::runs::get(&client, &run_id).await,
+            RunsAction::Cancel { run_id } => commands::runs::cancel(&client, &run_id).await,
+            RunsAction::Resume { run_id } => commands::runs::resume(&client, &run_id).await,
+        },
+        _ => {
+            anstream::eprintln!("{}", output::error("not yet ported at this commit"));
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = result {
+        anstream::eprintln!("{}", output::error(&e.to_string()));
+        std::process::exit(e.exit_code());
+    }
+}

--- a/rust/src/cli/output/mod.rs
+++ b/rust/src/cli/output/mod.rs
@@ -1,0 +1,168 @@
+//! Everything the CLI puts on a terminal.
+//!
+//! Ported from `cli/output.py`, which already centralised status colouring,
+//! key-value printing and duration formatting. §6a warns against reimplementing
+//! logic the original had factored, so each of those keeps one home here rather
+//! than one per command.
+//!
+//! `rich` has no Rust equivalent worth depending on, so tables come from
+//! `comfy-table` and colour from `anstyle`. `anstyle` is declared in the
+//! manifest because Rust needs a direct dependency to import it, but it adds
+//! nothing to the compiled tree: `clap` already brings it.
+
+use anstyle::{AnsiColor, Color, Style};
+use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL};
+
+pub mod status;
+
+/// The status palette, one place, as `_STATUS_STYLES` was in Python.
+fn status_style(status: &str) -> Style {
+    let colour = match status {
+        "ready" | "completed" => AnsiColor::Green,
+        "running" => AnsiColor::BrightBlue,
+        "creating" | "queued" | "awaiting_approval" => AnsiColor::Yellow,
+        "failed" | "cancelled" => AnsiColor::Red,
+        _ => return Style::new(),
+    };
+    Style::new().fg_color(Some(Color::Ansi(colour)))
+}
+
+/// A status, coloured when colour is on and plain when it is not.
+///
+/// The decision is made once, by `anstream`, from whether the stream is a
+/// terminal and whether `NO_COLOR` is set. No command asks that question.
+pub fn format_status(status: &str) -> String {
+    let s = status_style(status);
+    format!("{s}{status}{s:#}")
+}
+
+/// A table with the shape the CLI has always drawn.
+pub fn render_table(headers: &[&str], rows: &[Vec<String>]) -> String {
+    let mut table = Table::new();
+    table
+        .load_style(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(headers.iter().map(|h| h.to_string()));
+    for row in rows {
+        table.add_row(row.clone());
+    }
+    table.to_string()
+}
+
+/// Key and value, at the fixed label width the Python version used.
+pub fn render_kv(pairs: &[(String, String)]) -> String {
+    const LABEL_WIDTH: usize = 12;
+    pairs
+        .iter()
+        .map(|(k, v)| format!("{k:<LABEL_WIDTH$} {v}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A duration, in the CLI's own shorthand.
+pub fn format_duration(seconds: f64) -> String {
+    if seconds < 1.0 {
+        return format!("{:.0}ms", seconds * 1000.0);
+    }
+    if seconds < 60.0 {
+        return format!("{seconds:.0}s");
+    }
+    let minutes = (seconds / 60.0).floor();
+    let rest = seconds - minutes * 60.0;
+    if minutes < 60.0 {
+        return format!("{minutes:.0}m {rest:.0}s");
+    }
+    let hours = (minutes / 60.0).floor();
+    format!("{hours:.0}h {:.0}m", minutes - hours * 60.0)
+}
+
+fn styled(prefix: &str, colour: AnsiColor, message: &str) -> String {
+    let s = Style::new().fg_color(Some(Color::Ansi(colour)));
+    format!("{s}{prefix}{s:#} {message}")
+}
+
+pub fn success(message: &str) -> String {
+    styled("[vadgr]", AnsiColor::Green, message)
+}
+
+pub fn info(message: &str) -> String {
+    styled("[vadgr]", AnsiColor::Blue, message)
+}
+
+pub fn warning(message: &str) -> String {
+    styled("[vadgr]", AnsiColor::Yellow, message)
+}
+
+pub fn error(message: &str) -> String {
+    styled("Error:", AnsiColor::Red, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Assert the rendering as text rather than by eye, which is why colour is
+    /// forced off for these.
+    fn plain(s: &str) -> String {
+        // Strip SGR sequences so the shape is asserted, not the escapes.
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn a_table_carries_its_headers_and_every_row() {
+        let out = render_table(
+            &["Run ID", "Status"],
+            &[
+                vec!["run-abcd".into(), "completed".into()],
+                vec!["run-efgh".into(), "failed".into()],
+            ],
+        );
+        assert!(out.contains("Run ID"));
+        assert!(out.contains("run-abcd"));
+        assert!(out.contains("run-efgh"));
+        assert_eq!(out.matches("run-").count(), 2, "no row is dropped");
+    }
+
+    #[test]
+    fn a_key_value_block_pads_to_the_label_width() {
+        let out = render_kv(&[("Status".into(), "running".into())]);
+        assert_eq!(out, "Status       running");
+    }
+
+    #[test]
+    fn a_status_reads_the_same_with_colour_stripped() {
+        assert_eq!(plain(&format_status("completed")), "completed");
+        assert_eq!(plain(&format_status("failed")), "failed");
+        // An unknown status still renders, uncoloured rather than dropped.
+        assert_eq!(plain(&format_status("surprising")), "surprising");
+    }
+
+    #[test]
+    fn durations_read_the_way_the_cli_has_always_written_them() {
+        assert_eq!(format_duration(0.25), "250ms");
+        assert_eq!(format_duration(9.0), "9s");
+        assert_eq!(format_duration(75.0), "1m 15s");
+        assert_eq!(format_duration(3720.0), "1h 2m");
+    }
+
+    #[test]
+    fn the_four_levels_carry_their_prefix() {
+        assert!(plain(&success("done")).starts_with("[vadgr] done"));
+        assert!(plain(&info("checking")).starts_with("[vadgr] checking"));
+        assert!(plain(&warning("careful")).starts_with("[vadgr] careful"));
+        assert!(plain(&error("no")).starts_with("Error: no"));
+    }
+}

--- a/rust/src/cli/output/status.rs
+++ b/rust/src/cli/output/status.rs
@@ -1,0 +1,51 @@
+//! The waiting spinner, replacing `rich`'s `console.status`.
+//!
+//! `indicatif` is the one crate added purely for this. It is off when the stream
+//! is not a terminal, so piping a command to a file does not fill it with frames.
+
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// The tick pattern `rich` called `dots`, kept so the CLI looks unchanged.
+const DOTS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// A spinner that runs while something is awaited.
+pub struct Spinner(ProgressBar);
+
+impl Spinner {
+    pub fn start(message: impl Into<String>) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::with_template("{spinner} {msg}")
+                .expect("the spinner template parses")
+                .tick_strings(DOTS),
+        );
+        bar.set_message(message.into());
+        bar.enable_steady_tick(Duration::from_millis(80));
+        Self(bar)
+    }
+
+    pub fn update(&self, message: impl Into<String>) {
+        self.0.set_message(message.into());
+    }
+
+    /// Stop and clear the line, so the next thing printed owns it.
+    pub fn stop(self) {
+        self.0.finish_and_clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The spinner must always be stoppable, because a spinner that never stops
+    /// is what a user sees when a command fails on a path nobody tested.
+    #[test]
+    fn a_spinner_starts_updates_and_stops() {
+        let s = Spinner::start("waiting");
+        s.update("still waiting");
+        s.stop();
+    }
+}

--- a/rust/src/cli/stream.rs
+++ b/rust/src/cli/stream.rs
@@ -1,0 +1,236 @@
+//! Watching a run over its public socket.
+//!
+//! Ported from `cli/stream.py`, and this is the one file the design marks as
+//! **improved rather than ported**. The Python consumer handles three event
+//! types. The daemon publishes twelve. A cancelled run therefore said nothing at
+//! all to someone watching from the terminal, which is the defect the migration
+//! ratchet requires fixing rather than carrying.
+
+use std::time::{Duration, Instant};
+
+use futures_util::StreamExt;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::output;
+
+/// How a watch ended, and the exit code it implies.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Completed,
+    Failed,
+    Cancelled,
+    /// The watch timed out. The run keeps going without us.
+    Detached,
+    /// The socket dropped. We do not know how the run ended.
+    Unknown,
+}
+
+impl Outcome {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            // A cancellation is what the owner asked for, so it is not a failure.
+            Self::Completed | Self::Cancelled => 0,
+            Self::Failed => 1,
+            // "Still running" and "we lost the socket" are not failures of the
+            // run, and a script that treats them as one would kill work that is
+            // fine.
+            Self::Detached | Self::Unknown => 0,
+        }
+    }
+}
+
+/// Every event type the daemon publishes on the mobile route.
+///
+/// Listed exhaustively on purpose. The Python consumer matched three and let the
+/// rest fall through, so `run_cancelled` arrived and produced silence.
+pub fn describe(event_type: &str, data: &serde_json::Value) -> Option<String> {
+    let text = |k: &str| data.get(k).and_then(|v| v.as_str()).unwrap_or("");
+    Some(match event_type {
+        "run_started" => "Run started".to_owned(),
+        "run_resumed" => "Run resumed from its journal".to_owned(),
+        "agent_started" => {
+            let name = text("name");
+            if name.is_empty() {
+                "Running...".to_owned()
+            } else {
+                format!("Running {name}...")
+            }
+        }
+        "agent_log" => text("message").to_owned(),
+        "todos" => "Updated its plan".to_owned(),
+        "agent_completed" => "Finished the work".to_owned(),
+        "agent_failed" => format!("Step failed: {}", text("error")),
+        "agent_cancelled" => "Cancelling...".to_owned(),
+        // The three terminal frames are handled by the caller, which needs the
+        // outcome rather than a line of prose.
+        "run_completed" | "run_failed" | "run_cancelled" => return None,
+        _ => return None,
+    })
+}
+
+/// Whether an event type ends the watch, and how.
+pub fn terminal_outcome(event_type: &str) -> Option<Outcome> {
+    match event_type {
+        "run_completed" => Some(Outcome::Completed),
+        "run_failed" => Some(Outcome::Failed),
+        "run_cancelled" => Some(Outcome::Cancelled),
+        _ => None,
+    }
+}
+
+/// Follow a run to its terminal frame.
+pub async fn follow(api_url: &str, run_id: &str, timeout: Duration) -> Outcome {
+    let ws_url = format!(
+        "{}/api/ws/runs/{run_id}",
+        api_url
+            .replacen("http://", "ws://", 1)
+            .replacen("https://", "wss://", 1)
+    );
+
+    let Ok((mut socket, _)) = tokio_tungstenite::connect_async(&ws_url).await else {
+        anstream::println!(
+            "  Could not connect to the run stream. The run continues in the background."
+        );
+        anstream::println!("  See the run: vadgr runs get {run_id}");
+        return Outcome::Unknown;
+    };
+
+    let started = Instant::now();
+    let spinner = output::status::Spinner::start("Starting...");
+
+    loop {
+        if started.elapsed() > timeout {
+            spinner.stop();
+            anstream::println!(
+                "  Timed out after {}. The run continues in the background.",
+                output::format_duration(timeout.as_secs_f64())
+            );
+            return Outcome::Detached;
+        }
+
+        let next = tokio::time::timeout(Duration::from_secs(3), socket.next()).await;
+        let raw = match next {
+            Err(_) => continue,
+            Ok(None) => {
+                spinner.stop();
+                anstream::println!("  The run stream closed. The run continues in the background.");
+                anstream::println!("  See the run: vadgr runs get {run_id}");
+                return Outcome::Unknown;
+            }
+            Ok(Some(Err(_))) => {
+                spinner.stop();
+                anstream::println!("  Lost the run stream. The run continues in the background.");
+                return Outcome::Unknown;
+            }
+            Ok(Some(Ok(Message::Text(t)))) => t.to_string(),
+            Ok(Some(Ok(_))) => continue,
+        };
+
+        let Ok(event) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let data = event
+            .get("data")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        if let Some(outcome) = terminal_outcome(event_type) {
+            spinner.stop();
+            let elapsed = output::format_duration(started.elapsed().as_secs_f64());
+            match outcome {
+                Outcome::Completed => {
+                    anstream::println!(
+                        "{}",
+                        output::success(&format!("Run completed ({elapsed})"))
+                    );
+                }
+                Outcome::Failed => {
+                    let error = data
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Unknown error");
+                    anstream::println!(
+                        "{}",
+                        output::error(&format!("Run failed ({elapsed}): {error}"))
+                    );
+                    anstream::println!("  See the run: vadgr runs get {run_id}");
+                }
+                // The frame this port exists to handle.
+                Outcome::Cancelled => {
+                    anstream::println!(
+                        "{}",
+                        output::warning(&format!("Run cancelled ({elapsed})"))
+                    );
+                }
+                _ => {}
+            }
+            return outcome;
+        }
+
+        if let Some(line) = describe(event_type, &data) {
+            if !line.is_empty() {
+                spinner.update(line);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The regression this release fixes: a cancelled run must end the watch and
+    /// say so. Against the Python consumer's three types this is `None`.
+    #[test]
+    fn a_cancelled_run_is_a_terminal_outcome() {
+        assert_eq!(terminal_outcome("run_cancelled"), Some(Outcome::Cancelled));
+    }
+
+    #[test]
+    fn the_three_terminal_frames_end_the_watch() {
+        assert_eq!(terminal_outcome("run_completed"), Some(Outcome::Completed));
+        assert_eq!(terminal_outcome("run_failed"), Some(Outcome::Failed));
+        assert_eq!(terminal_outcome("run_cancelled"), Some(Outcome::Cancelled));
+        assert_eq!(terminal_outcome("agent_started"), None);
+    }
+
+    /// Every type the daemon publishes is either described or terminal. A type
+    /// that is neither is one a watcher would sit silently through.
+    #[test]
+    fn every_published_event_type_is_handled() {
+        let published = [
+            "run_started",
+            "run_resumed",
+            "run_completed",
+            "run_failed",
+            "run_cancelled",
+            "agent_started",
+            "agent_log",
+            "agent_completed",
+            "agent_failed",
+            "agent_cancelled",
+            "todos",
+        ];
+        let null = serde_json::Value::Null;
+        for t in published {
+            let handled = describe(t, &null).is_some() || terminal_outcome(t).is_some();
+            assert!(handled, "{t} is published but the watcher ignores it");
+        }
+    }
+
+    #[test]
+    fn a_cancellation_is_not_a_failed_exit() {
+        assert_eq!(Outcome::Cancelled.exit_code(), 0);
+        assert_eq!(Outcome::Completed.exit_code(), 0);
+        assert_eq!(Outcome::Failed.exit_code(), 1);
+    }
+
+    /// Losing the socket says nothing about the run, so it must not be reported
+    /// as a failure.
+    #[test]
+    fn losing_the_stream_does_not_fail_the_run() {
+        assert_eq!(Outcome::Unknown.exit_code(), 0);
+        assert_eq!(Outcome::Detached.exit_code(), 0);
+    }
+}

--- a/rust/tests/cli_output_is_pipe_safe.rs
+++ b/rust/tests/cli_output_is_pipe_safe.rs
@@ -1,0 +1,75 @@
+//! Piped CLI output carries no terminal escape sequences.
+//!
+//! This is a regression test for a real defect, found by driving the CLI rather
+//! than by a unit test. `anstyle` describes a style; it does not decide whether
+//! to emit one. Printing a styled string through `std::println!` writes the
+//! escapes unconditionally, so `vadgr runs list > file` wrote
+//! `\x1b[34m[vadgr]\x1b[0m No runs yet.` into the file.
+//!
+//! The shipped Python CLI writes clean text when piped, so this was a
+//! regression rather than a new rough edge, and the migration standard's ratchet
+//! makes a regression block the release.
+//!
+//! The command here needs no daemon: with nothing listening, the CLI reports the
+//! daemon as unreachable, and that message is styled.
+
+use std::process::Command;
+
+/// A port chosen to have nothing on it, so the CLI takes its unreachable path.
+const DEAD_PORT: &str = "59999";
+
+#[test]
+fn piped_output_carries_no_escape_sequences() {
+    let out = Command::new(env!("CARGO_BIN_EXE_vadgr-cli"))
+        .args(["health"])
+        .env("VADGR_PORT", DEAD_PORT)
+        .output()
+        .expect("the CLI binary runs");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "stdout carried an escape sequence when piped: {stdout:?}"
+    );
+    assert!(
+        !stderr.contains('\u{1b}'),
+        "stderr carried an escape sequence when piped: {stderr:?}"
+    );
+    assert!(
+        !stderr.is_empty(),
+        "the unreachable daemon must still say so; a silent pass proves nothing"
+    );
+}
+
+/// The two failures keep different exit codes, because a script branches on
+/// them: "it is down" is retried after a start and "it ran and said no" is not.
+#[test]
+fn an_unreachable_daemon_exits_three() {
+    let out = Command::new(env!("CARGO_BIN_EXE_vadgr-cli"))
+        .args(["health"])
+        .env("VADGR_PORT", DEAD_PORT)
+        .output()
+        .expect("the CLI binary runs");
+    assert_eq!(out.status.code(), Some(3), "down is exit 3, not 1");
+}
+
+/// A usage error is `clap`'s `2`, the same code `click` produced, because the
+/// recorded surface sweep asserts exit codes.
+#[test]
+fn a_usage_error_exits_two() {
+    let out = Command::new(env!("CARGO_BIN_EXE_vadgr-cli"))
+        .args(["runs", "get"])
+        .output()
+        .expect("the CLI binary runs");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a missing required argument is a usage error"
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "usage goes to stderr, so a shell can separate it from output"
+    );
+}


### PR DESCRIPTION
Ports `cli/` to Rust. 1,559 lines of Python across eleven files, judged against the recorded surface sweep: same argv, same exit codes.

**`vadgr start` still launches the Python daemon in this release.** The cutover is `0.4.9`, alone in its release, so a defect found after it has one candidate cause.

## Code

Landed so far: the HTTP client, the output layer, the run stream consumer, and the `health`, `providers`, `computer-use` and `runs` commands. `provider`, `model`, `pair`, `run` and the service group are in progress.

Three behaviours the design named as load-bearing, each with its own test because these are what a port silently drops:

- `DaemonUnreachable` exits **3** while a daemon error exits **1**, so a script branches on "it is down" versus "it ran and said no".
- `ApiClientError` keeps `status`, `code` and `details`, so a command recovers by category rather than by matching a message string.
- The reachability probe keeps its **narrowness**: loopback with an explicit port and nothing else. On WSL2 a connect to a dead local port is swallowed and `vadgr health` took fifteen seconds; a wider probe would invent failures on an `https` host with no port.

**The run stream is improved rather than ported.** The Python consumer handles three event types and the daemon publishes twelve, so a cancelled run watched from the terminal said nothing at all. Every published type is now either described or terminal, with a test that fails if a new frame is added into silence.

Presentation: `comfy-table` and `indicatif` are the only two crates added for it. `anstyle` and `anstream` are declared because Rust needs a direct dependency to import them, but they add nothing to the tree since `clap` already brings them.

## Tests

`cargo test`: 225 passed. 20 of those are new CLI unit tests plus 3 integration tests.

One defect was found by driving the CLI rather than by a unit test: **piped output carried raw escape sequences**. `anstyle` describes a style but does not decide whether to emit one, so `std::println!` wrote them unconditionally and `vadgr runs list > file` captured them. The shipped Python CLI writes clean text when piped, so this was a regression rather than a rough edge. Output routes through `anstream` now, and the regression test was seen red against the old behaviour.

## User-visible changes

None yet: the Rust CLI is not the installed entry point in this commit. When it is, a cancelled run being watched will say so, which today it does not.

## Caveats

Draft while the remaining commands are ported. The e2e runbook and the `forge` naming sweep are still to come in this PR.