### PR TITLE
E2E: read the whole document first, and evidence goes to the branch

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -102,6 +102,19 @@ jobs:
           python3 scripts/check_evidence.py \
             --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
 
+      # Evidence went straight to the default branch once per release for three
+      # releases running, always by the same host and always with rule 8 on its
+      # screen. A push carries no diff anyone read and no checks, so it is
+      # caught here, on the push itself. The range is what the push introduced:
+      # pointed at the whole branch this fires on history nobody can now fix.
+      - name: Reject evidence pushed to the default branch with no pull request
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.before != '0000000000000000000000000000000000000000'
+        shell: bash
+        run: |
+          python3 scripts/check_evidence.py \
+            --range "${{ github.event.before }}..${{ github.event.after }}" \
+            --require-pull-request
+
   # The gate itself had no test and ran on one operating system, so its Windows
   # DACL control was never executed anywhere. It refused every file it was given
   # for as long as that lasted, and nothing reported it.

--- a/E2E/README.md
+++ b/E2E/README.md
@@ -1,5 +1,18 @@
 # E2E verification - read the journal, not the agent's words
 
+> **Read this whole file before you run anything, and read
+> [`TEMPLATE.md`](TEMPLATE.md) beside it.** Not the rules that look relevant to the
+> cell in front of you: the whole file. Every rule in it was written because a
+> pass broke it, and a pass that starts at the first cell meets them one at a
+> time, each at the cost of the thing it was protecting.
+>
+> **This instruction exists because a rule that was already written, already
+> indexed and already in front of the driver was broken by three separate
+> passes**: evidence for `vadgr 0.4.7`, `0.4.8` and `0.4.9` was pushed straight
+> to the docs default branch instead of the minor's evidence branch, once per
+> release, by a host that had the rule on its screen. Reading the document is
+> the cheapest of every remedy available, and it is the one that was skipped.
+
 Applies to **every** runbook in this directory (`E2E/<version>/e2e.md`).
 
 **The rules in one place: `## The rules`, the first section of

--- a/E2E/TEMPLATE.md
+++ b/E2E/TEMPLATE.md
@@ -1,5 +1,18 @@
 # <version> - <what this minor made true>: e2e runbook
 
+> **Read this whole file before you run anything, and read
+> [`README.md`](README.md) beside it.** Not the rules that look relevant to the
+> cell in front of you: the whole file. Every rule in it was written because a
+> pass broke it, and a pass that starts at the first cell meets them one at a
+> time, each at the cost of the thing it was protecting.
+>
+> **This instruction exists because a rule that was already written, already
+> indexed and already in front of the driver was broken by three separate
+> passes**: evidence for `vadgr 0.4.7`, `0.4.8` and `0.4.9` was pushed straight
+> to the docs default branch instead of the minor's evidence branch, once per
+> release, by a host that had the rule on its screen. Reading the document is
+> the cheapest of every remedy available, and it is the one that was skipped.
+
 <One sentence: what a reader is being convinced of. Not what changed - what is
 now demonstrably true that was not before.>
 
@@ -61,7 +74,11 @@ present in a given runbook, the entry is all there is.
    pushes into that one branch.** `evidence/<repo>-<version>`, cut once from a
    freshly pulled default branch there: a later operating system adds its
    boundary beside the first rather than opening a second pull request, and
-   nothing else travels in it. [How a pass is run]
+   nothing else travels in it. **The default branch is never the target**, on
+   any host, for any reason, and a pass that cannot find the branch asks for it
+   rather than pushing past it. Broken once per release for three releases
+   running, always by the same host and always with the rule on screen, so it is
+   now a check rather than a sentence. [How a pass is run]
 
 9. **A fix is verified by re-running the cell that found it**, whole and from its
    stated precondition, against a rebuilt and reinstalled product. A unit test is

--- a/scripts/check_evidence.py
+++ b/scripts/check_evidence.py
@@ -9,6 +9,14 @@ else, and it reached the default branch inside a pull request nobody read it in.
 Evidence is the record a release rests on. It gets its own change, so a reviewer
 looking at a diff of evidence is looking at evidence.
 
+**Evidence reaches the default branch only through a pull request.** The rule
+was written, indexed as rule 8 of every runbook, and broken once per release for
+three releases running by a host that had it on screen: the `0.4.7`, `0.4.8` and
+`0.4.9` macOS boundaries were each pushed straight to the docs default branch.
+A direct push has no diff anyone read and no checks. The tell is the subject: a
+squash merge carries `(#NN)`, a merge commit has two parents, and a direct push
+has neither.
+
 **Every boundary names the commit it was produced from.** A directory of results
 that cannot say which build produced them is not evidence: three fixes landed
 mid-pass in `vadgr 0.4.9`, the binaries moved three commits, and no cell in that
@@ -16,9 +24,15 @@ pass could name the artifact behind it. The whole pass was withdrawn.
 
     python3 scripts/check_evidence.py [--range <start>..<end>]
 
-With no range it reads the working tree and the index. It prints one line per
-check it performs, because a coverage list restated in prose is the fact that
-drifts.
+With no range it reads the working tree, the index, **and the branch's own
+commits since it left the default branch**. The branch is what a reviewer opens
+in a pull request, so the branch is the change. Reading the working tree alone
+left a hole this gate fell straight through: an `e2e_evidence/` commit and a
+planning-document commit sat side by side on one branch, the working tree was
+clean, and the gate printed `ok`.
+
+It prints one line per check it performs, because a coverage list restated in
+prose is the fact that drifts.
 """
 
 from __future__ import annotations
@@ -39,6 +53,40 @@ def git(*args: str) -> str:
         ["git", *args], cwd=ROOT, capture_output=True, text=True, timeout=60
     )
     return result.stdout
+
+
+def default_branch() -> str | None:
+    """The branch this one was cut from, or None when it cannot be told.
+
+    A gate that guesses wrong fires on correct work, which teaches everyone to
+    ignore it. So when nothing answers, the branch half is skipped and says so
+    rather than inventing a base to diff against.
+    """
+    head = git("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD").strip()
+    if head.startswith("origin/"):
+        return head[len("origin/") :]
+    for name in ("master", "main"):
+        for ref in (f"refs/heads/{name}", f"refs/remotes/origin/{name}"):
+            if git("rev-parse", "--verify", "--quiet", ref).strip():
+                return name
+    return None
+
+
+def branch_paths() -> tuple[list[str], str]:
+    """What this branch changed since it left the default branch."""
+    base_name = default_branch()
+    if not base_name:
+        return [], "no default branch to compare against, so only the working tree"
+    current = git("rev-parse", "--abbrev-ref", "HEAD").strip()
+    if current == base_name:
+        return [], f"on {base_name} itself, so only the working tree"
+    base = git("merge-base", base_name, "HEAD").strip()
+    if not base:
+        return [], f"no common commit with {base_name}, so only the working tree"
+    out = git("diff", "--name-only", f"{base}..HEAD")
+    return [line.strip() for line in out.splitlines() if line.strip()], (
+        f"the working tree and this branch's commits since {base_name}"
+    )
 
 
 def changed_paths(rev_range: str | None) -> list[str]:
@@ -107,17 +155,71 @@ def every_boundary_names_its_build(paths: list[str]) -> list[str]:
     return problems
 
 
+SQUASHED = re.compile(r"\(#\d+\)\s*$")
+
+
+def evidence_arrived_through_a_pull_request(rev_range: str) -> list[str]:
+    """No commit touching evidence entered this range by a direct push.
+
+    GitHub leaves a mark either way. A squash merge appends `(#NN)` to the
+    subject and a merge commit has two parents; a push straight to the branch
+    has neither. Anything with neither was written onto the branch by a person
+    or an agent with no diff anyone read.
+
+    **It reads a range, never a whole branch**, because the rule has a start
+    date and the history before it does not. Pointed at all of `master` this
+    fires eighteen times on work nobody can now fix, which is the way to make a
+    gate ignored. CI gives it exactly what a push introduced.
+    """
+    out = git(
+        "log", "--no-merges", "--format=%H%x1f%P%x1f%s", rev_range, "--", EVIDENCE
+    )
+    problems = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        sha, parents, subject = line.split("\x1f", 2)
+        if len(parents.split()) > 1:
+            continue
+        if SQUASHED.search(subject):
+            continue
+        problems.append(
+            f"{sha[:8]} pushed evidence with no pull request: "
+            f"{subject!r}. Evidence goes to the minor's evidence branch and "
+            "reaches the default branch by merging that branch's pull request."
+        )
+    return problems
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--range", dest="rev_range", default=None)
+    parser.add_argument(
+        "--require-pull-request",
+        dest="require_pull_request",
+        action="store_true",
+        help="also check that evidence in --range arrived through a pull request",
+    )
     args = parser.parse_args()
 
     problems = []
     paths = changed_paths(args.rev_range)
+    if args.rev_range:
+        scope = f"the range {args.rev_range}"
+    else:
+        committed, scope = branch_paths()
+        paths = sorted(set(paths) | set(committed))
+    print(f"  read  {scope}")
     print("  ok    evidence and documents do not ride in one change")
     problems += evidence_travels_alone(paths)
     print("  ok    every pass this change touches names the commit it came from")
     problems += every_boundary_names_its_build(paths)
+    if args.require_pull_request:
+        if not args.rev_range:
+            print("  ERROR --require-pull-request needs --range")
+            return 2
+        print("  ok    evidence in this range arrived through a pull request")
+        problems += evidence_arrived_through_a_pull_request(args.rev_range)
 
     print()
     if problems:

--- a/scripts/tests/test_check_evidence.py
+++ b/scripts/tests/test_check_evidence.py
@@ -107,3 +107,126 @@ def test_a_whole_pass_filed_at_once_is_still_seen(tmp_path):
     file_a_pass(root, "20260819-wsl", with_host=False)
     result = gate(root)
     assert "carries no host.txt" in result.stdout
+
+
+def branch_with(root, *steps):
+    """Cut a branch from the default and commit each step on it."""
+    run = lambda *a: subprocess.run(a, cwd=root, check=True, capture_output=True)
+    run("git", "branch", "-M", "master")
+    run("git", "checkout", "-q", "-b", "work")
+    for message, make in steps:
+        make(root)
+        run("git", "add", "-A")
+        run("git", "commit", "-qm", message)
+    return root
+
+
+def test_a_branch_mixing_them_in_separate_commits_is_refused(tmp_path):
+    """The hole the gate fell through: clean tree, two commits, one branch.
+
+    Evidence went in one commit and a document in the next. Nothing was
+    uncommitted, so reading the working tree saw an empty change and the gate
+    printed ok while the pull request carried both.
+    """
+    root = workspace(tmp_path)
+    branch_with(
+        root,
+        ("file the pass", lambda r: file_a_pass(r, "20260819-wsl")),
+        ("edit a document", lambda r: (r / "NOTES.md").write_text("# notes\n\nedited\n")),
+    )
+    result = gate(root)
+    assert result.returncode == 1, result.stdout
+    assert "files evidence and edits" in result.stdout
+
+
+def test_a_branch_of_evidence_alone_is_accepted(tmp_path):
+    """The other half: the gate must not fire on a correct evidence branch."""
+    root = workspace(tmp_path)
+    branch_with(
+        root,
+        ("file the pass", lambda r: file_a_pass(r, "20260819-wsl")),
+        ("file another group", lambda r: (
+            r / "e2e_evidence" / "vadgr-0.4.9" / "20260819-wsl" / "A" / "A2.txt"
+        ).write_text("the second cell\n")),
+    )
+    result = gate(root)
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_branch_of_documents_alone_is_accepted(tmp_path):
+    root = workspace(tmp_path)
+    branch_with(
+        root,
+        ("edit a document", lambda r: (r / "NOTES.md").write_text("# notes\n\nedited\n")),
+        ("edit it again", lambda r: (r / "NOTES.md").write_text("# notes\n\ntwice\n")),
+    )
+    result = gate(root)
+    assert result.returncode == 0, result.stdout
+
+
+def test_the_default_branch_itself_is_not_diffed_against_itself(tmp_path):
+    """On master there is no branch to read, and the gate says so."""
+    root = workspace(tmp_path)
+    subprocess.run(["git", "branch", "-M", "master"], cwd=root, check=True, capture_output=True)
+    result = gate(root)
+    assert result.returncode == 0, result.stdout
+    assert "on master itself" in result.stdout
+
+
+def test_a_repository_with_no_default_branch_skips_the_branch_half(tmp_path):
+    """It says which sources it read rather than inventing a base to diff."""
+    root = workspace(tmp_path)
+    subprocess.run(
+        ["git", "branch", "-M", "somewhere-else"], cwd=root, check=True, capture_output=True
+    )
+    result = gate(root)
+    assert result.returncode == 0, result.stdout
+    assert "no default branch to compare against" in result.stdout
+
+
+def commit_evidence(root, message):
+    run = lambda *a: subprocess.run(a, cwd=root, check=True, capture_output=True)
+    file_a_pass(root, "20260819-wsl")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", message)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def test_evidence_pushed_straight_to_a_branch_is_refused(tmp_path):
+    """The macOS boundary, three releases running, with no diff anyone read."""
+    root = workspace(tmp_path)
+    head = commit_evidence(root, "e2e_evidence(vadgr-0.4.9): the macOS pass")
+    result = gate(root, "--range", f"{head}~1..{head}", "--require-pull-request")
+    assert result.returncode == 1, result.stdout
+    assert "pushed evidence with no pull request" in result.stdout
+
+
+def test_evidence_from_a_squash_merged_pull_request_is_accepted(tmp_path):
+    """GitHub appends (#NN) on a squash merge, and that is the mark."""
+    root = workspace(tmp_path)
+    head = commit_evidence(root, "0.4.9 e2e evidence: the WSL pass (#93)")
+    result = gate(root, "--range", f"{head}~1..{head}", "--require-pull-request")
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_range_holding_no_evidence_says_nothing(tmp_path):
+    root = workspace(tmp_path)
+    run = lambda *a: subprocess.run(a, cwd=root, check=True, capture_output=True)
+    (root / "NOTES.md").write_text("# notes\n\nan ordinary edit\n")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "an ordinary edit")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True
+    ).stdout.strip()
+    result = gate(root, "--range", f"{head}~1..{head}", "--require-pull-request")
+    assert result.returncode == 0, result.stdout
+
+
+def test_the_pull_request_rule_needs_a_range(tmp_path):
+    """Pointed at a whole branch it fires on history nobody can fix."""
+    root = workspace(tmp_path)
+    result = gate(root, "--require-pull-request")
+    assert result.returncode == 2, result.stdout
+    assert "needs --range" in result.stdout


### PR DESCRIPTION
Rule 8 of every runbook says a host pushes its evidence boundary into the minor's evidence branch in the documentation repository. It was broken **once per release for three releases running**, always by the same host, always with the rule indexed and on screen.

**The document half.** Reading the whole file is the cheapest remedy available and it is the one that was skipped, so the instruction to read it, and its sibling beside it, is now the first thing `TEMPLATE.md` and `README.md` say, above the title block and every rule. Rule 8 also states plainly that the default branch is never the target, and names the repeat.

**The gate half**, so it is more than a sentence. All four repos hold the same secret-scan workflow and the same evidence gate, and both gain two rules:

- **A push to a default branch that adds evidence with no pull request is refused.** The tell is what GitHub leaves behind: `(#NN)` on a squash merge, two parents on a merge commit, neither on a direct push. It reads only what the push introduced, because pointed at a whole branch it fires on history from before the rule existed.
- **The gate reads the branch, not only the working tree.** A branch that files evidence in one commit and edits a document in the next has a clean tree, so the old gate saw an empty change and printed `ok` on exactly what it exists to refuse.

Sixteen tests, and each new rule has both halves: the defect fires, and the correct shape stays quiet.