### PR TITLE
A release touches its README, or says it did not

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -73,6 +73,17 @@ jobs:
       # A branch cut from another branch carries that branch's commits, and a
       # squash merge replays the whole diff, so merging it merges the other work
       # too. Ancestry is the signal, and it needs the pull request list.
+      # README.md is the file most people read and the one nobody remembers to
+      # open. It was wrong in all three repositories at once, for three minors,
+      # and nothing failed. A version that moves alone is the shape all three had.
+      - name: A release touches its README, or says it did not
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          python3 scripts/check_readme_touched.py \
+            --git-range "${{ github.event.pull_request.base.sha }}..${{ github.sha }}" \
+            --event-file "$GITHUB_EVENT_PATH"
+
       - name: Reject a branch cut from another branch
         if: github.event_name == 'pull_request'
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,19 @@ branches deleted local and remote, every repo back on its default branch, then
 `PROGRESS.md` updated and the next item named - read from `PLANS.md`'s
 iteration table, not decided.
 
+**The README is checked, because it was wrong in all three repos at once.**
+`scripts/check_readme_touched.py` fails a pull request that moves a version and
+touches no README. It cannot read a README for truth; it can see the shape all
+three of those had, which is a version moving alone. **The escape is a sentence,
+not a flag**: write `README: nothing changed` in the body, and mean it. A rule
+that cannot be answered is one people route around.
+
+**And prose about the product is swept like code.** A README, a design note or a
+doc comment naming a runtime the product no longer has is the same defect as a
+stale command, and it fails no build. When a release removes something, the sweep
+covers the documentation and the comments in the same pull request, not a
+follow-up.
+
 **A tag and its release are named one way in every repo**, because six shapes
 across three repos is what happens when each release is named freehand: `vadgr
 0.4.7`, `v0.4.6 - the Rust execution engine`, `v0.4.4`, `vadgr 0.4.2 - the web

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,19 @@ branches deleted local and remote, every repo back on its default branch, then
 `PROGRESS.md` updated and the next item named - read from `PLANS.md`'s
 iteration table, not decided.
 
+**The README is checked, because it was wrong in all three repos at once.**
+`scripts/check_readme_touched.py` fails a pull request that moves a version and
+touches no README. It cannot read a README for truth; it can see the shape all
+three of those had, which is a version moving alone. **The escape is a sentence,
+not a flag**: write `README: nothing changed` in the body, and mean it. A rule
+that cannot be answered is one people route around.
+
+**And prose about the product is swept like code.** A README, a design note or a
+doc comment naming a runtime the product no longer has is the same defect as a
+stale command, and it fails no build. When a release removes something, the sweep
+covers the documentation and the comments in the same pull request, not a
+follow-up.
+
 **A tag and its release are named one way in every repo**, because six shapes
 across three repos is what happens when each release is named freehand: `vadgr
 0.4.7`, `v0.4.6 - the Rust execution engine`, `v0.4.4`, `vadgr 0.4.2 - the web

--- a/scripts/check_readme_touched.py
+++ b/scripts/check_readme_touched.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""A change that ships a new version touches its README, or says it did not.
+
+`README.md` is the file most people read and the one nobody remembers to open.
+A minor that deletes a surface, renames a command, moves a directory or changes
+what the product is has changed the README, and it is updated in the same pull
+request.
+
+**The rule is old and it was broken in all three repositories at once**, for
+three minors: one README was the untouched framework template, one called the
+daemon a workflow engine after that concept had been deleted whole, and one sold
+a product name that no longer existed with an install command pointing at the
+repository's former name. Nobody noticed, because nothing fails when a README
+rots.
+
+**What this checks is narrow on purpose.** It cannot read a README for truth. It
+can see that a pull request bumped the version and left every README untouched
+without saying so, which is the shape every one of those three had.
+
+The escape is a sentence, not a flag: write `README: nothing changed` in the pull
+request body, and mean it. A rule that cannot be answered is one people route
+around.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+VERSION_FILES = ("Cargo.toml", "rust/Cargo.toml", "pyproject.toml", "pubspec.yaml")
+DECLARATION = re.compile(r"(?i)README\s*:\s*nothing changed")
+
+
+def changed_files(git_range: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", git_range], capture_output=True, text=True
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def version_changed(git_range: str, files: list[str]) -> bool:
+    """Whether this range edits a version line in a manifest."""
+    for path in files:
+        if not any(path.endswith(v) for v in VERSION_FILES):
+            continue
+        diff = subprocess.run(
+            ["git", "diff", git_range, "--", path], capture_output=True, text=True
+        ).stdout
+        for line in diff.splitlines():
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+                if re.match(r"[+-]\s*version\s*[:=]", line):
+                    return True
+    return False
+
+
+def touches_readme(files: list[str]) -> bool:
+    return any(pathlib.Path(f).name.lower() == "readme.md" for f in files)
+
+
+def declared(event_file: pathlib.Path | None) -> bool:
+    if not event_file or not event_file.exists():
+        return False
+    try:
+        event = json.loads(event_file.read_text())
+    except Exception:
+        return False
+    body = ((event.get("pull_request") or {}).get("body")) or ""
+    return bool(DECLARATION.search(body))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--git-range", required=True)
+    parser.add_argument("--event-file", type=pathlib.Path)
+    args = parser.parse_args()
+
+    if subprocess.run(
+        ["git", "rev-list", "--quiet", args.git_range], capture_output=True
+    ).returncode not in (0, 1):
+        print("readme check could not run: the requested Git range is not available")
+        return 2
+
+    files = changed_files(args.git_range)
+    if not version_changed(args.git_range, files):
+        print("README CHECK PASSED (no version change in this range)")
+        return 0
+    if touches_readme(files):
+        print("README CHECK PASSED (the version moved and a README moved with it)")
+        return 0
+    if declared(args.event_file):
+        print("README CHECK PASSED (the version moved and the body says nothing changed)")
+        return 0
+
+    print("A VERSION MOVED AND NO README DID")
+    print()
+    print("  README.md is the file most people read and the one nobody remembers")
+    print("  to open. If this release deletes a surface, renames a command, moves")
+    print("  a directory or changes what the product is, its README has changed.")
+    print()
+    print("  Update it, or write 'README: nothing changed' in the pull request")
+    print("  body and mean it.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_readme_touched.py
+++ b/scripts/tests/test_check_readme_touched.py
@@ -1,0 +1,97 @@
+"""Tests for the README gate.
+
+Both halves. The second is the one that decides whether the gate survives: it
+must stay silent on the hundreds of changes that ship no version, or it becomes
+noise attached to every pull request.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "check_readme_touched.py"
+
+
+def repo(tmp_path):
+    run = lambda *a: subprocess.run(a, cwd=tmp_path, check=True, capture_output=True)
+    run("git", "init", "-q")
+    run("git", "config", "user.email", "a@b.c")
+    run("git", "config", "user.name", "A")
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+    (tmp_path / "README.md").write_text("# x\n")
+    (tmp_path / "src.rs").write_text("fn main() {}\n")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "base")
+    return run
+
+
+def check(tmp_path, event=None):
+    args = [sys.executable, str(SCRIPT), "--git-range", "HEAD~1..HEAD"]
+    if event is not None:
+        p = tmp_path / "event.json"
+        p.write_text(event)
+        args += ["--event-file", str(p)]
+    return subprocess.run(args, cwd=tmp_path, capture_output=True, text=True)
+
+
+class TestItCatchesTheRealShape:
+    def test_a_version_moved_and_no_readme_did(self, tmp_path):
+        run = repo(tmp_path)
+        (tmp_path / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.2.0"\n')
+        run("git", "commit", "-aqm", "bump")
+        result = check(tmp_path)
+        assert result.returncode == 1
+        assert "NO README DID" in result.stdout
+
+
+class TestItLeavesCorrectWorkAlone:
+    def test_a_version_moved_and_the_readme_moved_with_it(self, tmp_path):
+        run = repo(tmp_path)
+        (tmp_path / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.2.0"\n')
+        (tmp_path / "README.md").write_text("# x\n\nnow does something else\n")
+        run("git", "commit", "-aqm", "bump and say so")
+        assert check(tmp_path).returncode == 0
+
+    def test_a_change_that_ships_no_version(self, tmp_path):
+        """The common case, and the one that decides whether the gate survives."""
+        run = repo(tmp_path)
+        (tmp_path / "src.rs").write_text("fn main() { }\n")
+        run("git", "commit", "-aqm", "a fix")
+        result = check(tmp_path)
+        assert result.returncode == 0
+        assert "no version change" in result.stdout
+
+    def test_a_manifest_edited_without_touching_its_version(self, tmp_path):
+        run = repo(tmp_path)
+        (tmp_path / "Cargo.toml").write_text(
+            '[package]\nname = "x"\nversion = "0.1.0"\n\n[dependencies]\nserde = "1"\n'
+        )
+        run("git", "commit", "-aqm", "add a dependency")
+        assert check(tmp_path).returncode == 0
+
+    def test_the_body_says_nothing_changed(self, tmp_path):
+        run = repo(tmp_path)
+        (tmp_path / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.2.0"\n')
+        run("git", "commit", "-aqm", "bump")
+        event = '{"pull_request": {"body": "A patch.\\n\\nREADME: nothing changed\\n"}}'
+        result = check(tmp_path, event)
+        assert result.returncode == 0, result.stdout
+        assert "nothing changed" in result.stdout
+
+    def test_a_body_that_does_not_say_it_is_not_an_escape(self, tmp_path):
+        run = repo(tmp_path)
+        (tmp_path / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.2.0"\n')
+        run("git", "commit", "-aqm", "bump")
+        assert check(tmp_path, '{"pull_request": {"body": "a patch"}}').returncode == 1
+
+
+class TestItRefusesRatherThanPasses:
+    def test_an_unavailable_range(self, tmp_path):
+        repo(tmp_path)
+        result = check.__wrapped__ if hasattr(check, "__wrapped__") else None
+        out = subprocess.run(
+            [sys.executable, str(SCRIPT), "--git-range", "deadbeef..HEAD"],
+            cwd=tmp_path, capture_output=True, text=True,
+        )
+        assert out.returncode == 2
+        assert "could not run" in out.stdout


### PR DESCRIPTION
**`README.md` is the file most people read and the one nobody remembers to open.** It was wrong in all three repositories at once, for three minors: one was the untouched framework template, one called the daemon a workflow engine after that concept had been deleted whole, and one sold a product name that no longer existed with an install command pointing at the repository's former name. **Nothing failed**, because nothing fails when a README rots.

## Code

- `scripts/check_readme_touched.py`, new: it fails a pull request that **moves a version and touches no README**.
- `.github/workflows/secret-scan.yml` runs it on `pull_request`.
- `CLAUDE.md` and `AGENTS.md` name it in the close-out, beside the changelog and the tag.

It cannot read a README for truth. It can see the shape all three of those had, which is a version moving alone.

**The escape is a sentence, not a flag**: write `README: nothing changed` in the body, and mean it. A rule that cannot be answered is one people route around, and a gate with no legitimate answer is one somebody deletes.

## And prose is swept like code

A README, a design note, a docstring or a doc comment naming a runtime, a command or a directory the product no longer has is the same defect as a stale code path, and it fails no build. When a release removes something, the sweep covers the documentation and the comments **in the same pull request** rather than as a follow-up. The follow-up is where the three rotten READMEs came from.

## Tests

Seven, both directions. The half that decides whether the gate survives is the second: it stays silent on a change that ships no version, on a manifest edited without touching its version, and on a version bumped with a README beside it. It refuses rather than passes when the range is unavailable.

## User-visible changes

None.

## E2E

Not applicable. This is a CI check and prose; it reaches no shipped behaviour.

README: nothing changed