### PR TITLE
E2E: one rules section at the top of the runbook template

### DIFF
--- a/E2E/README.md
+++ b/E2E/README.md
@@ -2,6 +2,13 @@
 
 Applies to **every** runbook in this directory (`E2E/<version>/e2e.md`).
 
+**The rules in one place: `## The rules`, the first section of
+[`TEMPLATE.md`](TEMPLATE.md) and of every runbook copied from it.** That list is
+the index, and it is what gets read before a pass starts. This file is one of
+the long forms it points at: the cross-cutting rules are stated here in full,
+with the incidents that produced them. **A rule is stated in full in one place**,
+so the index stays an index and the two cannot drift.
+
 An e2e is driven by a **real agent given a goal-level task**, never by a script.
 A `.py` that imports `run_loop` and calls it directly is an **acceptance test**,
 not an e2e - it proves the function works, not that the product does. The agent's

--- a/E2E/TEMPLATE.md
+++ b/E2E/TEMPLATE.md
@@ -15,117 +15,114 @@ written and never run. The cross-cutting rules are in
 
 ## The rules
 
-**Read this section before the first cell. Every rule in it was learned by
-breaking it, they hold on every supported operating system and for every driver
-of a runbook, and none of them is negotiable against a deadline or a token
-budget.** The list is here, at the top, because the rules that get forgotten are
-the ones a reader had to go looking for.
+**Read this before the first cell.** Every rule here was learned by breaking it,
+they hold on every supported operating system and for every driver of a runbook,
+and none of them is negotiable against a deadline or a token budget.
 
-A bracketed name is the section in this file that carries the rule in full, with
-the incident behind it. Not every runbook carries every section: where the
-bracketed name is not below, this entry is the whole rule.
+**This list is an index, not the rules themselves.** Each entry is deliberately
+short. A bracketed name is where the rule is stated in full, with the incident
+that produced it: a section of this file, or `../README.md`. Read the entry
+before you start and the section when it bites. Where a bracketed name is not
+present in a given runbook, the entry is all there is.
 
-1. **Whatever needs the owner runs first.** Before a single unattended cell,
-   read the whole matrix, list every cell that cannot proceed without a human,
-   and run those cells at the start of the pass. **Running them is the rule;
-   announcing them is not**, because a cell named in an opening message is still
-   an outstanding cell and the owner is still waiting.
-   [How a pass is run, before anything else in this file]
+1. **Whatever needs the owner runs first.** Read the whole matrix, list every
+   cell that cannot proceed without a human, and run those cells before any
+   unattended one. **Running them is the rule; announcing them is not.**
+   [How a pass is run] [../README.md]
 
 2. **Do not stop the pass to report.** The pass runs to completion for the
-   operating system it is on: findings, blocked cells, corrections and questions
-   go into the runbook and the evidence as they happen, and they are reported
-   when the pass ends. Only a cell that physically cannot proceed without the
-   owner, or a decision only the owner can make, ends a pass early.
-   [How a pass is run, before anything else in this file]
+   operating system it is on, and what it finds is written down as it happens and
+   reported at the end. [How a pass is run] [../README.md]
 
 3. **A bug you find is a bug you fix, here and now, with a test that fails
-   without the fix.** Fix the code, add the test, re-run the failing cell until
-   it passes, and push to the pull request branch before carrying on with the
-   rest of the matrix. A finding recorded without a fix is a moved problem, not
-   a found one. [How a pass is run, before anything else in this file]
+   without the fix.** Re-run the failing cell until it passes and push to the
+   pull request branch before carrying on. [How a pass is run] [../README.md]
 
-4. **A fix invalidates the cells it touched on every operating system that
-   passed them.** Name those cells in the finding, mark them `not run` again,
-   and re-run them: no operating system inherits a result from a build that no
-   longer exists. **A rebuild is a new subject**, so re-run the identity cell and
-   record the new hashes before any further cell.
-   [How a pass is run, before anything else in this file]
+4. **A fix invalidates the cells it touched on every operating system that passed
+   them**, so name them, mark them `not run` and re-run them. **A rebuild is a
+   new subject**: re-run the identity cell and record the new hashes before any
+   further cell. [How a pass is run]
 
-5. **The evidence is pushed, not left on the machine that produced it.** The
-   boundary directory exists before the first cell, each group files its output
-   at its own boundary, and the whole boundary is committed on a branch and
-   opened as a pull request **as part of the pass**, not after somebody asks for
-   it. [How a pass is run, before anything else in this file]
+5. **The evidence is pushed, not left on the machine that produced it, and it is
+   pushed to the private docs repository** under `e2e_evidence/<repo>-<minor>/`,
+   never into this one. The pull request carrying it is opened there as part of
+   the pass, not after somebody asks. [How a pass is run] [Evidence]
 
 6. **A cell is `pass` only when the observation and the artifact both exist.** A
    cell that ran, was read correctly and left nothing on disk is `not run` with a
-   note, because there is nothing a reviewer or the next host can check.
-   [How a pass is run, before anything else in this file]
+   note. [How a pass is run]
 
-7. **Evidence is what the execution produced, never a summary somebody wrote.**
-   Captured stdout and stderr with the exit code, the wire body as it arrived,
-   the hash lines, the listing, the log lines, the socket frames, the journal.
-   The test to apply to every file you file: **could somebody who does not trust
-   you re-derive your status line from this artifact alone?**
-   [How a pass is run, before anything else in this file]
+7. **Evidence is what the execution produced, never a summary somebody wrote**:
+   captured stdout and stderr with the exit code, wire bodies as they arrived,
+   hash lines, listings, log lines, socket frames, journals. A coverage table is
+   generated from a recorded sweep, never typed. [How a pass is run] [Evidence]
 
-8. **One branch per minor for evidence, and every host pushes into it.** One
-   branch cut once from a freshly pulled default branch, one boundary directory
-   per host, and **nothing else travels in it**: not a script, not a rule, not
-   another release's evidence. The second host to finish adds its boundary beside
-   the first rather than opening a second pull request.
-   [How a pass is run, before anything else in this file]
+8. **One branch per minor for evidence, in the docs repository, and every host
+   pushes into that one branch.** `evidence/<repo>-<version>`, cut once from a
+   freshly pulled default branch there: a later operating system adds its
+   boundary beside the first rather than opening a second pull request, and
+   nothing else travels in it. [How a pass is run]
 
-9. **A fix is verified by re-running the cell that found it**, whole, from its
-   stated precondition, against a rebuilt and reinstalled product. A unit test
-   that fails without the fix is necessary and it is never sufficient: it speaks
-   for the function you changed, not for the thing the cell was watching.
-   [A fix is verified by the cell that found it, not by the test you wrote for it]
+9. **A fix is verified by re-running the cell that found it**, whole and from its
+   stated precondition, against a rebuilt and reinstalled product. A unit test is
+   necessary and never sufficient.
+   [A fix is verified by the cell that found it] [../README.md]
 
 10. **Never edit a cell so it matches the behaviour you shipped.** If an
-    assertion is genuinely wrong, say so in the cell's status, with the evidence,
-    and leave the assertion where the next reader can argue with it. Weakening an
-    oracle to turn a red cell green destroys the only record that the product
-    ever behaved differently.
-    [A fix is verified by the cell that found it, not by the test you wrote for it]
+    assertion is genuinely wrong, say so in the cell's status and leave the
+    assertion where the next reader can argue with it.
+    [A fix is verified by the cell that found it]
 
 11. **One failure is not a finding: reproduce before you diagnose, and reproduce
-    through the same path the user used.** A well sourced explanation of somebody
-    else's failure will fit yours convincingly without being true of it, and a
-    failure seen only through your own wrapper is a fact about the wrapper. The
-    behaviour that worked earlier with nothing changing it, and the failure you
-    cannot reproduce on demand, are both evidence for a transient.
+    through the same path the user used.** Behaviour that worked earlier with
+    nothing changing it, and a failure you cannot reproduce on demand, are both
+    evidence for a transient.
 
-12. **Account for what the pass leaves running and on disk.** End the pass by
-    listing every process it started, stopping it and showing the ports free, and
-    name in each group's cleanup the directories that group created so they go at
-    that group's boundary. A stray daemon or an empty directory blocks a cell
-    weeks later and reads as a platform fact.
+12. **Account for what the pass leaves running and on disk.** List and stop every
+    process the pass started and show the ports free, and name the directories a
+    group created in that group's cleanup column.
     [Account for what the pass leaves running]
     [Account for what the pass leaves on disk]
 
 13. **One command at a time, and read its output and exit code before choosing
-    the next.** A wrapper script that runs a whole group in one shot is not an
-    execution of that group, and **a result from a command whose exit code you
-    did not read is not a result**. A helper may build state before a group and
-    parse evidence after a command has run; it may not sequence the product
-    commands. [One command at a time, and read its output before the next]
+    the next.** A result from a command whose exit code you did not read is not a
+    result. [One command at a time, and read its output before the next]
 
-14. **Before you file a finding, suspect your own harness.** A schema you assumed,
-    a default that changed the path, a route that does not exist, a body you had
-    already truncated, one output stream counted, a poll slower than the event,
-    your own leaked daemon: each produces a confident false result that looks
-    exactly like a product failure. Suspecting the harness is the right instinct
-    and it must not stop one question early: a harness can produce the condition
-    and the product's answer to that condition can still be wrong.
+14. **Before you file a finding, suspect your own harness**, and do not stop one
+    question early: a harness can create the condition while the product's answer
+    to that condition is still wrong.
     [Before you file a finding, suspect your own harness]
 
-15. **Finish the matrix: every cell carries a verdict or a named blocker.** A
-    blocked cell is owed only after the blocker itself was investigated, and
-    "it needs a tool this host does not have" is a claim to check rather than to
-    report. Partial results read as progress, get committed, and the cells that
-    never ran quietly stay never run. [Finish the matrix]
+15. **Finish the matrix: every cell carries a verdict or a named blocker**, and a
+    blocked cell is owed only after the blocker itself was investigated.
+    `Not-Needed` is a verdict with a reason, never a synonym for "did not run".
+    [Finish the matrix] [Per-OS results] [../README.md]
+
+16. **The oracle is never the product's own report.** The verdict comes from what
+    the machine wrote down, and a claimed success with no confirming read-back is
+    a fail; with neither journal nor transcript the result is `not verified`
+    rather than a pass. [The approach] [../README.md]
+
+17. **The runbook is complete before the first live cell, and the surface is
+    enumerated rather than sampled.** Name the axes, multiply them, write the
+    count, and give every cell an id, precondition, setup, action, expected
+    observable, oracle, evidence boundary, cleanup and result slot. A check that
+    needs something not built yet belongs to the minor that builds it.
+    [Coverage] [../README.md]
+
+18. **Evidence is filed while the pass runs, never assembled after it.** A bundle
+    assembled once the answer was known is a bundle whose artifacts were chosen,
+    and a group that captured nothing gets a note rather than a reconstruction.
+    [Evidence] [../README.md]
+
+19. **Credentials never enter Git or evidence.** Read only what a cell needs from
+    the workspace `../.env`, never echo or copy a value anywhere, and run the
+    secret check before every commit and before evidence is sealed.
+    [Owner and environment requirements]
+
+20. **Passes are independent only when each has its own port, database and
+    daemon.** Two drivers sharing one daemon read each other's work and neither
+    verdict means anything. [Repeatability] [../README.md]
 
 **A pass is finished, not paused, and reporting is not a stopping point.** A
 checkpoint or a progress summary does not end your turn: write it and keep

--- a/E2E/TEMPLATE.md
+++ b/E2E/TEMPLATE.md
@@ -13,6 +13,120 @@ bracket notes as you go; a leftover placeholder is the tell that a runbook was
 written and never run. The cross-cutting rules are in
 [`../README.md`](../README.md) and are not repeated here.>
 
+## The rules
+
+**Read this section before the first cell. Every rule in it was learned by
+breaking it, they hold on every supported operating system and for every driver
+of a runbook, and none of them is negotiable against a deadline or a token
+budget.** The list is here, at the top, because the rules that get forgotten are
+the ones a reader had to go looking for.
+
+A bracketed name is the section in this file that carries the rule in full, with
+the incident behind it. Not every runbook carries every section: where the
+bracketed name is not below, this entry is the whole rule.
+
+1. **Whatever needs the owner runs first.** Before a single unattended cell,
+   read the whole matrix, list every cell that cannot proceed without a human,
+   and run those cells at the start of the pass. **Running them is the rule;
+   announcing them is not**, because a cell named in an opening message is still
+   an outstanding cell and the owner is still waiting.
+   [How a pass is run, before anything else in this file]
+
+2. **Do not stop the pass to report.** The pass runs to completion for the
+   operating system it is on: findings, blocked cells, corrections and questions
+   go into the runbook and the evidence as they happen, and they are reported
+   when the pass ends. Only a cell that physically cannot proceed without the
+   owner, or a decision only the owner can make, ends a pass early.
+   [How a pass is run, before anything else in this file]
+
+3. **A bug you find is a bug you fix, here and now, with a test that fails
+   without the fix.** Fix the code, add the test, re-run the failing cell until
+   it passes, and push to the pull request branch before carrying on with the
+   rest of the matrix. A finding recorded without a fix is a moved problem, not
+   a found one. [How a pass is run, before anything else in this file]
+
+4. **A fix invalidates the cells it touched on every operating system that
+   passed them.** Name those cells in the finding, mark them `not run` again,
+   and re-run them: no operating system inherits a result from a build that no
+   longer exists. **A rebuild is a new subject**, so re-run the identity cell and
+   record the new hashes before any further cell.
+   [How a pass is run, before anything else in this file]
+
+5. **The evidence is pushed, not left on the machine that produced it.** The
+   boundary directory exists before the first cell, each group files its output
+   at its own boundary, and the whole boundary is committed on a branch and
+   opened as a pull request **as part of the pass**, not after somebody asks for
+   it. [How a pass is run, before anything else in this file]
+
+6. **A cell is `pass` only when the observation and the artifact both exist.** A
+   cell that ran, was read correctly and left nothing on disk is `not run` with a
+   note, because there is nothing a reviewer or the next host can check.
+   [How a pass is run, before anything else in this file]
+
+7. **Evidence is what the execution produced, never a summary somebody wrote.**
+   Captured stdout and stderr with the exit code, the wire body as it arrived,
+   the hash lines, the listing, the log lines, the socket frames, the journal.
+   The test to apply to every file you file: **could somebody who does not trust
+   you re-derive your status line from this artifact alone?**
+   [How a pass is run, before anything else in this file]
+
+8. **One branch per minor for evidence, and every host pushes into it.** One
+   branch cut once from a freshly pulled default branch, one boundary directory
+   per host, and **nothing else travels in it**: not a script, not a rule, not
+   another release's evidence. The second host to finish adds its boundary beside
+   the first rather than opening a second pull request.
+   [How a pass is run, before anything else in this file]
+
+9. **A fix is verified by re-running the cell that found it**, whole, from its
+   stated precondition, against a rebuilt and reinstalled product. A unit test
+   that fails without the fix is necessary and it is never sufficient: it speaks
+   for the function you changed, not for the thing the cell was watching.
+   [A fix is verified by the cell that found it, not by the test you wrote for it]
+
+10. **Never edit a cell so it matches the behaviour you shipped.** If an
+    assertion is genuinely wrong, say so in the cell's status, with the evidence,
+    and leave the assertion where the next reader can argue with it. Weakening an
+    oracle to turn a red cell green destroys the only record that the product
+    ever behaved differently.
+    [A fix is verified by the cell that found it, not by the test you wrote for it]
+
+11. **One failure is not a finding: reproduce before you diagnose, and reproduce
+    through the same path the user used.** A well sourced explanation of somebody
+    else's failure will fit yours convincingly without being true of it, and a
+    failure seen only through your own wrapper is a fact about the wrapper. The
+    behaviour that worked earlier with nothing changing it, and the failure you
+    cannot reproduce on demand, are both evidence for a transient.
+
+12. **Account for what the pass leaves running and on disk.** End the pass by
+    listing every process it started, stopping it and showing the ports free, and
+    name in each group's cleanup the directories that group created so they go at
+    that group's boundary. A stray daemon or an empty directory blocks a cell
+    weeks later and reads as a platform fact.
+    [Account for what the pass leaves running]
+    [Account for what the pass leaves on disk]
+
+13. **One command at a time, and read its output and exit code before choosing
+    the next.** A wrapper script that runs a whole group in one shot is not an
+    execution of that group, and **a result from a command whose exit code you
+    did not read is not a result**. A helper may build state before a group and
+    parse evidence after a command has run; it may not sequence the product
+    commands. [One command at a time, and read its output before the next]
+
+14. **Before you file a finding, suspect your own harness.** A schema you assumed,
+    a default that changed the path, a route that does not exist, a body you had
+    already truncated, one output stream counted, a poll slower than the event,
+    your own leaked daemon: each produces a confident false result that looks
+    exactly like a product failure. Suspecting the harness is the right instinct
+    and it must not stop one question early: a harness can produce the condition
+    and the product's answer to that condition can still be wrong.
+    [Before you file a finding, suspect your own harness]
+
+15. **Finish the matrix: every cell carries a verdict or a named blocker.** A
+    blocked cell is owed only after the blocker itself was investigated, and
+    "it needs a tool this host does not have" is a claim to check rather than to
+    report. Partial results read as progress, get committed, and the cells that
+    never ran quietly stay never run. [Finish the matrix]
+
 **A pass is finished, not paused, and reporting is not a stopping point.** A
 checkpoint or a progress summary does not end your turn: write it and keep
 driving in the same turn. A pass ends when every cell carries a verdict or a


### PR DESCRIPTION
## What changed

`E2E/TEMPLATE.md` gains one section, `## The rules`, placed immediately after
the status block and before every other section. It is a numbered index of 20
entries. Each is one or two sentences with a bolded lead, followed by the names
of the sections that carry the rule in full with the incident behind it.

`E2E/README.md` gains one paragraph naming that section as the index and saying
a rule is stated in full in one place. Nothing was removed from either file.

## Why

The rules were spread through the whole of one template and were absent from the
other two, so a reader who wanted them before starting a pass had to hunt, and
they kept being missed. They are now one screen at the top of every runbook.

The section is an index, not a second copy. The long sections still carry the
incidents, which is what makes a rule stick.

## The 20 rules

1. Whatever needs the owner runs first. Running them is the rule; announcing
   them is not.
2. Do not stop the pass to report.
3. A bug you find is a bug you fix, here and now, with a test that fails without
   the fix.
4. A fix invalidates the cells it touched on every operating system that passed
   them, and a rebuild is a new subject.
5. The evidence is pushed to the private docs repository, and its pull request
   is opened there.
6. A cell is `pass` only when the observation and the artifact both exist.
7. Evidence is what the execution produced, never a summary somebody wrote.
8. One branch per minor for evidence, and every host pushes into that one
   branch.
9. A fix is verified by re-running the cell that found it.
10. Never edit a cell so it matches the behaviour you shipped.
11. One failure is not a finding: reproduce before you diagnose.
12. Account for what the pass leaves running and on disk.
13. One command at a time, and read its output and exit code before choosing the
    next.
14. Before you file a finding, suspect your own harness.
15. Finish the matrix: every cell carries a verdict or a named blocker.
16. The oracle is never the product's own report.
17. The runbook is complete before the first live cell, and the surface is
    enumerated rather than sampled.
18. Evidence is filed while the pass runs, never assembled after it.
19. Credentials never enter Git or evidence.
20. Passes are independent only when each has its own port, database and daemon.

Rules 1 to 5 keep the numbers the existing runbooks already cite, so a finding
that says "rule 4" still means what it meant.

## Identical in all three repositories

The section is byte for byte identical in `vadgr`, `vadgr-computer-use` and
`vadgr-mobile`: 6148 bytes, sha256
`200ad491e53c2a603d2d2e479c35e5fe4f4e138faa2bceb0345435241ef3f192`, extracted
from each committed file and diffed with no differences. The rest of each
template is untouched, because the three prove different products. Where a rule
names something a given repository does not have, the wording stays general.

## Rules that were not already in the template

Rule 11 was in no template. It is the engineering standard this family already
follows, and the `0.4.9` runbook records the incident: a sign-in failure was
diagnosed as the provider rejecting the product's own identity, a change to that
identity was written, and the cause was one line that let the shell truncate the
authorization URL at its first `&`.

Rules 16 to 20 were in `E2E/README.md` only, so a reader of the template never
met them.

Every other entry is a shorter statement of text that was already in a template.

## Tests

No code changed, so there is no suite to move. Checked:

- `python3 ../vadgr-docs/scripts/check_style.py E2E/TEMPLATE.md E2E/README.md`
  exits `0`, no em dashes and no en dashes.
- The section extracted from all three committed templates is identical.
- `git diff --stat <default>...HEAD` shows only the two files this PR is about.

## Caveats

Not every bracketed section name is present in every template. Each repository
proves a different product and its runbook shape is its own, and two of the
sections named reach one repository's default branch with its open `0.4.9` pull
request. The section says so at the top: where a bracketed name is not present,
the entry is all there is.

README: nothing changed.
