### PR TITLE
0.4.8 is dated the day it shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [SemVer](https://semver.org/).
 
-## [0.4.8] - 2026-08-18
+## [0.4.8] - 2026-08-19
 
 ### Added
 - **The CLI is rewritten in Rust.** Every command keeps its name, its arguments


### PR DESCRIPTION
The changelog entry was written on the 18th. The release lands on the 19th, after native Linux, native Windows and macOS ran the runbook and three more defects were found and fixed.

## Code

`CHANGELOG.md`, one line.

## User-visible changes

None.

## E2E

Not applicable. This is a date in a changelog and reaches no shipped behaviour.