### PR TITLE
A branch cut from another branch is refused by CI

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -70,6 +70,15 @@ jobs:
             ARGS+=(--git-range "$START..${{ github.sha }}")
           fi
           python3 scripts/check_no_ai_attribution.py "${ARGS[@]}"
+      # A branch cut from another branch carries that branch's commits, and a
+      # squash merge replays the whole diff, so merging it merges the other work
+      # too. Ancestry is the signal, and it needs the pull request list.
+      - name: Reject a branch cut from another branch
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/check_branch_point.py --pr-number "${{ github.event.pull_request.number }}"
 
   # The gate itself had no test and ran on one operating system, so its Windows
   # DACL control was never executed anywhere. It refused every file it was given

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,6 +468,11 @@ must show only files your subject is about: **a diff carrying work the title doe
 not mention means the branch point was wrong**, and the fix is to re-cut it from
 the default branch rather than to explain it in the body.
 
+**And CI refuses it**, because prose did not stop it the first time.
+`scripts/check_branch_point.py` fails a pull request whose branch contains
+another open pull request's head: that ancestry is what a branch cut from a
+feature branch looks like, and there is no innocent version of it.
+
 **Nothing reaches a default branch except through a pull request, and the docs
 repo is not an exception.** Branch, push, open the PR, merge it. That covers
 code, plans, design specs, runbooks and **e2e evidence**: evidence is filed on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,6 +468,11 @@ must show only files your subject is about: **a diff carrying work the title doe
 not mention means the branch point was wrong**, and the fix is to re-cut it from
 the default branch rather than to explain it in the body.
 
+**And CI refuses it**, because prose did not stop it the first time.
+`scripts/check_branch_point.py` fails a pull request whose branch contains
+another open pull request's head: that ancestry is what a branch cut from a
+feature branch looks like, and there is no innocent version of it.
+
 **Nothing reaches a default branch except through a pull request, and the docs
 repo is not an exception.** Branch, push, open the PR, merge it. That covers
 code, plans, design specs, runbooks and **e2e evidence**: evidence is filed on

--- a/scripts/check_branch_point.py
+++ b/scripts/check_branch_point.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Reject a branch cut from another branch's work.
+
+Every branch starts from a freshly pulled default branch. A branch cut from a
+feature branch carries that feature's commits, and a squash merge replays the
+whole diff, so merging it merges the feature too: **under the wrong title and
+without its gate**.
+
+That is not a hypothetical. Three doctrine pull requests were cut from a release
+branch and merging them put an entire unfinished CLI into the default branch,
+while its e2e was still running on two operating systems.
+
+**The signal is ancestry.** If another open pull request's head is an ancestor of
+this one, this branch was cut from that branch rather than from the default
+branch, and it carries work that belongs to the other review.
+
+It reads the open pull requests from the GitHub CLI when one is available, so the
+same script runs in CI and by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def is_ancestor(candidate: str, head: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", candidate, head],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def inherited(head: str, others: list[dict], ancestry=is_ancestor) -> list[str]:
+    """The open pull requests whose work this branch already contains.
+
+    `others` excludes this pull request; each entry needs `number`, `title` and
+    `head`. A head we cannot resolve is skipped rather than guessed at: a branch
+    deleted mid-run is not evidence of anything.
+    """
+    problems = []
+    for other in others:
+        sha = other.get("head")
+        if not sha or sha == head:
+            continue
+        if ancestry(sha, head):
+            problems.append(
+                f"#{other['number']} ({other['title']}) is an ancestor of this branch"
+            )
+    return problems
+
+
+def open_pull_requests(number: int | None) -> list[dict]:
+    out = subprocess.run(
+        ["gh", "pr", "list", "--state", "open", "--json", "number,title,headRefOid"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        return []
+    rows = json.loads(out.stdout or "[]")
+    return [
+        {"number": r["number"], "title": r["title"], "head": r["headRefOid"]}
+        for r in rows
+        if r["number"] != number
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-number", type=int)
+    args = parser.parse_args()
+
+    head = subprocess.run(
+        ["git", "rev-parse", args.head], capture_output=True, text=True
+    ).stdout.strip()
+    if not head:
+        print("branch point check could not run: no such revision")
+        return 2
+
+    problems = inherited(head, open_pull_requests(args.pr_number))
+    if problems:
+        print("THIS BRANCH WAS CUT FROM ANOTHER BRANCH")
+        for problem in problems:
+            print(f"  {problem}")
+        print()
+        print("A squash merge replays the whole diff, so merging this would merge")
+        print("that work too, under this title and without its gate. Re-cut the")
+        print("branch from the default branch and cherry-pick your own commits.")
+        return 1
+
+    print("BRANCH POINT CHECK PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_branch_point.py
+++ b/scripts/tests/test_check_branch_point.py
@@ -1,0 +1,64 @@
+"""Tests for the branch-point gate.
+
+The ancestry lookup is injected, so the logic is tested without a network, a
+GitHub token or a repository shaped for the occasion.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from check_branch_point import inherited  # noqa: E402
+
+
+def ancestry_of(pairs):
+    """A stub: `pairs` are the (candidate, head) couples that are ancestors."""
+    return lambda candidate, head: (candidate, head) in pairs
+
+
+class TestItCatchesTheRealShape:
+    def test_a_branch_cut_from_an_open_pull_request(self):
+        others = [{"number": 190, "title": "0.4.8: the CLI in Rust", "head": "featsha"}]
+        problems = inherited("mysha", others, ancestry_of({("featsha", "mysha")}))
+        assert len(problems) == 1
+        assert "#190" in problems[0]
+
+    def test_it_names_every_one_it_inherited(self):
+        others = [
+            {"number": 1, "title": "a", "head": "x"},
+            {"number": 2, "title": "b", "head": "y"},
+        ]
+        problems = inherited("mine", others, ancestry_of({("x", "mine"), ("y", "mine")}))
+        assert len(problems) == 2
+
+
+class TestItLeavesCorrectWorkAlone:
+    def test_a_branch_cut_from_the_default_branch(self):
+        others = [{"number": 190, "title": "a feature", "head": "featsha"}]
+        assert inherited("mysha", others, ancestry_of(set())) == []
+
+    def test_the_only_open_pull_request_is_this_one(self):
+        assert inherited("mysha", [], ancestry_of(set())) == []
+
+    def test_a_pull_request_whose_head_is_this_head(self):
+        """The same branch pushed twice is not an inheritance."""
+        others = [{"number": 5, "title": "same", "head": "mysha"}]
+        assert inherited("mysha", others, ancestry_of({("mysha", "mysha")})) == []
+
+    def test_a_head_that_cannot_be_resolved_is_skipped(self):
+        """A branch deleted mid-run is not evidence of anything."""
+        others = [{"number": 7, "title": "gone", "head": None}]
+        assert inherited("mysha", others, ancestry_of(set())) == []
+
+
+class TestTheScriptRuns:
+    def test_it_reports_on_this_repository(self):
+        script = pathlib.Path(__file__).resolve().parents[1] / "check_branch_point.py"
+        result = subprocess.run(
+            [sys.executable, str(script)], capture_output=True, text=True,
+            cwd=script.parents[1],
+        )
+        assert result.returncode in (0, 1), result.stdout
+        assert "BRANCH POINT CHECK" in result.stdout or "CUT FROM" in result.stdout


### PR DESCRIPTION
Prose did not stop it the first time, so this is a check.

`scripts/check_branch_point.py` fails a pull request whose branch **contains another open pull request's head**. That ancestry is exactly what a branch cut from a feature branch looks like, and there is no innocent version of it: if another review's commits are in your history, merging yours merges theirs, **under your title and without their gate**.

## The incident

Three doctrine pull requests were cut from `vadgr 0.4.8`'s release branch. Squash-merging them put the entire unfinished CLI into `master` while its e2e was still running on two operating systems and two defects were unfixed.

## Code

- `scripts/check_branch_point.py`, new.
- `.github/workflows/secret-scan.yml` runs it on `pull_request`, where the pull request list is available.
- `CLAUDE.md` and `AGENTS.md` name the gate beside the two by-hand checks.

## Tests

Seven, with the ancestry lookup injected so the logic is tested without a network or a token.

**The gate was seen firing** on a branch cut from `0.4.8`'s, naming the pull request it had inherited, before this landed.

## User-visible changes

None.

## E2E

Not applicable. This is a CI check and prose; it reaches no shipped behaviour.