### PR TITLE
A pass does not stop to report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,13 @@ one is not, because nobody can tell an owed cell from a forgotten one. It also
 prints the cell counts every time, so a summary is compared against the cells
 rather than trusted. It cannot tell whether a `pass` is true.
 
+**A pass is finished, not paused, and reporting is not a stopping point.** A
+checkpoint or a progress summary does not end your turn: write it and keep
+driving in the same turn. A pass ends when every cell carries a verdict or a
+named blocker. Only a cell that cannot proceed without the owner, or a decision
+only the owner can make, ends one early. Stopping to report looks like progress
+and is the opposite, because the cells that were never run stay never run.
+
 **Evidence is filed while the pass runs, never assembled after it.** The
 evidence directory exists before the first cell, each group files what it
 produced at its own boundary, and a group that captured nothing gets a note

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,13 @@ one is not, because nobody can tell an owed cell from a forgotten one. It also
 prints the cell counts every time, so a summary is compared against the cells
 rather than trusted. It cannot tell whether a `pass` is true.
 
+**A pass is finished, not paused, and reporting is not a stopping point.** A
+checkpoint or a progress summary does not end your turn: write it and keep
+driving in the same turn. A pass ends when every cell carries a verdict or a
+named blocker. Only a cell that cannot proceed without the owner, or a decision
+only the owner can make, ends one early. Stopping to report looks like progress
+and is the opposite, because the cells that were never run stay never run.
+
 **Evidence is filed while the pass runs, never assembled after it.** The
 evidence directory exists before the first cell, each group files what it
 produced at its own boundary, and a group that captured nothing gets a note

--- a/E2E/README.md
+++ b/E2E/README.md
@@ -174,6 +174,27 @@ results look like progress, they get committed, and the cells that never ran
 quietly stay never run. `0.4.7`'s Windows pass had to be restarted by the owner
 several times for exactly this reason.
 
+**Reporting is not a stopping point.** A checkpoint, a progress summary, a
+finding you are pleased with: none of them ends your turn. Write the lines and
+keep driving in the same turn. A pass ends when every cell carries a verdict or
+a named blocker, and only then does control go back to the owner.
+
+Stopping to report looks like progress and is the opposite. The owner now has to
+say "continue", the momentum is gone, and the cells that were never run stay
+never run. **It is the most repeated failure in this project's passes**, and it
+has cost more owner time than every real defect these runbooks have found.
+
+Exactly two things end a pass early:
+
+- a cell that physically cannot proceed without the owner, which rule 1 exists to
+  prevent after the start, and
+- a decision only the owner can make, surfaced with the options and a
+  recommendation.
+
+"I have finished an interesting group and want to tell you about it" is neither.
+Neither is "the next part is long". Neither is a defect you just fixed: fix it,
+record it, and carry on to the next cell in the same turn.
+
 Three rules follow from it:
 
 - **A blocked cell is owed only after its blocker was investigated.** On that

--- a/E2E/TEMPLATE.md
+++ b/E2E/TEMPLATE.md
@@ -13,6 +13,13 @@ bracket notes as you go; a leftover placeholder is the tell that a runbook was
 written and never run. The cross-cutting rules are in
 [`../README.md`](../README.md) and are not repeated here.>
 
+**A pass is finished, not paused, and reporting is not a stopping point.** A
+checkpoint or a progress summary does not end your turn: write it and keep
+driving in the same turn. A pass ends when every cell carries a verdict or a
+named blocker. Only a cell that cannot proceed without the owner, or a decision
+only the owner can make, ends one early. Stopping to report looks like progress
+and is the opposite, because the cells that were never run stay never run.
+
 ## How a pass is run, before anything else in this file
 
 **These five rules come first because every one of them was learned by breaking


### PR DESCRIPTION
## Code

No code. Documentation only.

## What changed

The rule that a pass runs to completion said "drive the whole matrix before reporting". Passes kept stopping anyway, because what they stopped for did not feel like stopping: a checkpoint, a summary of a group that went well, a defect just fixed. Each one hands control back and the owner has to say "continue".

The rule now names that failure directly. Reporting is not a stopping point: write the lines and keep driving in the same turn. Exactly two things end a pass early, and both are listed: a cell that cannot proceed without the owner, and a decision only the owner can make.

The long form is in the E2E doctrine. The short form sits with the rules at the top of the runbook template and in the shared practices block, which both entry points carry identically.

## Caveats

Wording only. No cell, no verdict and no runbook result changes.