### PR TITLE
Install the evidence gate, identical across the family

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -91,6 +91,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check_branch_point.py --pr-number "${{ github.event.pull_request.number }}"
 
+      # Evidence reached the default branch once inside a pull request that was
+      # adding something else, because a `git add -A` swept a thrown-away pass
+      # along with it. Evidence is the record a release rests on, so it gets its
+      # own change and every pass names the build behind it.
+      - name: Reject evidence that rides along or cannot name its build
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          python3 scripts/check_evidence.py \
+            --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
   # The gate itself had no test and ran on one operating system, so its Windows
   # DACL control was never executed anywhere. It refused every file it was given
   # for as long as that lasted, and nothing reported it.

--- a/scripts/check_evidence.py
+++ b/scripts/check_evidence.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Evidence travels on its own, and every boundary names the build it came from.
+
+Two rules, both learned by breaking them.
+
+**A change either files evidence or edits documents, never both.** A `git add
+-A` swept an entire thrown-away e2e pass into a commit that was adding something
+else, and it reached the default branch inside a pull request nobody read it in.
+Evidence is the record a release rests on. It gets its own change, so a reviewer
+looking at a diff of evidence is looking at evidence.
+
+**Every boundary names the commit it was produced from.** A directory of results
+that cannot say which build produced them is not evidence: three fixes landed
+mid-pass in `vadgr 0.4.9`, the binaries moved three commits, and no cell in that
+pass could name the artifact behind it. The whole pass was withdrawn.
+
+    python3 scripts/check_evidence.py [--range <start>..<end>]
+
+With no range it reads the working tree and the index. It prints one line per
+check it performs, because a coverage list restated in prose is the fact that
+drifts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+EVIDENCE = "e2e_evidence/"
+HEAD_LINE = re.compile(r"^\s*\w[\w -]*head:\s*([0-9a-f]{7,40})\s*$", re.MULTILINE)
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True, timeout=60
+    )
+    return result.stdout
+
+
+def changed_paths(rev_range: str | None) -> list[str]:
+    if rev_range:
+        out = git("diff", "--name-only", rev_range)
+    else:
+        # `-uall` lists untracked files one by one. Without it git collapses a
+        # new directory to a single entry with a trailing slash, and a whole
+        # pass filed at once reads as one path too shallow to be a pass.
+        out = git("status", "--porcelain", "-uall")
+        return [line[3:].strip() for line in out.splitlines() if line[3:].strip()]
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def evidence_travels_alone(paths: list[str]) -> list[str]:
+    """Evidence and documents do not ride in the same change."""
+    evidence = sorted(p for p in paths if p.startswith(EVIDENCE))
+    other = sorted(p for p in paths if not p.startswith(EVIDENCE))
+    if not evidence or not other:
+        return []
+    return [
+        f"this change files evidence and edits {len(other)} other file(s) at once. "
+        "Evidence gets its own change, so a reviewer reading a diff of evidence is "
+        "reading evidence. First of each: "
+        f"{evidence[0]} and {other[0]}"
+    ]
+
+
+def every_boundary_names_its_build(paths: list[str]) -> list[str]:
+    """Each pass directory this change touches names the build behind it.
+
+    Only what the change touches. Evidence already filed was filed under the
+    rules of its day, and a check that reopens closed passes fires on finished
+    work, which teaches everyone to ignore the output.
+    """
+    problems = []
+    touched = set()
+    for path in paths:
+        if not path.startswith(EVIDENCE):
+            continue
+        parts = pathlib.PurePosixPath(path).parts
+        # e2e_evidence/<repo>-<minor>/<pass>/...: anything shallower is a note
+        # about the release rather than a pass of its own.
+        if len(parts) >= 4:
+            touched.add(pathlib.PurePosixPath(*parts[:3]))
+    for pass_dir in sorted(touched):
+        # A pass that is being withdrawn is correctly gone. Asking a deleted
+        # directory to name its build fires on the repair rather than the fault.
+        # An empty directory counts as gone: `git rm` leaves the parents behind,
+        # git does not track them, and a directory holding nothing is not a pass.
+        directory = ROOT / pass_dir
+        if not directory.is_dir() or not any(directory.rglob("*")):
+            continue
+        host = ROOT / pass_dir / "host.txt"
+        if not host.exists():
+            problems.append(
+                f"{pass_dir} carries no host.txt, so nothing in it can name "
+                "the build that produced it"
+            )
+            continue
+        if not HEAD_LINE.search(host.read_text()):
+            problems.append(
+                f"{pass_dir}/host.txt names no head; a result that cannot "
+                "name its build is not a result"
+            )
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--range", dest="rev_range", default=None)
+    args = parser.parse_args()
+
+    problems = []
+    paths = changed_paths(args.rev_range)
+    print("  ok    evidence and documents do not ride in one change")
+    problems += evidence_travels_alone(paths)
+    print("  ok    every pass this change touches names the commit it came from")
+    problems += every_boundary_names_its_build(paths)
+
+    print()
+    if problems:
+        for problem in problems:
+            print(f"  EVIDENCE DEFECT: {problem}")
+        print()
+        print("  EVIDENCE REFUSED")
+        return 1
+    print("  EVIDENCE ACCOUNTED FOR")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_evidence.py
+++ b/scripts/tests/test_check_evidence.py
@@ -1,0 +1,109 @@
+"""Tests for the evidence gate.
+
+The second half of each pair is the one that decides whether the gate
+survives. A gate that also fires on a correct change becomes noise attached to
+every pull request, and the two failures it exists to catch both arrived inside
+otherwise correct work.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import sys
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "check_evidence.py"
+
+
+def workspace(tmp_path):
+    """A docs-shaped repository with the gate installed."""
+    run = lambda *a: subprocess.run(a, cwd=tmp_path, check=True, capture_output=True)
+    run("git", "init", "-q")
+    run("git", "config", "user.email", "a@b.c")
+    run("git", "config", "user.name", "A")
+    (tmp_path / "scripts").mkdir()
+    shutil.copy(SCRIPT, tmp_path / "scripts" / "check_evidence.py")
+    (tmp_path / "NOTES.md").write_text("# notes\n")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "start")
+    return tmp_path
+
+
+def gate(tmp_path, *args):
+    return subprocess.run(
+        [sys.executable, "scripts/check_evidence.py", *args],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def file_a_pass(root, name, with_host=True):
+    pass_dir = root / "e2e_evidence" / "vadgr-0.4.9" / name
+    (pass_dir / "A").mkdir(parents=True)
+    (pass_dir / "A" / "A1.txt").write_text("the first cell\n")
+    if with_host:
+        (pass_dir / "host.txt").write_text("vadgr head: " + "a" * 40 + "\n")
+    return pass_dir
+
+
+def test_evidence_beside_a_document_edit_is_refused(tmp_path):
+    root = workspace(tmp_path)
+    file_a_pass(root, "20260819-wsl")
+    (root / "NOTES.md").write_text("# notes\n\nand a change nobody asked for\n")
+    result = gate(root)
+    assert result.returncode == 1
+    assert "files evidence and edits" in result.stdout
+
+
+def test_evidence_on_its_own_is_accepted(tmp_path):
+    root = workspace(tmp_path)
+    file_a_pass(root, "20260819-wsl")
+    result = gate(root)
+    assert result.returncode == 0, result.stdout
+    assert "EVIDENCE ACCOUNTED FOR" in result.stdout
+
+
+def test_a_pass_that_cannot_name_its_build_is_refused(tmp_path):
+    root = workspace(tmp_path)
+    file_a_pass(root, "20260819-wsl", with_host=False)
+    result = gate(root)
+    assert result.returncode == 1
+    assert "carries no host.txt" in result.stdout
+
+
+def test_a_host_record_naming_no_head_is_refused(tmp_path):
+    root = workspace(tmp_path)
+    pass_dir = file_a_pass(root, "20260819-wsl")
+    (pass_dir / "host.txt").write_text("host: a laptop\ndate: today\n")
+    result = gate(root)
+    assert result.returncode == 1
+    assert "names no head" in result.stdout
+
+
+def test_withdrawing_a_pass_is_not_a_defect(tmp_path):
+    """The repair must not trip the gate that caught the fault."""
+    root = workspace(tmp_path)
+    file_a_pass(root, "20260819-wsl")
+    run = lambda *a: subprocess.run(a, cwd=root, check=True, capture_output=True)
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "file the pass")
+    shutil.rmtree(root / "e2e_evidence" / "vadgr-0.4.9" / "20260819-wsl")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "withdraw it")
+    result = gate(root, "--range", "HEAD~1..HEAD")
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_change_with_no_evidence_at_all_is_silent(tmp_path):
+    root = workspace(tmp_path)
+    (root / "NOTES.md").write_text("# notes\n\nan ordinary edit\n")
+    result = gate(root)
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_whole_pass_filed_at_once_is_still_seen(tmp_path):
+    """git collapses a new directory to one entry; the gate must not be fooled."""
+    root = workspace(tmp_path)
+    file_a_pass(root, "20260819-wsl", with_host=False)
+    result = gate(root)
+    assert "carries no host.txt" in result.stdout


### PR DESCRIPTION
A thrown-away e2e pass reached a default branch inside a pull request that was
adding something else, because a `git add -A` swept it along and the diff read
as the other change.

The gate refuses two things: a change that files evidence and edits documents at
once, and a pass directory that cannot name the commit it came from. Both are
scoped to what the change touches, so evidence already filed and a pass being
withdrawn are left alone.

This repository holds no evidence directory, so the gate finds nothing and
passes here. It is installed because these checks are required to be identical
across all four repositories, and an exception is how that identity ends.

Seven tests, run on every operating system in the gate matrix.