### PR TITLE
The owner's cells are executed first, not announced first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,18 @@ destructive action and owner decision up front, map each to its cells, and
 inform the owner before the affected group runs. Missing setup blocks written
 cells; it never deletes or collapses them.
 
+**The owner's cells are the first cells executed, and announcing them is not
+executing them.** A pass identifies every cell that cannot proceed without a
+human and **runs those first**, before any unattended cell. Naming the
+owner-blocked cell in an opening message and then starting part A satisfies
+nothing: the owner is still waiting, and the cell is still outstanding at the
+end. If such a cell needs setup, that setup is the first work of the pass.
+Before each command, ask **"is this the owner's cell, or could the owner's cell
+run now instead?"** Leaving it for later is the pass treating the owner's time
+as the cheap resource, which is backwards: the machine can wait and the person
+cannot. Written twice now, because the weaker form failed twice, the second time
+in the same message that had just quoted the rule.
+
 **A runbook another operating system can run, and a harness it can run with.**
 The remote-host handoff is written before another OS is asked for anything, and
 it is complete enough that a session with no context executes the pass from it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,18 @@ destructive action and owner decision up front, map each to its cells, and
 inform the owner before the affected group runs. Missing setup blocks written
 cells; it never deletes or collapses them.
 
+**The owner's cells are the first cells executed, and announcing them is not
+executing them.** A pass identifies every cell that cannot proceed without a
+human and **runs those first**, before any unattended cell. Naming the
+owner-blocked cell in an opening message and then starting part A satisfies
+nothing: the owner is still waiting, and the cell is still outstanding at the
+end. If such a cell needs setup, that setup is the first work of the pass.
+Before each command, ask **"is this the owner's cell, or could the owner's cell
+run now instead?"** Leaving it for later is the pass treating the owner's time
+as the cheap resource, which is backwards: the machine can wait and the person
+cannot. Written twice now, because the weaker form failed twice, the second time
+in the same message that had just quoted the rule.
+
 **A runbook another operating system can run, and a harness it can run with.**
 The remote-host handoff is written before another OS is asked for anything, and
 it is complete enough that a session with no context executes the pass from it

--- a/E2E/README.md
+++ b/E2E/README.md
@@ -138,6 +138,34 @@ text, documentation or evidence. Run
 `python3 scripts/check_no_secrets.py --env-file ../.env` before every commit and
 before sealing evidence.
 
+## The owner's cells are executed first, not announced first
+
+**Rule 1 is satisfied by running those cells, not by mentioning them.** Before
+any other cell, identify every cell that cannot proceed without a human, and
+**execute them**. Not list them, not warn about them, not tell the owner to
+stand by: run them, get the human observation, record it, and only then start
+the unattended matrix.
+
+This is written as its own section because the weaker form has already failed
+twice, the second time immediately after the rule was read aloud. `0.4.8`'s
+Windows pass opened by naming the handset cell as the one thing needing the
+owner, then ran parts A, B, C, D and E and reached the owner's cell an hour
+later. Naming it changed nothing: the owner still waited, and the pass still
+had a human-blocked cell outstanding while it did work that could have run at
+any time.
+
+The test to apply before the first command of a pass:
+
+- Which cells need a person? List them.
+- **Is one of them the command I am about to run?** If not, and one of them
+  could run now, run that one instead.
+- A cell that needs a person and also needs setup gets that setup **first**, and
+  nothing else does.
+
+An owner-blocked cell left until later is not scheduling. It is the pass
+deciding the owner's time is the cheap resource, which is exactly backwards: the
+machine can wait and the person cannot.
+
 ## A pass is finished, not paused
 
 **Drive the whole matrix before reporting.** The failure this stops is not

--- a/E2E/TEMPLATE.md
+++ b/E2E/TEMPLATE.md
@@ -29,6 +29,15 @@ after four hours of work. A pass that reaches its end and then asks for a
 browser click has wasted the owner's day and produced a runbook that is still
 `not run` where it matters most.
 
+**Running them is the rule. Announcing them is not.** Naming the owner's cell in
+an opening message and then starting part A satisfies nothing: the owner is
+still waiting and the cell is still outstanding. If an owner-blocked cell needs
+setup, that setup is the first work of the pass and nothing else is done until
+the human observation is recorded. Before each command, ask **"is this the
+owner's cell, or could the owner's cell run now instead?"** This paragraph
+exists because `0.4.8`'s Windows pass announced the handset cell in its first
+message and then ran five parts before reaching it.
+
 **2. Do not stop the pass to report.** The pass runs to completion for the
 operating system it is on. Findings, blocked cells, corrections and questions
 are written into the runbook and the evidence as they happen, and they are


### PR DESCRIPTION
Rule 1 already said whatever needs the owner runs first. It was not enough: a pass named the owner-blocked cell in its opening message, told the owner to stand by, and then ran five parts before reaching it. Announcing a cell is not running it.

**Code:** none. Documentation only.

**User-visible changes:** none in the product.

**What changed**

- `E2E/README.md` gains a section stating the test to apply before the first command of a pass: which cells need a person, is one of them the command about to run, and if not, could one of them run now instead.
- `E2E/TEMPLATE.md` keeps rule 1 and adds the enforcement paragraph directly under it.
- `CLAUDE.md` and `AGENTS.md` carry the same rule in the shared block. The two files remain byte-identical.

**Caveats:** this changes only the order in which a pass executes, not what any cell asserts. It names the pass that got the order wrong, so the next reader knows the rule came from a failure rather than from taste.