### PR TITLE
The harness travels with the runbook, and the handoff names what a host cannot do

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,18 @@ destructive action and owner decision up front, map each to its cells, and
 inform the owner before the affected group runs. Missing setup blocks written
 cells; it never deletes or collapses them.
 
+**A runbook another operating system can run, and a harness it can run with.**
+The remote-host handoff is written before another OS is asked for anything, and
+it is complete enough that a session with no context executes the pass from it
+alone. **Every helper lives at `E2E/<version>/harness/`**, committed beside the
+runbook with a README saying what each one is and that none of them drives the
+product: a helper sitting in a temporary directory on the machine that wrote it
+cannot be run anywhere else, so every other host produces a record nobody can
+compare. Run each from its committed path before offering the runbook, and list
+the prerequisites the pass actually hit, **each naming the cells it blocks**. A
+handoff assembled from the happy path leaves the next OS finding a blocker four
+groups in, which is what it exists to prevent.
+
 **Credentials never enter Git or evidence.** Local e2e reads only the required
 variables from the workspace `../.env`, without echoing values or placing them
 in command arguments, logs, screenshots, transcripts, process listings, PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,18 @@ destructive action and owner decision up front, map each to its cells, and
 inform the owner before the affected group runs. Missing setup blocks written
 cells; it never deletes or collapses them.
 
+**A runbook another operating system can run, and a harness it can run with.**
+The remote-host handoff is written before another OS is asked for anything, and
+it is complete enough that a session with no context executes the pass from it
+alone. **Every helper lives at `E2E/<version>/harness/`**, committed beside the
+runbook with a README saying what each one is and that none of them drives the
+product: a helper sitting in a temporary directory on the machine that wrote it
+cannot be run anywhere else, so every other host produces a record nobody can
+compare. Run each from its committed path before offering the runbook, and list
+the prerequisites the pass actually hit, **each naming the cells it blocks**. A
+handoff assembled from the happy path leaves the next OS finding a blocker four
+groups in, which is what it exists to prevent.
+
 **Credentials never enter Git or evidence.** Local e2e reads only the required
 variables from the workspace `../.env`, without echoing values or placing them
 in command arguments, logs, screenshots, transcripts, process listings, PR

--- a/E2E/TEMPLATE.md
+++ b/E2E/TEMPLATE.md
@@ -296,6 +296,21 @@ test machine. Include all of these items:>
    workspace `../.env`; never print or persist them. Run the secret check before
    the group and before evidence is sealed.>
 
+
+**The harness travels with this runbook.** Every helper the pass uses - the
+recorder, the generator that turns its record into a table, a decoder, a stand-in
+server - is committed at `E2E/<version>/harness/` with a README saying what each
+one is and that none of them drives the product. **A helper that exists only in a
+temporary directory on the machine that wrote it cannot be run anywhere else**,
+so every other host produces a record nobody can compare, and comparison is the
+point of a recorded sweep. Run each helper from its committed path before the
+runbook is offered.
+
+**Name what a host cannot do, not only what worked.** List the prerequisites the
+pass actually hit, each saying **which cells it blocks** and what a host without
+it records. A handoff assembled from the happy path leaves the next operating
+system discovering a blocker four groups in.
+
 <Provide paste-ready Linux/macOS shell and Windows PowerShell blocks. Use a free
 loopback port per concurrent pass. A platform row with only "run the same test"
 is incomplete.>


### PR DESCRIPTION
Two additions, both written after `vadgr 0.4.8` shipped its first draft without them.

**The harness travels with the runbook.** Every helper a pass uses lives at `E2E/<version>/harness/`, committed beside the runbook, with a README saying what each one is and that none of them drives the product. **A helper that exists only in a temporary directory on the machine that wrote it cannot be run anywhere else**, so every other host produces a record nobody can compare, and comparison is the entire point of a recorded sweep. Each is run from its committed path before the runbook is offered.

**The handoff names what a host cannot do.** It lists the prerequisites the pass **actually hit**, each saying which cells it blocks and what a host without it records. A handoff assembled from the happy path leaves the next operating system discovering a blocker four groups in.

## Code

Documentation only: `E2E/TEMPLATE.md` and the shared practices block in `CLAUDE.md` and `AGENTS.md`.

## The incident

`0.4.8` had no handoff section at all, and its four helpers sat in `/tmp` on the machine that ran the WSL pass. Two of its real prerequisites were only discovered by running: the still-shipped daemon's virtual environment, without which the service group starts nothing, and a transport that advertises an address, without which pairing correctly refuses.

## User-visible changes

None.

## E2E

Not applicable. This change is prose and reaches no shipped behaviour.