### PR TITLE
The credential gate survives a force push

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,10 +25,26 @@ jobs:
         shell: bash
         run: |
           ARGS=(--event-file "$GITHUB_EVENT_PATH")
+          # The range to scan. On a push it starts at the commit the branch used
+          # to point at, and **a force push makes that commit unreachable**, so
+          # the range cannot be resolved and the gate exits 2. That is the gate
+          # refusing rather than passing, which is right, but the cause is a
+          # rebase rather than a credential, and a gate that goes red for that
+          # teaches everyone to ignore it. So an unresolvable start falls back to
+          # the repository's default branch, which scans more rather than less.
+          START=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            ARGS+=(--git-range "${{ github.event.pull_request.base.sha }}..${{ github.sha }}")
+            START="${{ github.event.pull_request.base.sha }}"
           elif [ "${{ github.event_name }}" = "push" ]; then
-            ARGS+=(--git-range "${{ github.event.before }}..${{ github.sha }}")
+            START="${{ github.event.before }}"
+          fi
+          if [ -n "$START" ]; then
+            if ! git cat-file -e "$START^{commit}" 2>/dev/null; then
+              DEFAULT="${{ github.event.repository.default_branch }}"
+              echo "start commit $START is unreachable (a force push); scanning from origin/$DEFAULT instead"
+              START="$(git rev-parse "origin/$DEFAULT")"
+            fi
+            ARGS+=(--git-range "$START..${{ github.sha }}")
           fi
           python3 scripts/check_no_secrets.py "${ARGS[@]}"
 


### PR DESCRIPTION
On a push the credential gate scans from the commit the branch used to point at. **A force push makes that commit unreachable**, so the range cannot be resolved and the gate exits `2` with "the requested Git range is not available".

The refusal is correct: a gate that cannot see what it was asked to scan must not pass. But the cause is a rebase rather than a credential, and a gate that goes red for that is one everyone learns to ignore.

An unresolvable start now falls back to the repository's own default branch, which scans **more** rather than less, and says so in the log.

## Code

`.github/workflows/secret-scan.yml`.

The same change is already merged in the other three repos. This brings `vadgr` in line now rather than waiting for `0.4.8`, so the cross-repo consistency check passes today.

## Tests

Found live on the `0.4.8` pull request, whose branch was rebased before it opened: `secret-scan` was the one red check out of sixteen, and it is green after this.

## User-visible changes

None.

## E2E

Not applicable. This is one CI workflow and reaches no shipped behaviour.